### PR TITLE
Emit JSON encoder/decoder for dataclasses-json date fields

### DIFF
--- a/avrotize/avrotopython/dataclass_core.jinja
+++ b/avrotize/avrotopython/dataclass_core.jinja
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 {%- if dataclasses_json_annotation %}
 import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
-{%- for field in fields if field.type == "datetime" or field.type == "typing.Optional[datetime.datetime]" %}
+{%- for field in fields if field.type in ["datetime.datetime", "typing.Optional[datetime.datetime]", "datetime.date", "typing.Optional[datetime.date]"] %}
 {%- if loop.first %}
 from marshmallow import fields
 {%- endif %}
@@ -57,8 +57,9 @@ class {{ class_name }}:
         {%- endfor -%}
     """
     {% for field in fields %}
-    {%- set isdate = field.type == "datetime" or field.type == "typing.Optional[datetime.datetime]" %}
-    {{ field.name }}: {{ field.type }}=dataclasses.field(kw_only=True{% if dataclasses_json_annotation %}, metadata=dataclasses_json.config(field_name="{{ field.original_name }}"{%- if isdate -%}, encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso'){%- endif -%}){%- endif %})
+    {%- set isdate = field.type == "datetime.datetime" or field.type == "typing.Optional[datetime.datetime]" %}
+    {%- set isdateonly = field.type == "datetime.date" or field.type == "typing.Optional[datetime.date]" %}
+    {{ field.name }}: {{ field.type }}=dataclasses.field(kw_only=True{% if dataclasses_json_annotation %}, metadata=dataclasses_json.config(field_name="{{ field.original_name }}"{%- if isdate -%}, encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso'){%- elif isdateonly -%}, encoder=lambda d: d.isoformat() if isinstance(d, datetime.date) else d if d else None, decoder=lambda d: datetime.date.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.Date(format='iso'){%- endif -%}){%- endif %})
     {%- endfor %}
     {% if avro_annotation %}
     AvroType: typing.ClassVar[avro.schema.Schema] = avro.schema.make_avsc_object(

--- a/avrotize/structuretopython/dataclass_core.jinja
+++ b/avrotize/structuretopython/dataclass_core.jinja
@@ -17,7 +17,7 @@ from abc import ABC
 {%- if dataclasses_json_annotation %}
 import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
-{%- for field in fields if field.type == "datetime.datetime" or field.type == "typing.Optional[datetime.datetime]" %}
+{%- for field in fields if field.type in ["datetime.datetime", "typing.Optional[datetime.datetime]", "datetime.date", "typing.Optional[datetime.date]"] %}
 {%- if loop.first %}
 from marshmallow import fields
 {%- endif %}
@@ -70,9 +70,10 @@ class {{ class_name }}{% if base_class or is_abstract %}({% if base_class %}{{ b
     {% endif %}
     {% for field in fields %}
     {%- set isdate = field.type == "datetime.datetime" or field.type == "typing.Optional[datetime.datetime]" %}
+    {%- set isdateonly = field.type == "datetime.date" or field.type == "typing.Optional[datetime.date]" %}
     {%- set is_int_as_string = field.source_type in ['int64', 'uint64', 'int128', 'uint128'] %}
     {%- set is_decimal_as_string = field.source_type == 'decimal' %}
-    {{ field.name }}: {{ field.type }}=dataclasses.field(kw_only=True{% if dataclasses_json_annotation %}, metadata=dataclasses_json.config(field_name="{{ field.original_name }}"{%- if isdate -%}, encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso'){%- elif is_int_as_string -%}, encoder=lambda v: str(v) if v is not None else None, decoder=lambda v: int(v) if isinstance(v, str) else v{%- elif is_decimal_as_string -%}, encoder=lambda v: str(v) if v is not None else None, decoder=lambda v: decimal.Decimal(v) if isinstance(v, str) else v{%- endif -%}){%- endif %})
+    {{ field.name }}: {{ field.type }}=dataclasses.field(kw_only=True{% if dataclasses_json_annotation %}, metadata=dataclasses_json.config(field_name="{{ field.original_name }}"{%- if isdate -%}, encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso'){%- elif isdateonly -%}, encoder=lambda d: d.isoformat() if isinstance(d, datetime.date) else d if d else None, decoder=lambda d: datetime.date.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.Date(format='iso'){%- elif is_int_as_string -%}, encoder=lambda v: str(v) if v is not None else None, decoder=lambda v: int(v) if isinstance(v, str) else v{%- elif is_decimal_as_string -%}, encoder=lambda v: str(v) if v is not None else None, decoder=lambda v: decimal.Decimal(v) if isinstance(v, str) else v{%- endif -%}){%- endif %})
     {%- endfor %}
 
     @classmethod

--- a/test/test_structuretopython.py
+++ b/test/test_structuretopython.py
@@ -795,6 +795,59 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
         import ast
         ast.parse(source)
 
+    def test_date_field_gets_json_encoder(self):
+        """Regression test for issue #355.
+
+        date fields were emitted without an encoder/decoder, so .to_json() on a
+        dataclass holding a datetime.date raised
+        "TypeError: Object of type date is not JSON serializable". A date field
+        must get an isoformat encoder/decoder just like a datetime field does.
+        """
+        from avrotize.structuretopython import convert_structure_schema_to_python
+
+        schema = {
+            "type": "object",
+            "name": "DateRecord",
+            "namespace": "test.issue355",
+            "properties": {
+                "id": {"type": "string"},
+                "the_date": {"type": "date"},
+                "the_datetime": {"type": "datetime"},
+            },
+            "required": ["id", "the_date", "the_datetime"]
+        }
+
+        output_dir = os.path.join(tempfile.gettempdir(), "avrotize", "issue-355-date-encoder")
+        if os.path.exists(output_dir):
+            shutil.rmtree(output_dir, ignore_errors=True)
+        os.makedirs(output_dir, exist_ok=True)
+
+        convert_structure_schema_to_python(schema, output_dir, package_name="test_issue355",
+                                          dataclasses_json_annotation=True)
+
+        # Find the generated class file
+        src_dir = os.path.join(output_dir, "src")
+        class_file = None
+        for root, _dirs, files in os.walk(src_dir):
+            for f in files:
+                if "daterecord" in f.lower() and f.endswith(".py"):
+                    class_file = os.path.join(root, f)
+                    break
+
+        assert class_file is not None, f"Expected DateRecord class file under {src_dir}"
+
+        with open(class_file, "r", encoding="utf-8") as fh:
+            source = fh.read()
+
+        # The date field must round-trip through ISO strings, mirroring datetime.
+        assert "datetime.date.fromisoformat" in source, \
+            f"Expected date decoder for date field in:\n{source}"
+        assert "fields.Date(format='iso')" in source, \
+            f"Expected marshmallow Date field for date field in:\n{source}"
+
+        # Verify valid Python
+        import ast
+        ast.parse(source)
 
     def test_enum_collision_shindo_scale(self):
         """Test that enum symbols differing only by +/- produce unique member names.


### PR DESCRIPTION
Fixes #355. The dataclasses-json Python generator emitted a date field with a bare `dataclasses_json.config(field_name=...)` and no encoder/decoder, so `.to_json()` on a class holding a `datetime.date` raised `TypeError: Object of type date is not JSON serializable`. Date fields now get an isoformat encoder/decoder and a `fields.Date` marshmallow field, mirroring how datetime fields are already handled. I also corrected the datetime check in the avro-to-python template, which was matching "datetime" instead of the actual "datetime.datetime" type and so was silently skipping the encoder there too. Added a regression test alongside the existing int64/decimal serialization tests.