### PR TITLE
fix(ts): Lowercase base_package in TypeScript import paths

### DIFF
--- a/avrotize/structuretots.py
+++ b/avrotize/structuretots.py
@@ -125,7 +125,7 @@ class StructureToTypeScript:
             namespace_package = '.'.join([part.lower() for part in namespace.split('.')]) if namespace else ''
             package = namespace_package
         if self.base_package:
-            package = self.base_package + ('.' if package else '') + package
+            package = self.base_package.lower() + ('.' if package else '') + package
         return package
 
     def typescript_type_from_structure_type(self, type_name: str) -> str:


### PR DESCRIPTION
## Problem

On case-sensitive filesystems (Linux), TypeScript import paths were incorrect because \ase_package\ was used with original casing (e.g., \TestProjectData\) while the actual directories are always lowercase (\	estprojectdata\).

This caused imports like:
\\\	ypescript
import { InkColorEnum } from '../TestProjectData/InkColorEnum.js';
\\\

to fail with TS2307 because the relative path calculation saw \TestProjectData\ and \	estprojectdata\ as different directories on Linux.

## Solution

Lowercase \ase_package\ in \	ypescript_package_from_structure_type()\ so import paths are consistent with the file system:

\\\	ypescript
import { InkColorEnum } from './InkColorEnum.js';
\\\

## Testing

- Verified TypeScript build passes in Docker on Linux with the fix
- Related PR: https://github.com/xregistry/codegen/pull/124 (blocked by this issue)