### PR TITLE
Fix A2J

### DIFF
--- a/avrotize/avrotojsons.py
+++ b/avrotize/avrotojsons.py
@@ -231,6 +231,10 @@ class AvroToJsonSchemaConverter:
         required = []
         
         json_schema: Dict[str, Any] = {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "title": record_name
+        } if is_root else {
             "type": "object",
             "title": record_name
         }        


### PR DESCRIPTION
## Summary
Fixes #19: logical type conversion issue in Avro to JSON Schema conversion and missing JSON Schema reference

## Problem
Avro schemas with for example: `logicalType: "date"` were being converted to JSON Schema with `"type": "integer", "format": "int32"` instead of the correct `"type": "string", "format": "date"`.

## Solution
- Modified `avro_primitive_to_json_type` to check for `logicalType` before unwrapping
- Added proper JSON Schema draft-07 reference