### PR TITLE
feat: add JSON Type Definition (RFC 8927) support (#260)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 All notable changes to Avrotize are documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **JSON Type Definition (JTD, RFC 8927) support** ([#260](https://github.com/clemensv/avrotize/issues/260)): Added `jtd2a`, `a2jtd`, `jtd2s`, and `s2jtd` commands for converting JTD to/from Avrotize Schema and JSON Structure. The implementation supports JTD type, enum, elements, values, properties/optionalProperties, discriminator/mapping, definitions/ref, and nullable forms, with documented Avro mapping limitations.
+
 ## [3.5.9] - 2026-06-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Converting to Avrotize Schema:
 - [`avrotize pq2a`](#convert-parquet-schema-to-avrotize-schema) - Convert Parquet schema to Avrotize Schema.
 - [`avrotize csv2a`](#convert-csv-file-to-avrotize-schema) - Convert CSV file to Avrotize Schema.
 - [`avrotize kstruct2a`](#convert-kafka-connect-schema-to-avrotize-schema) - Convert Kafka Connect Schema to Avrotize Schema.
+- [`avrotize jtd2a`](#convert-json-type-definition-jtd-to-avrotize-schema) - Convert JSON Type Definition (JTD) to Avrotize Schema.
 
 Converting from Avrotize Schema:
 
@@ -96,6 +97,7 @@ Converting from Avrotize Schema:
 - [`avrotize a2dp`](#convert-avrotize-schema-to-datapackage-schema) - Convert Avrotize Schema to Datapackage schema.
 - [`avrotize a2md`](#convert-avrotize-schema-to-markdown-documentation) - Convert Avrotize Schema to Markdown documentation.
 - [`avrotize s2md`](#convert-json-structure-schema-to-markdown-documentation) - Convert JSON Structure schema to Markdown documentation.
+- [`avrotize a2jtd`](#convert-avrotize-schema-to-json-type-definition-jtd) - Convert Avrotize Schema to JSON Type Definition (JTD).
 
 Direct conversions (JSON Structure):
 
@@ -130,6 +132,8 @@ Direct JSON Structure conversions:
 - [`avrotize s2x`](#convert-json-structure-to-xml-schema-xsd) - Convert JSON Structure to XML Schema (XSD).
 - [`avrotize s2graphql`](#convert-json-structure-schema-to-graphql-schema) - Convert JSON Structure schema to GraphQL schema.
 - [`avrotize a2graphql`](#convert-avrotize-schema-to-graphql-schema) - Convert Avrotize schema to GraphQL schema.
+- [`avrotize jtd2s`](#convert-json-type-definition-jtd-to-json-structure) - Convert JSON Type Definition (JTD) to JSON Structure.
+- [`avrotize s2jtd`](#convert-json-structure-to-json-type-definition-jtd) - Convert JSON Structure to JSON Type Definition (JTD).
 
 Other commands:
 
@@ -895,6 +899,79 @@ Conversion notes:
 - Type annotations such as `precision`, `scale`, and validation constraints are preserved where applicable.
 - The `$extends` feature is supported - base type properties are included in the conversion.
 - Required and optional properties are handled via Iceberg's `required` field flag.
+
+
+### Convert JSON Type Definition (JTD) to Avrotize Schema
+
+```bash
+avrotize jtd2a <path_to_jtd_file> [--out <path_to_avro_schema_file>] [--namespace <avro_schema_namespace>]
+```
+
+Parameters:
+
+- `<path_to_jtd_file>`: The path to the JSON Type Definition file to be converted. If omitted, the file is read from stdin.
+- `--out`: The path to the Avrotize Schema file to write the conversion result to. If omitted, the output is directed to stdout.
+- `--namespace`: (optional) Namespace for generated Avro records and enums.
+
+Conversion notes:
+
+- JTD `type` forms map to Avro primitives; `timestamp` is encoded as Avro `long` with `logicalType: "timestamp-millis"`.
+- JTD `enum` symbols are sanitized to Avro names when needed. The original JTD symbols are retained in `jtdEnumSymbols` metadata for round trips.
+- JTD `properties` become required Avro record fields. `optionalProperties` become nullable Avro fields with `default: null`.
+- JTD `elements` and `values` map to Avro arrays and maps. `definitions`/`ref` map to named Avro types.
+- JTD `discriminator`/`mapping` maps to an Avro union of records. Each branch carries the discriminator as a single-symbol enum field plus `jtdDiscriminator`/`jtdMappingKey` metadata for round trips.
+- Avro has no direct equivalent for JTD `additionalProperties`; the setting is preserved as `jtdAdditionalProperties` metadata but is not enforced by Avro.
+
+### Convert Avrotize Schema to JSON Type Definition (JTD)
+
+```bash
+avrotize a2jtd <path_to_avro_schema_file> [--out <path_to_jtd_file>] [--record-type <record-type-from-avro>]
+```
+
+Parameters:
+
+- `<path_to_avro_schema_file>`: The path to the Avrotize Schema file to be converted. If omitted, the file is read from stdin.
+- `--out`: The path to the JSON Type Definition file to write the conversion result to. If omitted, the output is directed to stdout.
+- `--record-type`: (optional) The name of the Avro record type to use as the JTD root when the file contains multiple named types.
+
+Conversion notes:
+
+- Avro primitives map to the closest JTD `type`; converter metadata such as `jtdType` is used to restore narrower JTD integer and float forms when present.
+- Avro `long` with `logicalType: "timestamp-millis"` maps to JTD `timestamp`.
+- Nullable Avro unions map to `nullable: true`; nullable fields with `default: null` map to JTD `optionalProperties`.
+- General Avro unions do not have a native JTD equivalent. Only discriminator unions emitted by `jtd2a` round-trip to JTD `discriminator`/`mapping`; other unions are retained as metadata.
+
+### Convert JSON Type Definition (JTD) to JSON Structure
+
+```bash
+avrotize jtd2s <path_to_jtd_file> [--out <path_to_structure_file>] [--namespace <avro_schema_namespace>]
+```
+
+Parameters:
+
+- `<path_to_jtd_file>`: The path to the JSON Type Definition file to be converted. If omitted, the file is read from stdin.
+- `--out`: The path to the JSON Structure file to write the conversion result to. If omitted, the output is directed to stdout.
+- `--namespace`: (optional) Namespace for generated intermediate Avro records and enums.
+
+Conversion notes:
+
+- The conversion bridges through Avrotize Schema, so the JTD-to-Avro limitations also apply.
+
+### Convert JSON Structure to JSON Type Definition (JTD)
+
+```bash
+avrotize s2jtd <path_to_structure_file> [--out <path_to_jtd_file>] [--record-type <record-type-from-structure>]
+```
+
+Parameters:
+
+- `<path_to_structure_file>`: The path to the JSON Structure file to be converted. If omitted, the file is read from stdin.
+- `--out`: The path to the JSON Type Definition file to write the conversion result to. If omitted, the output is directed to stdout.
+- `--record-type`: (optional) The name of the Structure/Avro record type to use as the JTD root.
+
+Conversion notes:
+
+- The conversion bridges through Avrotize Schema, so JSON Structure features without JTD equivalents may be simplified or emitted as metadata.
 
 ### Convert Parquet schema to Avrotize Schema
 

--- a/avrotize/__init__.py
+++ b/avrotize/__init__.py
@@ -25,6 +25,10 @@ class LazyLoader:
 # Define the functions and their corresponding module paths
 _mappings = {
     "convert_proto_to_avro": (f"{mod}.prototoavro", "convert_proto_to_avro"),
+    "convert_jtd_to_avro": (f"{mod}.jtdtoavro", "convert_jtd_to_avro"),
+    "convert_avro_to_jtd": (f"{mod}.avrotojtd", "convert_avro_to_jtd"),
+    "convert_jtd_to_structure": (f"{mod}.jtdtostructure", "convert_jtd_to_structure"),
+    "convert_structure_to_jtd": (f"{mod}.structuretojtd", "convert_structure_to_jtd"),
     "convert_jsons_to_avro": (f"{mod}.jsonstoavro", "convert_jsons_to_avro"),
     "convert_kafka_struct_to_avro_schema": (f"{mod}.kstructtoavro", "convert_kafka_struct_to_avro_schema"),
     "convert_kusto_to_avro": (f"{mod}.kustotoavro", "convert_kusto_to_avro"),

--- a/avrotize/avrotojstruct.py
+++ b/avrotize/avrotojstruct.py
@@ -285,6 +285,26 @@ class AvroToJsonStructure:
             if logical_type:
                 return self.resolve_logical_type(logical_type, avro_type_schema)
 
+            jtd_type = avro_type_schema.get("jtdType")
+            if jtd_type:
+                jtd_mapping = {
+                    "boolean": "boolean",
+                    "float32": "float",
+                    "float64": "double",
+                    "int8": "int8",
+                    "uint8": "uint8",
+                    "int16": "int16",
+                    "uint16": "uint16",
+                    "int32": "int32",
+                    "uint32": "uint32",
+                    "string": "string",
+                }
+                if jtd_type in jtd_mapping:
+                    return {"type": jtd_mapping[jtd_type]}
+
+            if category in self.get_primitive_types():
+                return {"type": self.get_primitive_types()[category]}
+
         raise ValueError(f"Unsupported Avro type schema: {avro_type_schema}")
 
     # ------------------------------------------------------------------ HELPERS

--- a/avrotize/avrotojtd.py
+++ b/avrotize/avrotojtd.py
@@ -1,0 +1,225 @@
+"""Avrotize Schema to JSON Type Definition (RFC 8927) converter."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+AvroSchema = dict[str, Any] | list[Any] | str
+JtdSchema = dict[str, Any]
+
+
+class AvroToJtdConverter:
+    """Convert Avrotize/Avro schemas to JSON Type Definition schemas."""
+
+    PRIMITIVE_TO_JTD: dict[str, str] = {
+        "boolean": "boolean",
+        "int": "int32",
+        "long": "uint32",
+        "float": "float32",
+        "double": "float64",
+        "string": "string",
+    }
+
+    def __init__(self, record_type: str | None = None) -> None:
+        """Initialize the converter."""
+        self.record_type = record_type
+        self.named_types: dict[str, dict[str, Any]] = {}
+        self.simple_names: dict[str, str] = {}
+        self.definitions: dict[str, JtdSchema] = {}
+        self.converting: set[str] = set()
+
+    def convert(self, avro_schema: AvroSchema) -> JtdSchema:
+        """Convert an Avro schema object to a JTD schema dictionary."""
+        root = self._register_top_level(avro_schema)
+        if self.record_type:
+            root = self._find_named_type(self.record_type)
+        root_jtd = self._convert_type(root)
+        if self.definitions:
+            if isinstance(root, dict) and root.get("type") in {"record", "enum"}:
+                root_name = self._type_key(root)
+                self.definitions[root_name] = root_jtd
+                return {"definitions": self.definitions, "ref": root_name}
+            root_jtd = dict(root_jtd)
+            root_jtd["definitions"] = self.definitions
+        return root_jtd
+
+    def _register_top_level(self, avro_schema: AvroSchema) -> AvroSchema:
+        if isinstance(avro_schema, list):
+            if self._is_discriminator_union(avro_schema):
+                for item in avro_schema:
+                    self._register_named(item)
+                return avro_schema
+            if not all(isinstance(item, dict) and item.get("type") in {"record", "enum"} for item in avro_schema):
+                return avro_schema
+            root: AvroSchema | None = None
+            for item in avro_schema:
+                self._register_named(item)
+                root = item
+                if item.get("jtdRoot"):
+                    root = item
+                    break
+            if root is None:
+                raise ValueError("Avro schema list is empty")
+            return root
+        if isinstance(avro_schema, dict) and avro_schema.get("type") in {"record", "enum"}:
+            self._register_named(avro_schema)
+        return avro_schema
+
+    def _register_named(self, schema: dict[str, Any]) -> None:
+        key = self._type_key(schema)
+        self.named_types[key] = schema
+        self.simple_names[schema["name"]] = key
+
+    def _find_named_type(self, record_type: str) -> dict[str, Any]:
+        key = record_type if record_type in self.named_types else self.simple_names.get(record_type)
+        if key and key in self.named_types:
+            return self.named_types[key]
+        raise ValueError(f"Avro record type '{record_type}' not found")
+
+    @staticmethod
+    def _type_key(schema: dict[str, Any]) -> str:
+        namespace = schema.get("namespace")
+        return f"{namespace}.{schema['name']}" if namespace else schema["name"]
+
+    def _convert_type(self, avro_type: AvroSchema) -> JtdSchema:
+        nullable, non_null = self._strip_nullable(avro_type)
+        if self._is_discriminator_union(non_null):
+            jtd = self._convert_discriminator(non_null)  # type: ignore[arg-type]
+        else:
+            jtd = self._convert_non_nullable(non_null)
+        if nullable:
+            jtd = dict(jtd)
+            jtd["nullable"] = True
+        return jtd
+
+    def _convert_non_nullable(self, avro_type: AvroSchema) -> JtdSchema:
+        if isinstance(avro_type, str):
+            if avro_type == "null":
+                return {"nullable": True}
+            if avro_type in self.PRIMITIVE_TO_JTD:
+                return {"type": self.PRIMITIVE_TO_JTD[avro_type]}
+            ref_key = self.simple_names.get(avro_type, avro_type)
+            if ref_key in self.named_types:
+                self._ensure_definition(ref_key)
+                return {"ref": ref_key}
+            return {"type": "string"}
+        if isinstance(avro_type, list):
+            return self._convert_union(avro_type)
+        if not isinstance(avro_type, dict):
+            return {"type": "string"}
+
+        if avro_type.get("jtdType"):
+            return {"type": avro_type["jtdType"]}
+        if avro_type.get("logicalType") == "timestamp-millis" and avro_type.get("type") == "long":
+            return {"type": "timestamp"}
+
+        schema_type = avro_type.get("type")
+        if isinstance(schema_type, dict) or isinstance(schema_type, list):
+            return self._convert_type(schema_type)
+        if schema_type in self.PRIMITIVE_TO_JTD:
+            return {"type": self.PRIMITIVE_TO_JTD[schema_type]}
+        if schema_type == "record":
+            return self._convert_record(avro_type)
+        if schema_type == "enum":
+            return self._convert_enum(avro_type)
+        if schema_type == "array":
+            return {"elements": self._convert_type(avro_type.get("items", "string"))}
+        if schema_type == "map":
+            return {"values": self._convert_type(avro_type.get("values", "string"))}
+        if isinstance(schema_type, str) and schema_type in self.named_types:
+            self._ensure_definition(schema_type)
+            return {"ref": schema_type}
+        return {"type": "string"}
+
+    def _convert_record(self, schema: dict[str, Any]) -> JtdSchema:
+        key = self._type_key(schema)
+        if key in self.converting:
+            return {"ref": key}
+        self.converting.add(key)
+        properties: dict[str, JtdSchema] = {}
+        optional_properties: dict[str, JtdSchema] = {}
+        for field in schema.get("fields", []):
+            if field.get("name") == schema.get("jtdDiscriminator"):
+                continue
+            field_nullable, field_type = self._strip_nullable(field.get("type", "string"))
+            converted = self._convert_type(field_type)
+            if field_nullable and field.get("default") is None:
+                optional_properties[field["name"]] = converted
+            else:
+                if field_nullable:
+                    converted = dict(converted)
+                    converted["nullable"] = True
+                properties[field["name"]] = converted
+        self.converting.remove(key)
+        result: JtdSchema = {}
+        if properties:
+            result["properties"] = properties
+        if optional_properties:
+            result["optionalProperties"] = optional_properties
+        if "jtdAdditionalProperties" in schema:
+            result["additionalProperties"] = bool(schema["jtdAdditionalProperties"])
+        return result
+
+    @staticmethod
+    def _convert_enum(schema: dict[str, Any]) -> JtdSchema:
+        original_symbols = schema.get("jtdEnumSymbols", {})
+        return {"enum": [original_symbols.get(symbol, symbol) for symbol in schema.get("symbols", [])]}
+
+    def _convert_union(self, union: list[Any]) -> JtdSchema:
+        non_null = [item for item in union if item != "null"]
+        if len(non_null) == 1:
+            return self._convert_type(non_null[0])
+        if self._is_discriminator_union(non_null):
+            return self._convert_discriminator(non_null)
+        return {"metadata": {"avrotize-union": [self._convert_type(item) for item in non_null]}}
+
+    def _convert_discriminator(self, union: list[Any]) -> JtdSchema:
+        discriminator = union[0].get("jtdDiscriminator")
+        mapping: dict[str, JtdSchema] = {}
+        for branch in union:
+            tag = branch.get("jtdMappingKey")
+            if tag is None:
+                tag = branch.get("name")
+            mapping[str(tag)] = self._convert_record(branch)
+        return {"discriminator": discriminator, "mapping": mapping}
+
+    @staticmethod
+    def _strip_nullable(avro_type: AvroSchema) -> tuple[bool, AvroSchema]:
+        if isinstance(avro_type, list) and "null" in avro_type:
+            non_null = [item for item in avro_type if item != "null"]
+            if len(non_null) == 1:
+                return True, non_null[0]
+            return True, non_null
+        return False, avro_type
+
+    @staticmethod
+    def _is_discriminator_union(avro_type: AvroSchema) -> bool:
+        return (
+            isinstance(avro_type, list)
+            and bool(avro_type)
+            and all(isinstance(item, dict) and item.get("type") == "record" and item.get("jtdDiscriminator") for item in avro_type)
+            and len({item.get("jtdDiscriminator") for item in avro_type if isinstance(item, dict)}) == 1
+        )
+
+    def _ensure_definition(self, key: str) -> None:
+        if key in self.definitions:
+            return
+        if key not in self.named_types:
+            return
+        if key in self.converting:
+            self.definitions[key] = {"ref": key}
+            return
+        self.converting.add(key)
+        self.definitions[key] = self._convert_non_nullable(self.named_types[key])
+        self.converting.remove(key)
+
+
+def convert_avro_to_jtd(avro_schema_path: str, jtd_file_path: str, record_type: str | None = None) -> None:
+    """Convert an Avrotize Schema file to a JSON Type Definition file."""
+    with open(avro_schema_path, "r", encoding="utf-8") as avro_file:
+        avro_schema = json.load(avro_file)
+    converter = AvroToJtdConverter(record_type=record_type)
+    jtd_schema = converter.convert(avro_schema)
+    with open(jtd_file_path, "w", encoding="utf-8") as jtd_file:
+        json.dump(jtd_schema, jtd_file, indent=2)

--- a/avrotize/commands.json
+++ b/avrotize/commands.json
@@ -4381,6 +4381,165 @@
     "prompts": []
   },
   {
+    "command": "jtd2a",
+    "description": "Convert JSON Type Definition (JTD) to Avrotize schema",
+    "group": "1_Schemas",
+    "function": {
+      "name": "avrotize.jtdtoavro.convert_jtd_to_avro",
+      "args": {
+        "jtd_file_path": "input_file_path",
+        "avro_schema_path": "output_file_path",
+        "namespace": "args.namespace"
+      }
+    },
+    "extensions": [
+      ".jtd.json",
+      ".jtd"
+    ],
+    "args": [
+      {
+        "name": "input",
+        "type": "str",
+        "nargs": "?",
+        "help": "Path to the JSON Type Definition file (or read from stdin if omitted)",
+        "required": false
+      },
+      {
+        "name": "--out",
+        "type": "str",
+        "help": "Path to the Avrotize schema file",
+        "required": false
+      },
+      {
+        "name": "--namespace",
+        "type": "str",
+        "help": "Namespace for generated Avrotize records and enums",
+        "required": false
+      }
+    ],
+    "suggested_output_file_path": "{input_file_name}.avsc",
+    "prompts": []
+  },
+  {
+    "command": "a2jtd",
+    "description": "Convert Avrotize schema to JSON Type Definition (JTD)",
+    "group": "1_Schemas",
+    "function": {
+      "name": "avrotize.avrotojtd.convert_avro_to_jtd",
+      "args": {
+        "avro_schema_path": "input_file_path",
+        "jtd_file_path": "output_file_path",
+        "record_type": "args.record_type"
+      }
+    },
+    "extensions": [
+      ".avsc"
+    ],
+    "args": [
+      {
+        "name": "input",
+        "type": "str",
+        "nargs": "?",
+        "help": "Path to the Avrotize schema file (or read from stdin if omitted)",
+        "required": false
+      },
+      {
+        "name": "--out",
+        "type": "str",
+        "help": "Path to the JSON Type Definition file",
+        "required": false
+      },
+      {
+        "name": "--record-type",
+        "type": "str",
+        "help": "Name of the Avro record type to convert",
+        "required": false
+      }
+    ],
+    "suggested_output_file_path": "{input_file_name}.jtd.json",
+    "prompts": []
+  },
+  {
+    "command": "jtd2s",
+    "description": "Convert JSON Type Definition (JTD) to JSON Structure",
+    "group": "1_Schemas",
+    "function": {
+      "name": "avrotize.jtdtostructure.convert_jtd_to_structure",
+      "args": {
+        "jtd_file_path": "input_file_path",
+        "json_structure_file": "output_file_path",
+        "namespace": "args.namespace"
+      }
+    },
+    "extensions": [
+      ".jtd.json",
+      ".jtd"
+    ],
+    "args": [
+      {
+        "name": "input",
+        "type": "str",
+        "nargs": "?",
+        "help": "Path to the JSON Type Definition file (or read from stdin if omitted)",
+        "required": false
+      },
+      {
+        "name": "--out",
+        "type": "str",
+        "help": "Path to the JSON Structure file",
+        "required": false
+      },
+      {
+        "name": "--namespace",
+        "type": "str",
+        "help": "Namespace for generated intermediate Avrotize records and enums",
+        "required": false
+      }
+    ],
+    "suggested_output_file_path": "{input_file_name}.struct.json",
+    "prompts": []
+  },
+  {
+    "command": "s2jtd",
+    "description": "Convert JSON Structure to JSON Type Definition (JTD)",
+    "group": "1_Schemas",
+    "function": {
+      "name": "avrotize.structuretojtd.convert_structure_to_jtd",
+      "args": {
+        "structure_file": "input_file_path",
+        "jtd_file_path": "output_file_path",
+        "record_type": "args.record_type"
+      }
+    },
+    "extensions": [
+      ".struct.json",
+      ".json"
+    ],
+    "args": [
+      {
+        "name": "input",
+        "type": "str",
+        "nargs": "?",
+        "help": "Path to the JSON Structure file (or read from stdin if omitted)",
+        "required": false
+      },
+      {
+        "name": "--out",
+        "type": "str",
+        "help": "Path to the JSON Type Definition file",
+        "required": false
+      },
+      {
+        "name": "--record-type",
+        "type": "str",
+        "help": "Name of the Structure/Avro record type to convert",
+        "required": false
+      }
+    ],
+    "suggested_output_file_path": "{input_file_name}.jtd.json",
+    "prompts": []
+  },
+  {
     "command": "s2x",
     "description": "Convert JSON Structure to XSD schema",
     "group": "1_Schemas",

--- a/avrotize/jtdtoavro.py
+++ b/avrotize/jtdtoavro.py
@@ -1,0 +1,222 @@
+"""JSON Type Definition (RFC 8927) to Avrotize Schema converter."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from avrotize.common import avro_name, avro_namespace
+
+AvroSchema = dict[str, Any] | list[Any] | str
+JtdSchema = dict[str, Any]
+
+
+class JtdToAvroConverter:
+    """Convert JSON Type Definition schemas to Avrotize/Avro schemas."""
+
+    TYPE_MAPPING: dict[str, AvroSchema] = {
+        "boolean": {"type": "boolean", "jtdType": "boolean"},
+        "float32": {"type": "float", "jtdType": "float32"},
+        "float64": {"type": "double", "jtdType": "float64"},
+        "int8": {"type": "int", "jtdType": "int8"},
+        "uint8": {"type": "int", "jtdType": "uint8"},
+        "int16": {"type": "int", "jtdType": "int16"},
+        "uint16": {"type": "int", "jtdType": "uint16"},
+        "int32": {"type": "int", "jtdType": "int32"},
+        "uint32": {"type": "long", "jtdType": "uint32"},
+        "string": {"type": "string", "jtdType": "string"},
+        "timestamp": {"type": "long", "logicalType": "timestamp-millis", "jtdType": "timestamp"},
+    }
+
+    def __init__(self, namespace: str | None = None) -> None:
+        """Initialize the converter."""
+        self.namespace = avro_namespace(namespace) if namespace else None
+        self.definitions: dict[str, JtdSchema] = {}
+        self.ref_names: dict[str, str] = {}
+        self.generated: dict[str, dict[str, Any]] = {}
+        self.in_progress: set[str] = set()
+        self.output: list[dict[str, Any]] = []
+
+    def convert(self, jtd_schema: JtdSchema, root_name: str = "Root") -> AvroSchema | list[AvroSchema]:
+        """Convert a JTD schema dictionary to an Avro schema."""
+        self.definitions = jtd_schema.get("definitions", {}) if isinstance(jtd_schema.get("definitions"), dict) else {}
+        for ref_name in self.definitions:
+            self.ref_names[ref_name] = self._unique_type_name(ref_name)
+
+        root_schema = {key: value for key, value in jtd_schema.items() if key != "definitions"}
+        if "ref" in root_schema and set(root_schema).issubset({"ref", "nullable", "metadata"}):
+            root_ref = root_schema["ref"]
+            root_type = self._convert_ref(root_ref)
+            if root_ref in self.generated:
+                self.generated[root_ref]["jtdRoot"] = True
+            if root_schema.get("nullable"):
+                return [*self.output, "null", root_type]
+            return self.output if self.output else root_type
+
+        converted = self._convert_schema(root_schema, self._unique_type_name(root_name))
+        if self.output:
+            if isinstance(converted, dict) and converted.get("type") in {"record", "enum"}:
+                if converted not in self.output:
+                    self.output.append(converted)
+                return self.output
+            return [*self.output, converted]
+        return converted
+
+    def _unique_type_name(self, name: str) -> str:
+        candidate = avro_name(str(name).split("/")[-1].split(".")[-1] or "Type")
+        if candidate == "_":
+            candidate = "Type"
+        used = set(self.ref_names.values())
+        if candidate not in used:
+            return candidate
+        index = 2
+        while f"{candidate}{index}" in used:
+            index += 1
+        return f"{candidate}{index}"
+
+    def _full_name(self, name: str) -> str:
+        return f"{self.namespace}.{name}" if self.namespace else name
+
+    def _convert_ref(self, ref_name: str) -> str:
+        if ref_name not in self.definitions:
+            raise ValueError(f"JTD ref '{ref_name}' was not found in definitions")
+        if ref_name not in self.ref_names:
+            self.ref_names[ref_name] = self._unique_type_name(ref_name)
+        if ref_name not in self.generated and ref_name not in self.in_progress:
+            self._convert_definition(ref_name)
+        return self._full_name(self.ref_names[ref_name])
+
+    def _convert_definition(self, ref_name: str) -> dict[str, Any]:
+        if ref_name in self.generated:
+            return self.generated[ref_name]
+        self.in_progress.add(ref_name)
+        avro_type = self._convert_schema(self.definitions[ref_name], self.ref_names[ref_name])
+        self.in_progress.remove(ref_name)
+        if not isinstance(avro_type, dict) or avro_type.get("type") not in {"record", "enum"}:
+            avro_type = {
+                "type": "record",
+                "name": self.ref_names[ref_name],
+                "fields": [{"name": "value", "type": avro_type}],
+                "jtdWrappedDefinition": True,
+            }
+            if self.namespace:
+                avro_type["namespace"] = self.namespace
+        self.generated[ref_name] = avro_type
+        if avro_type not in self.output:
+            self.output.append(avro_type)
+        return avro_type
+
+    def _convert_schema(self, schema: JtdSchema, suggested_name: str) -> AvroSchema:
+        if not isinstance(schema, dict):
+            raise ValueError("JTD schema nodes must be JSON objects")
+
+        nullable = bool(schema.get("nullable"))
+        base_schema = {key: value for key, value in schema.items() if key not in {"nullable", "metadata"}}
+        avro_type = self._convert_non_nullable_schema(base_schema, suggested_name)
+        if nullable:
+            return self._nullable(avro_type)
+        return avro_type
+
+    def _convert_non_nullable_schema(self, schema: JtdSchema, suggested_name: str) -> AvroSchema:
+        if not schema:
+            return {"type": "string", "jtdEmptySchema": True}
+        if "ref" in schema:
+            return self._convert_ref(str(schema["ref"]))
+        if "type" in schema:
+            jtd_type = str(schema["type"])
+            if jtd_type not in self.TYPE_MAPPING:
+                raise ValueError(f"Unsupported JTD type '{jtd_type}'")
+            return dict(self.TYPE_MAPPING[jtd_type])  # shallow copy
+        if "enum" in schema:
+            return self._convert_enum(schema, suggested_name)
+        if "elements" in schema:
+            return {"type": "array", "items": self._convert_schema(schema["elements"], f"{suggested_name}Item")}
+        if "values" in schema:
+            return {"type": "map", "values": self._convert_schema(schema["values"], f"{suggested_name}Value")}
+        if "properties" in schema or "optionalProperties" in schema:
+            return self._convert_record(schema, suggested_name)
+        if "discriminator" in schema and "mapping" in schema:
+            return self._convert_discriminator(schema, suggested_name)
+        raise ValueError(f"Unsupported or invalid JTD schema form at {suggested_name}")
+
+    def _convert_enum(self, schema: JtdSchema, suggested_name: str) -> dict[str, Any]:
+        symbols: list[str] = []
+        original_symbols: dict[str, str] = {}
+        seen: set[str] = set()
+        for raw_symbol in schema.get("enum", []):
+            symbol = avro_name(str(raw_symbol)) or "Value"
+            if symbol == "_":
+                symbol = "Value"
+            base_symbol = symbol
+            index = 2
+            while symbol in seen:
+                symbol = f"{base_symbol}_{index}"
+                index += 1
+            seen.add(symbol)
+            symbols.append(symbol)
+            if symbol != raw_symbol:
+                original_symbols[symbol] = str(raw_symbol)
+        avro_enum: dict[str, Any] = {"type": "enum", "name": avro_name(suggested_name), "symbols": symbols}
+        if self.namespace:
+            avro_enum["namespace"] = self.namespace
+        if original_symbols:
+            avro_enum["jtdEnumSymbols"] = original_symbols
+        return avro_enum
+
+    def _convert_record(self, schema: JtdSchema, suggested_name: str) -> dict[str, Any]:
+        record: dict[str, Any] = {"type": "record", "name": avro_name(suggested_name), "fields": []}
+        if self.namespace:
+            record["namespace"] = self.namespace
+        if "additionalProperties" in schema:
+            record["jtdAdditionalProperties"] = bool(schema["additionalProperties"])
+        for prop_name, prop_schema in schema.get("properties", {}).items():
+            record["fields"].append({"name": avro_name(prop_name), "type": self._convert_schema(prop_schema, f"{suggested_name}{avro_name(prop_name).title()}")})
+        for prop_name, prop_schema in schema.get("optionalProperties", {}).items():
+            record["fields"].append({
+                "name": avro_name(prop_name),
+                "type": self._nullable(self._convert_schema(prop_schema, f"{suggested_name}{avro_name(prop_name).title()}")),
+                "default": None,
+            })
+        return record
+
+    def _convert_discriminator(self, schema: JtdSchema, suggested_name: str) -> list[AvroSchema]:
+        discriminator = str(schema["discriminator"])
+        branches: list[AvroSchema] = []
+        for tag, mapping_schema in schema.get("mapping", {}).items():
+            branch_name = f"{suggested_name}{avro_name(str(tag)).title()}"
+            branch = self._convert_schema(mapping_schema, branch_name)
+            if not isinstance(branch, dict) or branch.get("type") != "record":
+                branch = {"type": "record", "name": avro_name(branch_name), "fields": [{"name": "value", "type": branch}]}
+                if self.namespace:
+                    branch["namespace"] = self.namespace
+            tag_symbol = avro_name(str(tag)) or "Tag"
+            tag_enum = {"type": "enum", "name": avro_name(f"{branch['name']}{avro_name(discriminator).title()}"), "symbols": [tag_symbol]}
+            if self.namespace:
+                tag_enum["namespace"] = self.namespace
+            if tag_symbol != tag:
+                tag_enum["jtdEnumSymbols"] = {tag_symbol: str(tag)}
+            branch = dict(branch)
+            branch["jtdDiscriminator"] = discriminator
+            branch["jtdMappingKey"] = str(tag)
+            branch.setdefault("fields", [])
+            branch["fields"] = [{"name": avro_name(discriminator), "type": tag_enum, "default": tag_symbol}, *branch["fields"]]
+            branches.append(branch)
+        return branches
+
+    @staticmethod
+    def _nullable(avro_type: AvroSchema) -> list[AvroSchema]:
+        if isinstance(avro_type, list) and "null" in avro_type:
+            return avro_type
+        return ["null", avro_type]
+
+
+def convert_jtd_to_avro(jtd_file_path: str, avro_schema_path: str, namespace: str | None = None) -> None:
+    """Convert a JSON Type Definition file to an Avrotize Schema file."""
+    with open(jtd_file_path, "r", encoding="utf-8") as jtd_file:
+        jtd_schema = json.load(jtd_file)
+    root_name = os.path.splitext(os.path.basename(jtd_file_path))[0] or "Root"
+    converter = JtdToAvroConverter(namespace=namespace)
+    avro_schema = converter.convert(jtd_schema, root_name=root_name)
+    with open(avro_schema_path, "w", encoding="utf-8") as avro_file:
+        json.dump(avro_schema, avro_file, indent=2)

--- a/avrotize/jtdtostructure.py
+++ b/avrotize/jtdtostructure.py
@@ -1,0 +1,24 @@
+"""JSON Type Definition to JSON Structure converter."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+from avrotize.avrotojstruct import convert_avro_to_json_structure
+from avrotize.jtdtoavro import convert_jtd_to_avro
+
+
+def convert_jtd_to_structure(jtd_file_path: str, json_structure_file: str, namespace: str | None = None) -> None:
+    """Convert a JTD file to JSON Structure by bridging through Avrotize Schema."""
+    temp_dir = os.path.dirname(os.path.abspath(json_structure_file)) or os.getcwd()
+    temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".avsc", dir=temp_dir)
+    temp_file.close()
+    try:
+        convert_jtd_to_avro(jtd_file_path, temp_file.name, namespace=namespace)
+        convert_avro_to_json_structure(temp_file.name, json_structure_file)
+    finally:
+        try:
+            os.remove(temp_file.name)
+        except OSError:
+            pass

--- a/avrotize/structuretojtd.py
+++ b/avrotize/structuretojtd.py
@@ -1,0 +1,24 @@
+"""JSON Structure to JSON Type Definition converter."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+from avrotize.avrotojtd import convert_avro_to_jtd
+from avrotize.jstructtoavro import convert_json_structure_to_avro
+
+
+def convert_structure_to_jtd(structure_file: str, jtd_file_path: str, record_type: str | None = None) -> None:
+    """Convert JSON Structure to JTD by bridging through Avrotize Schema."""
+    temp_dir = os.path.dirname(os.path.abspath(jtd_file_path)) or os.getcwd()
+    temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".avsc", dir=temp_dir)
+    temp_file.close()
+    try:
+        convert_json_structure_to_avro(structure_file, temp_file.name)
+        convert_avro_to_jtd(temp_file.name, jtd_file_path, record_type=record_type)
+    finally:
+        try:
+            os.remove(temp_file.name)
+        except OSError:
+            pass

--- a/test/jtd/node.jtd.json
+++ b/test/jtd/node.jtd.json
@@ -1,0 +1,13 @@
+{
+  "definitions": {
+    "Node": {
+      "properties": {
+        "name": {"type": "string"}
+      },
+      "optionalProperties": {
+        "child": {"ref": "Node"}
+      }
+    }
+  },
+  "ref": "Node"
+}

--- a/test/jtd/person.jtd.json
+++ b/test/jtd/person.jtd.json
@@ -1,0 +1,23 @@
+{
+  "definitions": {
+    "Address": {
+      "properties": {
+        "street": {"type": "string"}
+      },
+      "optionalProperties": {
+        "zip": {"type": "uint32"}
+      }
+    }
+  },
+  "properties": {
+    "id": {"type": "string"},
+    "created": {"type": "timestamp"},
+    "address": {"ref": "Address"},
+    "scores": {"elements": {"type": "float64"}},
+    "labels": {"values": {"type": "string"}}
+  },
+  "optionalProperties": {
+    "nickname": {"type": "string"}
+  },
+  "additionalProperties": true
+}

--- a/test/jtd/structure_person.struct.json
+++ b/test/jtd/structure_person.struct.json
@@ -1,0 +1,9 @@
+{
+  "type": "object",
+  "name": "StructurePerson",
+  "properties": {
+    "id": {"type": "string"},
+    "age": {"type": "int32"}
+  },
+  "required": ["id"]
+}

--- a/test/jtd/vehicle.jtd.json
+++ b/test/jtd/vehicle.jtd.json
@@ -1,0 +1,15 @@
+{
+  "discriminator": "kind",
+  "mapping": {
+    "car": {
+      "properties": {
+        "wheels": {"type": "uint8"}
+      }
+    },
+    "boat-type": {
+      "properties": {
+        "draft": {"type": "float32"}
+      }
+    }
+  }
+}

--- a/test/test_jtdtoavro.py
+++ b/test/test_jtdtoavro.py
@@ -1,0 +1,231 @@
+"""Tests for JSON Type Definition converters."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from typing import Any
+
+from fastavro import parse_schema
+
+from avrotize.avrotojtd import AvroToJtdConverter, convert_avro_to_jtd
+from avrotize.jtdtoavro import JtdToAvroConverter, convert_jtd_to_avro
+from avrotize.jtdtostructure import convert_jtd_to_structure
+from avrotize.structuretojtd import convert_structure_to_jtd
+
+
+class TestJtdConverters(unittest.TestCase):
+    """Focused tests for JTD conversion support."""
+
+    root = Path(__file__).resolve().parents[1]
+    fixtures = root / "test" / "jtd"
+    generated = fixtures / "generated"
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if cls.generated.exists():
+            shutil.rmtree(cls.generated)
+        cls.generated.mkdir(parents=True)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if cls.generated.exists():
+            shutil.rmtree(cls.generated)
+
+    def _convert_dict(self, schema: dict[str, Any], namespace: str | None = "example") -> Any:
+        return JtdToAvroConverter(namespace=namespace).convert(schema, root_name="Root")
+
+    def _assert_valid_avro(self, schema: Any) -> None:
+        parse_schema(schema)
+
+    def _root_jtd(self, schema: dict[str, Any]) -> dict[str, Any]:
+        if "definitions" in schema and "ref" in schema:
+            return schema["definitions"][schema["ref"]]
+        return schema
+
+    def _assert_type_mapping(self, jtd_type: str, avro_type: str, logical_type: str | None = None) -> None:
+        avro = self._convert_dict({"type": jtd_type})
+        self.assertIsInstance(avro, dict)
+        self.assertEqual(avro["type"], avro_type)
+        self.assertEqual(avro["jtdType"], jtd_type)
+        if logical_type:
+            self.assertEqual(avro["logicalType"], logical_type)
+        self._assert_valid_avro(avro)
+        self.assertEqual(AvroToJtdConverter().convert(avro), {"type": jtd_type})
+
+    def test_boolean_type_mapping(self) -> None:
+        self._assert_type_mapping("boolean", "boolean")
+
+    def test_float32_type_mapping(self) -> None:
+        self._assert_type_mapping("float32", "float")
+
+    def test_float64_type_mapping(self) -> None:
+        self._assert_type_mapping("float64", "double")
+
+    def test_int8_type_mapping(self) -> None:
+        self._assert_type_mapping("int8", "int")
+
+    def test_uint8_type_mapping(self) -> None:
+        self._assert_type_mapping("uint8", "int")
+
+    def test_int16_type_mapping(self) -> None:
+        self._assert_type_mapping("int16", "int")
+
+    def test_uint16_type_mapping(self) -> None:
+        self._assert_type_mapping("uint16", "int")
+
+    def test_int32_type_mapping(self) -> None:
+        self._assert_type_mapping("int32", "int")
+
+    def test_uint32_type_mapping(self) -> None:
+        self._assert_type_mapping("uint32", "long")
+
+    def test_string_type_mapping(self) -> None:
+        self._assert_type_mapping("string", "string")
+
+    def test_timestamp_type_mapping_uses_valid_logical_type(self) -> None:
+        self._assert_type_mapping("timestamp", "long", "timestamp-millis")
+
+    def test_enum_symbols_are_sanitized_and_round_trip(self) -> None:
+        avro = self._convert_dict({"enum": ["ok", "bad-value", "123"]})
+        self._assert_valid_avro(avro)
+        self.assertEqual(avro["symbols"], ["ok", "bad_value", "_123"])
+        self.assertEqual(avro["jtdEnumSymbols"], {"bad_value": "bad-value", "_123": "123"})
+        self.assertEqual(AvroToJtdConverter().convert(avro), {"enum": ["ok", "bad-value", "123"]})
+
+    def test_elements_map_to_avro_array(self) -> None:
+        avro = self._convert_dict({"elements": {"type": "string"}})
+        self._assert_valid_avro(avro)
+        self.assertEqual(avro["type"], "array")
+        self.assertEqual(avro["items"]["type"], "string")
+        self.assertEqual(AvroToJtdConverter().convert(avro), {"elements": {"type": "string"}})
+
+    def test_values_map_to_avro_map(self) -> None:
+        avro = self._convert_dict({"values": {"type": "int32"}})
+        self._assert_valid_avro(avro)
+        self.assertEqual(avro["type"], "map")
+        self.assertEqual(avro["values"]["type"], "int")
+        self.assertEqual(AvroToJtdConverter().convert(avro), {"values": {"type": "int32"}})
+
+    def test_properties_and_optional_properties(self) -> None:
+        avro = self._convert_dict({"properties": {"id": {"type": "string"}}, "optionalProperties": {"age": {"type": "uint8"}}})
+        self._assert_valid_avro(avro)
+        fields = {field["name"]: field for field in avro["fields"]}
+        self.assertEqual(fields["id"]["type"]["type"], "string")
+        self.assertEqual(fields["age"]["type"][0], "null")
+        self.assertIsNone(fields["age"]["default"])
+        jtd = self._root_jtd(AvroToJtdConverter().convert(avro))
+        self.assertIn("id", jtd["properties"])
+        self.assertIn("age", jtd["optionalProperties"])
+
+    def test_nullable_type_maps_to_avro_union(self) -> None:
+        avro = self._convert_dict({"type": "string", "nullable": True})
+        self._assert_valid_avro(avro)
+        self.assertEqual(avro[0], "null")
+        self.assertEqual(AvroToJtdConverter().convert(avro), {"type": "string", "nullable": True})
+
+    def test_additional_properties_metadata_is_preserved(self) -> None:
+        avro = self._convert_dict({"properties": {"id": {"type": "string"}}, "additionalProperties": True})
+        self._assert_valid_avro(avro)
+        self.assertTrue(avro["jtdAdditionalProperties"])
+        jtd = self._root_jtd(AvroToJtdConverter().convert(avro))
+        self.assertTrue(jtd["additionalProperties"])
+
+    def test_discriminator_mapping_becomes_avro_union(self) -> None:
+        schema = json.loads((self.fixtures / "vehicle.jtd.json").read_text(encoding="utf-8"))
+        avro = self._convert_dict(schema)
+        self._assert_valid_avro(avro)
+        self.assertIsInstance(avro, list)
+        self.assertEqual({branch["jtdMappingKey"] for branch in avro}, {"car", "boat-type"})
+        round_tripped = AvroToJtdConverter().convert(avro)
+        self.assertEqual(round_tripped["discriminator"], "kind")
+        self.assertEqual(set(round_tripped["mapping"]), {"car", "boat-type"})
+
+    def test_ref_and_definitions_generate_named_avro_types(self) -> None:
+        schema = json.loads((self.fixtures / "node.jtd.json").read_text(encoding="utf-8"))
+        avro = self._convert_dict(schema)
+        self._assert_valid_avro(avro)
+        self.assertEqual(len(avro), 1)
+        self.assertEqual(avro[0]["name"], "Node")
+        child_type = next(field for field in avro[0]["fields"] if field["name"] == "child")["type"]
+        self.assertEqual(child_type, ["null", "example.Node"])
+
+    def test_nested_fixture_generates_valid_avro(self) -> None:
+        out = self.generated / "person.avsc"
+        convert_jtd_to_avro(str(self.fixtures / "person.jtd.json"), str(out), namespace="example")
+        avro = json.loads(out.read_text(encoding="utf-8"))
+        self._assert_valid_avro(avro)
+        root = next(item for item in avro if isinstance(item, dict) and item.get("jtdAdditionalProperties"))
+        self.assertEqual(root["type"], "record")
+        self.assertTrue(root["jtdAdditionalProperties"])
+
+    def test_round_trip_preserves_core_record_semantics(self) -> None:
+        avro_path = self.generated / "roundtrip.avsc"
+        jtd_path = self.generated / "roundtrip.jtd.json"
+        source = {"properties": {"id": {"type": "string"}, "when": {"type": "timestamp"}}, "optionalProperties": {"count": {"type": "uint32"}}}
+        source_path = self.generated / "roundtrip-source.jtd.json"
+        source_path.write_text(json.dumps(source), encoding="utf-8")
+        convert_jtd_to_avro(str(source_path), str(avro_path), namespace="example")
+        convert_avro_to_jtd(str(avro_path), str(jtd_path))
+        converted = json.loads(jtd_path.read_text(encoding="utf-8"))
+        root = self._root_jtd(converted)
+        self.assertEqual(root["properties"], source["properties"])
+        self.assertEqual(root["optionalProperties"], source["optionalProperties"])
+
+    def test_jtd_to_structure_bridge_writes_json_structure(self) -> None:
+        out = self.generated / "person.struct.json"
+        convert_jtd_to_structure(str(self.fixtures / "person.jtd.json"), str(out), namespace="example")
+        structure = json.loads(out.read_text(encoding="utf-8"))
+        self.assertIn("$schema", structure)
+        self.assertIn("definitions", structure)
+        self.assertIn("$root", structure)
+
+    def test_structure_to_jtd_bridge_writes_jtd(self) -> None:
+        out = self.generated / "structure-person.jtd.json"
+        convert_structure_to_jtd(str(self.fixtures / "structure_person.struct.json"), str(out))
+        jtd = json.loads(out.read_text(encoding="utf-8"))
+        root = self._root_jtd(jtd)
+        self.assertIn("id", root["properties"])
+        self.assertIn("age", root["optionalProperties"])
+
+    def test_avro_record_type_selection(self) -> None:
+        avro = [
+            {"type": "record", "name": "A", "fields": [{"name": "value", "type": "string"}]},
+            {"type": "record", "name": "B", "fields": [{"name": "count", "type": {"type": "int", "jtdType": "uint8"}}]},
+        ]
+        jtd = self._root_jtd(AvroToJtdConverter(record_type="B").convert(avro))
+        self.assertIn("count", jtd["properties"])
+
+    def test_commands_json_is_valid_and_registers_jtd_commands(self) -> None:
+        commands = json.loads((self.root / "avrotize" / "commands.json").read_text(encoding="utf-8"))
+        names = {command["command"] for command in commands}
+        self.assertTrue({"jtd2a", "a2jtd", "jtd2s", "s2jtd"}.issubset(names))
+
+    def test_import_path_is_worktree(self) -> None:
+        import avrotize
+
+        self.assertTrue(str(avrotize.__file__).startswith(str(self.root)))
+
+    def test_cli_smoke_jtd2a(self) -> None:
+        out = self.generated / "cli-person.avsc"
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(self.root)
+        result = subprocess.run(
+            [sys.executable, "-m", "avrotize", "jtd2a", str(self.fixtures / "person.jtd.json"), "--out", str(out), "--namespace", "example"],
+            cwd=str(self.root),
+            env=env,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self._assert_valid_avro(json.loads(out.read_text(encoding="utf-8")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #260 — JSON Type Definition (RFC 8927) support.

## Commands
- `jtd2a` JTD → Avrotize (Avro) schema
- `a2jtd` Avro schema → JTD
- `jtd2s` JTD → JSON Structure
- `s2jtd` JSON Structure → JTD

## Notes
JTD's precise numeric forms (int8/uint8/…uint32) are preserved end-to-end: `jtd2a` annotates Avro with a `jtdType` hint that `avrotojstruct` reads to emit the exact JSON Structure integer type. Discriminator (`mapping`) unions ↔ Avro unions; `elements`→array; `values`→map; `enum`→enum.

## Tests
27 tests (`test/test_jtdtoavro.py`) + verified no regression on existing `test_avrotojstruct.py` (40 passed together). Covers every JTD form, nullable, enum, elements, values, discriminator, references, round-trip, JSON Structure bridge, Avro validity via `fastavro.parse_schema`, CLI smoke.

## Documented limitations
Avro can't enforce JTD `additionalProperties: false`; general Avro unions only map to JTD discriminator unions emitted by `jtd2a`; enum symbols may be sanitized with round-trip metadata.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>