### PR TITLE
fix(s2py): emit valid Python for integer enum members (#315)

### DIFF
--- a/avrotize/structuretopython.py
+++ b/avrotize/structuretopython.py
@@ -489,6 +489,36 @@ class StructureToPython:
         field_docstring = f"{field_name} ({field_type})"
         return field_docstring
 
+    def _python_enum_member_name(self, value) -> str:
+        """Derives a valid Python identifier for an enum member from a JSON
+        Structure enum value.
+
+        Numeric values (including negative integers) are prefixed with
+        ``VALUE_`` (with negatives spelled ``VALUE_NEG_n``) so the generated
+        class body is valid Python. String values that aren't already valid
+        identifiers — e.g. they start with a digit or contain hyphens/spaces —
+        are coerced via ``pascal`` and prefixed with ``VALUE_`` if they still
+        don't start with a letter or underscore. Reserved words get a
+        trailing underscore.
+        """
+        if isinstance(value, bool):
+            return "TRUE_" if value else "FALSE_"
+        if isinstance(value, (int, float)):
+            if isinstance(value, float):
+                token = str(value).replace('.', '_').replace('-', 'NEG_')
+            elif value < 0:
+                token = f"NEG_{abs(value)}"
+            else:
+                token = str(value)
+            return f"VALUE_{token}"
+        text = str(value)
+        candidate = re.sub(r'[^0-9A-Za-z_]', '_', text)
+        if not candidate or not (candidate[0].isalpha() or candidate[0] == '_'):
+            candidate = f"VALUE_{candidate}" if candidate else "VALUE_"
+        if is_python_reserved_word(candidate):
+            candidate = candidate + "_"
+        return candidate
+
     def generate_enum(self, structure_schema: Dict, field_name: str, parent_namespace: str, 
                      write_file: bool) -> str:
         """ Generates a Python enum from JSON Structure enum """
@@ -502,8 +532,24 @@ class StructureToPython:
         if python_qualified_name in self.generated_types:
             return python_qualified_name
 
-        symbols = [symbol if not is_python_reserved_word(symbol) else symbol + "_" 
-                  for symbol in structure_schema.get('enum', [])]
+        raw_values = structure_schema.get('enum', [])
+        is_numeric = bool(raw_values) and all(
+            isinstance(v, (int, float)) and not isinstance(v, bool) for v in raw_values
+        )
+
+        # Build (member_name, repr) pairs. ``repr`` is rendered verbatim into the
+        # class body, so for numeric enums we emit the bare numeric literal and
+        # for string enums a quoted Python string literal.
+        members: List[Tuple[str, str]] = []
+        symbols: List[str] = []
+        for value in raw_values:
+            member_name = self._python_enum_member_name(value)
+            if is_numeric:
+                value_repr = repr(value)
+            else:
+                value_repr = repr(str(value))
+            members.append((member_name, value_repr))
+            symbols.append(member_name)
 
         doc = structure_schema.get('description', structure_schema.get('doc', f'A {class_name} enum.'))
 
@@ -511,12 +557,15 @@ class StructureToPython:
             "structuretopython/enum_core.jinja",
             class_name=class_name,
             docstring=doc,
+            members=members,
+            is_numeric=is_numeric,
+            # ``symbols`` kept for backward compatibility with any external use
             symbols=symbols,
         )
 
         if write_file:
             self.write_to_file(package_name, class_name, enum_definition)
-            self.generate_test_enum(package_name, class_name, symbols)
+            self.generate_test_enum(package_name, class_name, members, is_numeric)
 
         self.generated_types[python_qualified_name] = 'enum'
         self.generated_enum_symbols[python_qualified_name] = symbols
@@ -717,7 +766,8 @@ class StructureToPython:
         with open(test_file_path, 'w', encoding='utf-8') as file:
             file.write(test_class_definition)
 
-    def generate_test_enum(self, package_name: str, class_name: str, symbols: List[str]) -> None:
+    def generate_test_enum(self, package_name: str, class_name: str,
+                           members: List[Tuple[str, str]], is_numeric: bool) -> None:
         """Generates a unit test class for a Python enum"""
         test_class_name = f"Test_{class_name}"
         # Use a simpler file naming scheme based on class name only
@@ -727,7 +777,8 @@ class StructureToPython:
             package_name=package_name,
             class_name=class_name,
             test_class_name=test_class_name,
-            symbols=symbols
+            members=members,
+            is_numeric=is_numeric,
         )
         base_dir = os.path.join(self.output_dir, "tests")
         test_file_path = os.path.join(base_dir, f"{test_file_name}.py")

--- a/avrotize/structuretopython/enum_core.jinja
+++ b/avrotize/structuretopython/enum_core.jinja
@@ -1,12 +1,12 @@
-from enum import Enum
+from enum import {% if is_numeric %}IntEnum{% else %}Enum{% endif %}
 
 
-class {{ class_name }}(Enum):
+class {{ class_name }}({% if is_numeric %}IntEnum{% else %}Enum{% endif %}):
     """
     {{ docstring }}
     """
