### PR TITLE
Fix TypeScript ESM compatibility for avro-js import

### DIFF
--- a/avrotize/avrotots/class_core.ts.jinja
+++ b/avrotize/avrotots/class_core.ts.jinja
@@ -8,7 +8,7 @@ import { jsonObject, jsonMember, TypedJSON } from 'typedjson';
 {%- endif %}
 {%- endif %}
 {%- if avro_annotation %}
-import { Type } from 'avro-js';
+import avro from 'avro-js';
 {%- endif %}
 {%- for import_type, import_path in imports.items() %}
 import { {{ import_type }} } from '{{ import_path }}';
@@ -20,7 +20,7 @@ import pako from 'pako';
 @jsonObject
 export class {{ class_name }} {
     {%- if avro_annotation %}
-    public static AvroType: Type = Type.forSchema({{ avro_schema_json }});
+    public static AvroType: avro.Type = avro.Type.forSchema({{ avro_schema_json }});
     {%- endif %}
 
     {%- for field in fields %}


### PR DESCRIPTION
## Problem
When generating TypeScript code with ESM modules, the generated import for avro-js fails at runtime:

`typescript
import { Type } from 'avro-js';
`

This produces: `TypeError: Cannot read properties of undefined (reading 'forSchema')`

## Root Cause
avro-js is a CommonJS module. When Node.js loads a CJS module in ESM context, named imports don't work - only the default export is available.

## Solution
Change to ESM-compatible default import pattern:

`typescript
import avro from 'avro-js';
// then use avro.Type instead of Type
`

## Testing
- pytest test/test_avrotots.py -k address passes
- Generated code now uses correct import pattern

Closes #159