### PR TITLE
fix(structuretopython): forward avro_annotation in convert_structure_schema_to_python

### DIFF
--- a/avrotize/structuretopython.py
+++ b/avrotize/structuretopython.py
@@ -863,10 +863,14 @@ def convert_structure_to_python(structure_schema_path, py_file_path, package_nam
     structure_to_python.convert(structure_schema_path, py_file_path)
 
 
-def convert_structure_schema_to_python(structure_schema, py_file_path, package_name='', dataclasses_json_annotation=False):
+def convert_structure_schema_to_python(structure_schema, py_file_path, package_name='', dataclasses_json_annotation=False, avro_annotation=False):
     """Converts JSON Structure schema to Python dataclasses"""
     package_name = safe_package_name(package_name) if package_name else package_name
-    structure_to_python = StructureToPython(package_name, dataclasses_json_annotation=dataclasses_json_annotation)
+    structure_to_python = StructureToPython(
+        package_name,
+        dataclasses_json_annotation=dataclasses_json_annotation,
+        avro_annotation=avro_annotation,
+    )
     if isinstance(structure_schema, dict):
         structure_schema = [structure_schema]
     structure_to_python.convert_schemas(structure_schema, py_file_path)


### PR DESCRIPTION
The dict-based wrapper `convert_structure_schema_to_python` was dropping the `avro_annotation` kwarg even though the underlying `StructureToPython` class supports it (see __init__, and the `avro_annotation` flag plumbed through the dataclass/test templates).

As a result, downstream callers handing in a JSON Structure schema as a dict (e.g. [xregistry/codegen](https://github.com/xregistry/codegen)'s jstruct path) could not opt into emitting the Avro codec branch in generated dataclasses:

- `AvroType: ClassVar[avro.schema.Schema]`
- `to_byte_array` `avro/binary` / `application/vnd.apache.avro+avro` branch using `DatumWriter` + `BinaryEncoder`
- `from_data` matching branch using `DatumReader` + `BinaryDecoder`

The path-based `convert_structure_to_python` and the JS/TS/Go structure-to-language wrappers already expose `avro_annotation`; this brings the Python dict wrapper into parity. Java and C# parity (C# already supports it on the wrapper; `StructureToJava` has no Avro emitter at all) can be tracked separately.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>