### PR TITLE
feat: Add CI workflow for testing across Python 3.10-3.14

### DIFF
--- a/.github/workflows/python-runtime-versions-test.yml
+++ b/.github/workflows/python-runtime-versions-test.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Run basic functionality test
         run: |
           echo '{"type": "record", "name": "TestRecord", "fields": [{"name": "id", "type": "int"}, {"name": "name", "type": "string"}]}' > test_schema.avsc
-          avrotize a2j --avsc test_schema.avsc --jsons test_schema.json
+          avrotize a2j --avsc test_schema.avsc --out test_schema.json
           cat test_schema.json
           echo "Basic conversion test passed"
 


### PR DESCRIPTION
This PR adds a comprehensive CI workflow that builds the wheel package and tests it across Python versions 3.10, 3.11, 3.12, 3.13, and 3.14.

**Features:**
- Builds wheel once and reuses across test jobs
- Tests installation and basic functionality on each Python version
- Verifies CLI commands are available
- Runs basic conversion tests to ensure core functionality works
- Includes pytest smoke tests

The workflow runs on push/PR to master/main branches and can be manually triggered.