### PR TITLE
fix: capitialize enum values when converting avro to java

### DIFF
--- a/avrotize/avrotojava.py
+++ b/avrotize/avrotojava.py
@@ -688,7 +688,7 @@ class AvroToJava:
         self.generated_types_avro_namespace[self.qualified_name(avro_schema.get('namespace', parent_package),avro_schema['name'])] = "enum"
         self.generated_types_java_package[type_name] = "enum"       
         symbols = avro_schema.get('symbols', [])
-        symbols_str = ', '.join(symbols)
+        symbols_str = ', '.join([symbol.upper() for symbol in symbols])
         enum_definition += f"public enum {enum_name} {{\n"
         enum_definition += f"{INDENT}{symbols_str};\n"
         enum_definition += "}\n"

--- a/test/avsc/enumfield-lower.avsc
+++ b/test/avsc/enumfield-lower.avsc
@@ -1,0 +1,41 @@
+[
+  {
+    "type": "record",
+    "name": "MyRecord",
+    "namespace": "com.example.avro",
+    "fields": [
+      {
+        "name": "snapshot",
+        "type": [
+          {
+            "type": "enum",
+            "name": "true_first_first_in_data_collection_last_in_data_collection_last_false_incremental",
+            "symbols": [
+              "true",
+              "first",
+              "first_in_data_collection",
+              "last_in_data_collection",
+              "last",
+              "false",
+              "incremental"
+            ],
+            "default": "false"
+          },
+          "null"
+        ],
+        "default": "false"
+      }
+    ]
+  },
+  {
+    "type": "record",
+    "name": "MyRecord2",
+    "namespace": "com.example.avro",
+    "fields": [
+      {
+        "name": "enumField",
+        "type": "com.example.avro.MyEnum"
+      }
+    ]
+  }
+]

--- a/test/avsc/enumfield-lower.avsc
+++ b/test/avsc/enumfield-lower.avsc
@@ -26,16 +26,5 @@
         "default": "false"
       }
     ]
-  },
-  {
-    "type": "record",
-    "name": "MyRecord2",
-    "namespace": "com.example.avro",
-    "fields": [
-      {
-        "name": "enumField",
-        "type": "com.example.avro.MyEnum"
-      }
-    ]
   }
 ]

--- a/test/test_avrotojava.py
+++ b/test/test_avrotojava.py
@@ -145,6 +145,15 @@ class TestAvroToJava(unittest.TestCase):
             shutil.rmtree(java_path, ignore_errors=True)
         os.makedirs(java_path, exist_ok=True)
 
-        convert_avro_to_java(avro_path, java_path, package_name="restricted.namespace.java")
+    def test_convert_enum_lower_avsc_to_java(self):
+        """ Test converting an avsc file with an enum value that is lowercase to Java """
+        cwd = os.getcwd()
+        avro_path = os.path.join(cwd, "test", "avsc", "enumfield-lower.avsc")
+        java_path = os.path.join(tempfile.gettempdir(), "avrotize", "enumfield-lower-java")
+        if os.path.exists(java_path):
+            shutil.rmtree(java_path, ignore_errors=True)
+        os.makedirs(java_path, exist_ok=True)
+
+        convert_avro_to_java(avro_path, java_path, package_name="enumfield.lower.java")
         assert subprocess.check_call(
             "mvn package -B", cwd=java_path, stdout=sys.stdout, stderr=sys.stderr, shell=True) == 0


### PR DESCRIPTION
This fixes an issue when restricted values are provided such as `true` or `false`. Additionally, this seems to be the general consensus for enum values in Java since they are constants