-    {%- for symbol in symbols %}
-    {{ symbol }} = '{{ symbol }}'
+    {%- for member_name, value_repr in members %}
+    {{ member_name }} = {{ value_repr }}
     {%- endfor %}
 
     @classmethod

--- a/avrotize/structuretopython/test_enum.jinja
+++ b/avrotize/structuretopython/test_enum.jinja
@@ -16,19 +16,19 @@ class {{ test_class_name }}(unittest.TestCase):
         """
         Setup test
         """
-        self.instance = {{ class_name }}.{{ symbols[0] }}
+        self.instance = {{ class_name }}.{{ members[0][0] }}
 
     @staticmethod
     def create_instance():
         """
         Create instance of {{ class_name }}
         """
-        return {{ class_name }}.{{ symbols[0] }}
+        return {{ class_name }}.{{ members[0][0] }}
 
     def test_enum_values(self):
         """
         Test that all enum values are defined
         """
-        {%- for symbol in symbols %}
-        self.assertEqual({{ class_name }}.{{ symbol }}.value, "{{ symbol }}")
+        {%- for member_name, value_repr in members %}
+        self.assertEqual({{ class_name }}.{{ member_name }}.value, {{ value_repr }})
         {%- endfor %}

--- a/test/test_structuretopython.py
+++ b/test/test_structuretopython.py
@@ -612,5 +612,66 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
             f"Expected types under de/wsv/pegelonline/, got file paths {py_files}"
 
 
+    def test_integer_enum_emits_valid_python(self):
+        """Regression test for issue #315.
+
+        Integer-valued JSON Structure enums (e.g. ``"enum": [0, 1, 2]``)
+        previously produced an importable-looking file whose class body
+        contained bare numeric literals like ``0 = '0'``, which is a
+        SyntaxError. The generator now prefixes numeric member names with
+        ``VALUE_`` and uses ``IntEnum`` with the original integer values.
+        """
+        from avrotize.structuretopython import convert_structure_schema_to_python
+
+        schema = {
+            "type": "object",
+            "name": "LightningStrike",
+            "namespace": "wx.dmi",
+            "properties": {
+                "id": {"type": "string"},
+                "type": {
+                    "type": {
+                        "type": "integer",
+                        "enum": [0, 1, 2],
+                        "description": "Strike type code.",
+                    },
+                },
+            },
+        }
+
+        output_dir = os.path.join(tempfile.gettempdir(), "avrotize", "issue-315-int-enum")
+        if os.path.exists(output_dir):
+            shutil.rmtree(output_dir, ignore_errors=True)
+        os.makedirs(output_dir, exist_ok=True)
+
+        convert_structure_schema_to_python(schema, output_dir, package_name="dmi_lightning")
+
+        # Find the generated enum file
+        src_dir = os.path.join(output_dir, "src")
+        enum_files = []
+        for root, _dirs, files in os.walk(src_dir):
+            for f in files:
+                if f.endswith(".py") and "typeenum" in f.lower():
+                    enum_files.append(os.path.join(root, f))
+        assert enum_files, f"Expected a *typeenum*.py file under {src_dir}"
+
+        enum_source = ""
+        for f in enum_files:
+            with open(f, "r", encoding="utf-8") as fh:
+                enum_source = fh.read()
+            break
+
+        # The file must be syntactically valid Python
+        import ast
+        ast.parse(enum_source)
+
+        # IntEnum with VALUE_n members and integer values (no quotes)
+        assert "IntEnum" in enum_source, f"Expected IntEnum in:\n{enum_source}"
+        assert "VALUE_0 = 0" in enum_source, f"Expected 'VALUE_0 = 0' in:\n{enum_source}"
+        assert "VALUE_1 = 1" in enum_source, f"Expected 'VALUE_1 = 1' in:\n{enum_source}"
+        assert "VALUE_2 = 2" in enum_source, f"Expected 'VALUE_2 = 2' in:\n{enum_source}"
+        assert "0 = '0'" not in enum_source, "Bare numeric member name regressed"
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #315.

Integer-valued JSON Structure enums (e.g. `"enum": [0, 1, 2]`) previously produced an enum file whose class body contained bare numeric literals like `0 = '0'`, which is a SyntaxError on import.

`generate_enum` now:

- Detects whether all enum values are numeric (and not bool).
- For numeric enums, emits an `IntEnum` with member names prefixed `VALUE_<n>` (or `VALUE_NEG_<n>` for negatives), assigning the original integer literal as the value. Mirrors the `Value{value}` pattern already used by the C# converter.
- For string enums, sanitizes non-identifier characters and prepends `VALUE_` when the candidate would still start with a digit, so hyphenated or numeric-prefixed string values are also handled.
- Reserved Python keywords continue to get a trailing underscore.

Templates `enum_core.jinja` and `test_enum.jinja` now accept `(member_name, value_repr)` tuples plus an `is_numeric` flag, so values render as Python literals rather than always quoted strings.

Regression test `test_integer_enum_emits_valid_python` uses the exact reproducer from the issue and asserts the generated file is syntactically valid Python with `IntEnum` and `VALUE_n = n` members. All 22 `test_structuretopython.py` tests pass plus the 5 Python-target `test_structure_codegen_flags.py` tests.