### PR TITLE
Don't trim whitespace around commas in TS class constructor params list 

### DIFF
--- a/avrotize/avrotots/class_core.ts.jinja
+++ b/avrotize/avrotots/class_core.ts.jinja
@@ -36,7 +36,7 @@ export class {{ class_name }} {
     public {{ field.name }}{%- if field.type.endswith('?')-%}?{%-endif-%} : {{ field.type_no_null }};
     {%- endfor %}
 
-    constructor({%- for field in fields %}{{ field.name }}: {{ field.type_no_null }}{%- if not loop.last %}, {%- endif %}{%- endfor %}) {
+    constructor({%- for field in fields %}{{ field.name }}: {{ field.type_no_null }}{% if not loop.last %}, {% endif %}{%- endfor %}) {
         {%- for field in fields %}
         {%- if field.is_enum %}
         if ( typeof {{ field.name }} === 'number' ) {


### PR DESCRIPTION
Although there is a space after a comma separating params in `avrotots/class_core.ts.jinja`, it's being trimmed by Jinja.
This MR fixes this.