### PR TITLE
Fix TypeScript createInstance() for enums (#163)

### DIFF
--- a/avrotize/avrotots.py
+++ b/avrotize/avrotots.py
@@ -266,9 +266,9 @@ class AvroToTypeScript:
             first_type = field_type.split('|')[0].strip()
             return self.generate_test_value(first_type, is_enum)
         
-        # Handle enums - use first value (will be set via template)
+        # Handle enums - use first value with Object.values()
         if is_enum:
-            return f'{field_type}.values()[0]'
+            return f'Object.values({field_type})[0] as {field_type}'
         
         # Handle primitive types
         primitive_values = {


### PR DESCRIPTION
## Summary
The \createInstance()\ method generated invalid code for enum fields, using \EnumType.values()[0]\ which doesn't exist in TypeScript.

## Fix
Changed from:
\\\	ypescript
Status.values()[0]  // ERROR: Property 'values' does not exist on type 'typeof Status'
\\\

To:
\\\	ypescript
Object.values(Status)[0] as Status  // Works correctly
\\\

## Changes
- \vrotize/avrotots.py\: Updated \generate_test_value()\ to use \Object.values(EnumType)[0] as EnumType\

Fixes #163