### PR TITLE
feat: add FlatBuffers schema support (#256)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 All notable changes to Avrotize are documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **FlatBuffers schema support** ([#256](https://github.com/clemensv/avrotize/issues/256)): Added `fbs2a`, `a2fbs`, `fbs2s`, and `s2fbs` conversions for FlatBuffers `.fbs` schemas, including namespace, table, struct, enum, union, vector, root type, required-field, and default-value handling. Documented mapping limitations for fixed-layout structs, enum integer values, unsigned 64-bit integers, `[ubyte]` vectors, and unsupported Avro/JSON Structure metadata.
+
 ## [3.5.9] - 2026-06-04
 
 ### Changed
@@ -59,6 +65,12 @@ All notable changes to Avrotize are documented in this file.
 # Changelog
 
 All notable changes to Avrotize are documented in this file.
+
+## [Unreleased]
+
+### Added
+
+- **FlatBuffers schema support** ([#256](https://github.com/clemensv/avrotize/issues/256)): Added `fbs2a`, `a2fbs`, `fbs2s`, and `s2fbs` conversions for FlatBuffers `.fbs` schemas, including namespace, table, struct, enum, union, vector, root type, required-field, and default-value handling. Documented mapping limitations for fixed-layout structs, enum integer values, unsigned 64-bit integers, `[ubyte]` vectors, and unsupported Avro/JSON Structure metadata.
 
 ## [3.5.5] - 2026-05-22
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Avrotize provides several commands for converting schema formats via Avrotize Sc
 Converting to Avrotize Schema:
 
 - [`avrotize p2a`](#convert-proto-schema-to-avrotize-schema) - Convert Protobuf (2 or 3) schema to Avrotize Schema.
+- [`avrotize fbs2a`](#convert-flatbuffers-schema-to-avrotize-schema) - Convert FlatBuffers schema to Avrotize Schema.
 - [`avrotize j2a`](#convert-json-schema-to-avrotize-schema) - Convert JSON schema to Avrotize Schema.
 - [`avrotize x2a`](#convert-xml-schema-xsd-to-avrotize-schema) - Convert XML schema to Avrotize Schema.
 - [`avrotize asn2a`](#convert-asn1-schema-to-avrotize-schema) - Convert ASN.1 to Avrotize Schema.
@@ -74,6 +75,7 @@ Converting to Avrotize Schema:
 Converting from Avrotize Schema:
 
 - [`avrotize a2p`](#convert-avrotize-schema-to-proto-schema) - Convert Avrotize Schema to Protobuf 3 schema.
+- [`avrotize a2fbs`](#convert-avrotize-schema-to-flatbuffers-schema) - Convert Avrotize Schema to FlatBuffers schema.
 - [`avrotize a2j`](#convert-avrotize-schema-to-json-schema) - Convert Avrotize Schema to JSON schema.
 - [`avrotize a2x`](#convert-avrotize-schema-to-xml-schema) - Convert Avrotize Schema to XML schema.
 - [`avrotize a2k`](#convert-avrotize-schema-to-kusto-table-declaration) - Convert Avrotize Schema to Kusto table definition.
@@ -100,6 +102,8 @@ Converting from Avrotize Schema:
 Direct conversions (JSON Structure):
 
 - [`avrotize s2p`](#convert-json-structure-to-protocol-buffers) - Convert JSON Structure to Protocol Buffers (.proto files).
+- [`avrotize fbs2s`](#convert-flatbuffers-schema-to-json-structure) - Convert FlatBuffers schema to JSON Structure.
+- [`avrotize s2fbs`](#convert-json-structure-to-flatbuffers-schema) - Convert JSON Structure to FlatBuffers schema.
 - [`avrotize oas2s`](#convert-openapi-to-json-structure) - Convert OpenAPI 3.x document to JSON Structure.
 
 Generate code from Avrotize Schema:
@@ -263,6 +267,82 @@ Conversion notes:
 - Avro namespaces are resolved into distinct proto package definitions. The tool will create a new `.proto` file with the package definition and an `import` statement for each namespace found in the Avrotize Schema.
 - Avro type unions `[]` are converted to `oneof` expressions in Proto. Avro allows for maps and arrays in the type union, whereas Proto only supports scalar types and message type references. The tool will therefore emit message types containing a single array or map field for any such case and add it to the containing type, and will also recursively resolve further unions in the array and map values.
 - The sequence of fields in a message follows the sequence of fields in the Avro record. When type unions need to be resolved into `oneof` expressions, the alternative fields need to be assigned field numbers, which will shift the field numbers for any subsequent fields.
+
+
+### Convert FlatBuffers schema to Avrotize Schema
+
+```bash
+avrotize fbs2a <path_to_fbs_file> [--out <path_to_avro_schema_file>] [--namespace <avro_schema_namespace>]
+```
+
+Parameters:
+
+- `<path_to_fbs_file>`: The path to the FlatBuffers `.fbs` schema file to be converted. If omitted, the file is read from stdin.
+- `--out`: The path to the Avrotize Schema file to write the conversion result to. If omitted, the output is directed to stdout.
+- `--namespace`: (optional) Override the FlatBuffers namespace for the Avrotize Schema.
+
+Conversion notes and limitations:
+
+- FlatBuffers `namespace` declarations are mapped to Avro namespaces. `table` and `struct` declarations are mapped to Avro records; FlatBuffers structs carry fixed inline layout semantics that Avro does not represent, so this is documented on the generated record.
+- FlatBuffers enums are mapped to Avro enums. Integer enum values are preserved in the non-standard Avrotize `ordinals` annotation; consumers that only understand Avro enum symbols may ignore those integer values.
+- FlatBuffers unions are mapped to Avro unions of their member record types.
+- Scalar mappings: signed 8/16/32-bit integers map to Avro `int`; unsigned 32-bit integers and all 64-bit integers map to Avro `long`; `uint64`/`ulong` values beyond signed 64-bit range cannot be represented exactly by Avro `long`; `float` and `double` map to Avro `float` and `double`; `string` maps to Avro `string`.
+- Vectors map to Avro arrays, except `[ubyte]`/`[uint8]`, which maps to Avro `bytes`.
+- Table fields without `(required)` are emitted as nullable Avro fields with `null` defaults. FlatBuffers field defaults are preserved as the Avrotize `fbsDefault` annotation for nullable fields.
+- `root_type` is preserved as a record-level `root_type` annotation.
+
+### Convert Avrotize Schema to FlatBuffers schema
+
+```bash
+avrotize a2fbs <path_to_avro_schema_file> [--out <path_to_fbs_file>] [--namespace <flatbuffers_namespace>]
+```
+
+Parameters:
+
+- `<path_to_avro_schema_file>`: The path to the Avrotize Schema file to be converted. If omitted, the file is read from stdin.
+- `--out`: The path to the FlatBuffers `.fbs` file to write the conversion result to. If omitted, the output is directed to stdout.
+- `--namespace`: (optional) Override the FlatBuffers namespace.
+
+Conversion notes and limitations:
+
+- Avro records are emitted as FlatBuffers tables, Avro enums as FlatBuffers enums, arrays as vectors, and Avro `bytes` as `[ubyte]`.
+- Nullable Avro unions (`["null", T]`) become optional FlatBuffers fields. Multi-branch Avro unions of named types are emitted as FlatBuffers `union` declarations.
+- Avro namespaces map to FlatBuffers namespaces. The top record, or the record annotated with `root_type`, is emitted as `root_type`.
+- Avro maps, logical types, fixed types, aliases, validation annotations, and arbitrary custom annotations have no direct FlatBuffers equivalent and are either simplified to compatible field types or omitted.
+
+### Convert FlatBuffers schema to JSON Structure
+
+```bash
+avrotize fbs2s <path_to_fbs_file> [--out <path_to_json_structure_file>] [--namespace <avro_schema_namespace>]
+```
+
+Parameters:
+
+- `<path_to_fbs_file>`: The path to the FlatBuffers `.fbs` schema file to be converted. If omitted, the file is read from stdin.
+- `--out`: The path to the JSON Structure file to write the conversion result to. If omitted, the output is directed to stdout.
+- `--namespace`: (optional) Override the namespace used by the Avrotize Schema bridge.
+
+Conversion notes:
+
+- This conversion bridges through Avrotize Schema (`fbs2a` followed by `a2s`) and therefore shares the FlatBuffers-to-Avro mapping limitations listed above.
+- The FlatBuffers `root_type` record is used as the JSON Structure root when present.
+
+### Convert JSON Structure to FlatBuffers schema
+
+```bash
+avrotize s2fbs <path_to_json_structure_file> [--out <path_to_fbs_file>] [--namespace <flatbuffers_namespace>]
+```
+
+Parameters:
+
+- `<path_to_json_structure_file>`: The path to the JSON Structure schema file to be converted. If omitted, the file is read from stdin.
+- `--out`: The path to the FlatBuffers `.fbs` file to write the conversion result to. If omitted, the output is directed to stdout.
+- `--namespace`: (optional) Override the FlatBuffers namespace.
+
+Conversion notes:
+
+- This conversion bridges through Avrotize Schema (`s2a` followed by `a2fbs`) and therefore shares the Avro-to-FlatBuffers mapping limitations listed above.
+- JSON Structure constraints and metadata that do not survive the Avrotize Schema bridge are not represented in the generated FlatBuffers schema.
 
 ### Convert JSON schema to Avrotize Schema
 

--- a/avrotize/__init__.py
+++ b/avrotize/__init__.py
@@ -25,6 +25,10 @@ class LazyLoader:
 # Define the functions and their corresponding module paths
 _mappings = {
     "convert_proto_to_avro": (f"{mod}.prototoavro", "convert_proto_to_avro"),
+    "convert_flatbuffers_to_avro": (f"{mod}.flatbufferstoavro", "convert_flatbuffers_to_avro"),
+    "convert_avro_to_flatbuffers": (f"{mod}.avrotoflatbuffers", "convert_avro_to_flatbuffers"),
+    "convert_flatbuffers_to_json_structure": (f"{mod}.flatbufferstojstruct", "convert_flatbuffers_to_json_structure"),
+    "convert_json_structure_to_flatbuffers": (f"{mod}.jstructtoflatbuffers", "convert_json_structure_to_flatbuffers"),
     "convert_jsons_to_avro": (f"{mod}.jsonstoavro", "convert_jsons_to_avro"),
     "convert_kafka_struct_to_avro_schema": (f"{mod}.kstructtoavro", "convert_kafka_struct_to_avro_schema"),
     "convert_kusto_to_avro": (f"{mod}.kustotoavro", "convert_kusto_to_avro"),

--- a/avrotize/avrotoflatbuffers.py
+++ b/avrotize/avrotoflatbuffers.py
@@ -1,0 +1,155 @@
+"""Convert Avrotize (Avro) schemas to FlatBuffers .fbs schemas."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import Any
+
+
+def _sanitize(name: str) -> str:
+    cleaned = re.sub(r"\W", "_", name)
+    if not cleaned or cleaned[0].isdigit():
+        cleaned = f"_{cleaned}"
+    return cleaned
+
+
+class AvroToFlatBuffersConverter:
+    primitive_map = {
+        "boolean": "bool", "int": "int", "long": "long", "float": "float",
+        "double": "double", "bytes": "[ubyte]", "string": "string", "null": "null",
+    }
+
+    def __init__(self, namespace: str | None = None):
+        self.namespace_override = namespace
+        self.named: dict[str, dict[str, Any]] = {}
+        self.union_defs: dict[str, list[str]] = {}
+
+    def convert_file(self, avro_schema_path: str) -> str:
+        with open(avro_schema_path, "r", encoding="utf-8") as f:
+            schema = json.load(f)
+        schemas = schema if isinstance(schema, list) else [schema]
+        for item in schemas:
+            if isinstance(item, dict) and item.get("type") in {"record", "enum"}:
+                qn = self.qualified_name(item)
+                self.named[qn] = item
+                self.named[item["name"]] = item
+        namespace = self.namespace_override or self.first_namespace(schemas)
+        lines: list[str] = []
+        if namespace:
+            lines.append(f"namespace {namespace};")
+            lines.append("")
+        for item in schemas:
+            if isinstance(item, dict) and item.get("type") == "enum":
+                lines.extend(self.render_enum(item)); lines.append("")
+        record_lines: list[str] = []
+        for item in schemas:
+            if isinstance(item, dict) and item.get("type") == "record":
+                record_lines.extend(self.render_record(item)); record_lines.append("")
+        for name, members in self.union_defs.items():
+            lines.append(f"union {name} {{ {', '.join(members)} }}")
+            lines.append("")
+        lines.extend(record_lines)
+        root = self.find_root(schemas)
+        if root:
+            lines.append(f"root_type {root};")
+        return "\n".join(lines).rstrip() + "\n"
+
+    @staticmethod
+    def qualified_name(schema: dict[str, Any]) -> str:
+        return f"{schema.get('namespace')}.{schema['name']}" if schema.get("namespace") else schema["name"]
+
+    @staticmethod
+    def first_namespace(schemas: list[Any]) -> str:
+        for item in schemas:
+            if isinstance(item, dict) and item.get("namespace"):
+                return item["namespace"]
+        return ""
+
+    @staticmethod
+    def find_root(schemas: list[Any]) -> str | None:
+        for item in schemas:
+            if isinstance(item, dict) and item.get("type") == "record" and item.get("root_type"):
+                return item["name"]
+        for item in reversed(schemas):
+            if isinstance(item, dict) and item.get("type") == "record":
+                return item["name"]
+        return None
+
+    def render_enum(self, schema: dict[str, Any]) -> list[str]:
+        ordinals = schema.get("ordinals", {})
+        parts = []
+        for i, symbol in enumerate(schema.get("symbols", [])):
+            value = ordinals.get(symbol, i)
+            parts.append(f"{_sanitize(symbol)} = {value}")
+        return [f"enum {schema['name']} : int {{ {', '.join(parts)} }}"]
+
+    def render_record(self, schema: dict[str, Any]) -> list[str]:
+        lines = [f"table {schema['name']} {{"]
+        for field in schema.get("fields", []):
+            fbs_type, nullable = self.avro_type_to_fbs(field["type"], schema["name"], field["name"])
+            default = ""
+            avro_default = field.get("fbsDefault", field.get("default"))
+            if avro_default is not None and not isinstance(field["type"], list):
+                default = f" = {self.format_default(avro_default)}"
+            attr = ""
+            if not nullable and self.can_be_required(fbs_type):
+                attr = " (required)"
+            lines.append(f"  {_sanitize(field['name'])}: {fbs_type}{default}{attr};")
+        lines.append("}")
+        return lines
+
+    def can_be_required(self, fbs_type: str) -> bool:
+        if fbs_type.startswith("[") or fbs_type in {"bool", "byte", "ubyte", "short", "ushort", "int", "uint", "long", "ulong", "float", "double"}:
+            return False
+        named = self.named.get(fbs_type)
+        if isinstance(named, dict) and named.get("type") == "enum":
+            return False
+        return True
+
+    @staticmethod
+    def format_default(value: Any) -> str:
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if isinstance(value, str):
+            return f'"{value}"'
+        return str(value)
+
+    def avro_type_to_fbs(self, avro_type: Any, record_name: str, field_name: str) -> tuple[str, bool]:
+        nullable = False
+        if isinstance(avro_type, list):
+            nullable = "null" in avro_type
+            non_null = [t for t in avro_type if t != "null"]
+            if len(non_null) == 1:
+                fbs, _ = self.avro_type_to_fbs(non_null[0], record_name, field_name)
+                return fbs, nullable
+            members = [self.avro_type_to_fbs(t, record_name, field_name)[0] for t in non_null]
+            union_name = f"{record_name}_{field_name}_Union"
+            self.union_defs[union_name] = [m for m in members if not m.startswith("[")]
+            return union_name, nullable
+        if isinstance(avro_type, str):
+            return self.primitive_map.get(avro_type, avro_type.split(".")[-1]), nullable
+        if isinstance(avro_type, dict):
+            typ = avro_type.get("type")
+            if typ == "array":
+                item, _ = self.avro_type_to_fbs(avro_type.get("items"), record_name, field_name)
+                return f"[{item}]", nullable
+            if typ == "map":
+                return "string", nullable
+            if typ == "enum" or typ == "record":
+                self.named[avro_type["name"]] = avro_type
+                return avro_type["name"], nullable
+            if typ == "bytes":
+                return "[ubyte]", nullable
+            return self.primitive_map.get(typ, typ), nullable
+        return "string", nullable
+
+
+def convert_avro_to_flatbuffers(avro_schema_path: str, fbs_file_path: str, namespace: str | None = None):
+    if not os.path.exists(avro_schema_path):
+        raise FileNotFoundError(f"Avro schema file {avro_schema_path} does not exist.")
+    converter = AvroToFlatBuffersConverter(namespace)
+    fbs_schema = converter.convert_file(avro_schema_path)
+    with open(fbs_file_path, "w", encoding="utf-8") as f:
+        f.write(fbs_schema)

--- a/avrotize/commands.json
+++ b/avrotize/commands.json
@@ -137,6 +137,163 @@
     ]
   },
   {
+    "command": "fbs2a",
+    "description": "Convert FlatBuffers schema to Avrotize schema",
+    "group": "1_Schemas",
+    "function": {
+      "name": "avrotize.flatbufferstoavro.convert_flatbuffers_to_avro",
+      "args": {
+        "fbs_file_path": "input_file_path",
+        "avro_schema_path": "output_file_path",
+        "namespace": "args.namespace"
+      }
+    },
+    "extensions": [
+      ".fbs"
+    ],
+    "args": [
+      {
+        "name": "input",
+        "type": "str",
+        "nargs": "?",
+        "help": "Path of the FlatBuffers .fbs file (or read from stdin if omitted)",
+        "required": false
+      },
+      {
+        "name": "--out",
+        "type": "str",
+        "help": "Path to the Avrotize schema file",
+        "required": false
+      },
+      {
+        "name": "--namespace",
+        "type": "str",
+        "help": "Namespace for the Avrotize schema",
+        "required": false
+      }
+    ],
+    "suggested_output_file_path": "{input_file_name}.avsc",
+    "prompts": []
+  },
+  {
+    "command": "a2fbs",
+    "description": "Convert Avrotize schema to FlatBuffers schema",
+    "group": "1_Schemas",
+    "function": {
+      "name": "avrotize.avrotoflatbuffers.convert_avro_to_flatbuffers",
+      "args": {
+        "avro_schema_path": "input_file_path",
+        "fbs_file_path": "output_file_path",
+        "namespace": "args.namespace"
+      }
+    },
+    "extensions": [
+      ".avsc"
+    ],
+    "args": [
+      {
+        "name": "input",
+        "type": "str",
+        "nargs": "?",
+        "help": "Path to the Avrotize schema file (or read from stdin if omitted)",
+        "required": false
+      },
+      {
+        "name": "--out",
+        "type": "str",
+        "help": "Path to the FlatBuffers .fbs file",
+        "required": false
+      },
+      {
+        "name": "--namespace",
+        "type": "str",
+        "help": "Namespace for the FlatBuffers schema",
+        "required": false
+      }
+    ],
+    "suggested_output_file_path": "{input_file_name}.fbs",
+    "prompts": []
+  },
+  {
+    "command": "fbs2s",
+    "description": "Convert FlatBuffers schema to JSON Structure",
+    "group": "1_Schemas",
+    "function": {
+      "name": "avrotize.flatbufferstojstruct.convert_flatbuffers_to_json_structure",
+      "args": {
+        "fbs_file_path": "input_file_path",
+        "json_structure_file": "output_file_path",
+        "namespace": "args.namespace"
+      }
+    },
+    "extensions": [
+      ".fbs"
+    ],
+    "args": [
+      {
+        "name": "input",
+        "type": "str",
+        "nargs": "?",
+        "help": "Path of the FlatBuffers .fbs file (or read from stdin if omitted)",
+        "required": false
+      },
+      {
+        "name": "--out",
+        "type": "str",
+        "help": "Path to the JSON Structure file",
+        "required": false
+      },
+      {
+        "name": "--namespace",
+        "type": "str",
+        "help": "Namespace for the Avrotize schema bridge",
+        "required": false
+      }
+    ],
+    "suggested_output_file_path": "{input_file_name}.struct.json",
+    "prompts": []
+  },
+  {
+    "command": "s2fbs",
+    "description": "Convert JSON Structure to FlatBuffers schema",
+    "group": "1_Schemas",
+    "function": {
+      "name": "avrotize.jstructtoflatbuffers.convert_json_structure_to_flatbuffers",
+      "args": {
+        "structure_file": "input_file_path",
+        "fbs_file_path": "output_file_path",
+        "namespace": "args.namespace"
+      }
+    },
+    "extensions": [
+      ".struct.json",
+      ".json"
+    ],
+    "args": [
+      {
+        "name": "input",
+        "type": "str",
+        "nargs": "?",
+        "help": "Path to the JSON Structure file (or read from stdin if omitted)",
+        "required": false
+      },
+      {
+        "name": "--out",
+        "type": "str",
+        "help": "Path to the FlatBuffers .fbs file",
+        "required": false
+      },
+      {
+        "name": "--namespace",
+        "type": "str",
+        "help": "Namespace for the FlatBuffers schema",
+        "required": false
+      }
+    ],
+    "suggested_output_file_path": "{input_file_name}.fbs",
+    "prompts": []
+  },
+  {
     "command": "s2p",
     "description": "Convert JSON Structure to Protocol Buffers (.proto)",
     "group": "1_Schemas",

--- a/avrotize/flatbufferstoavro.py
+++ b/avrotize/flatbufferstoavro.py
@@ -1,0 +1,352 @@
+"""Convert FlatBuffers .fbs schemas to Avrotize (Avro) schemas."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from avrotize.common import pascal
+
+
+@dataclass
+class FbsField:
+    name: str
+    type_name: str
+    is_vector: bool = False
+    default: Any = None
+    has_default: bool = False
+    attributes: set[str] = field(default_factory=set)
+
+
+@dataclass
+class FbsType:
+    name: str
+    kind: str
+    fields: list[FbsField] = field(default_factory=list)
+
+
+@dataclass
+class FbsEnum:
+    name: str
+    base_type: str = "int"
+    values: list[tuple[str, int | None]] = field(default_factory=list)
+
+
+@dataclass
+class FbsUnion:
+    name: str
+    members: list[str] = field(default_factory=list)
+
+
+@dataclass
+class FbsSchema:
+    namespace: str = ""
+    tables: list[FbsType] = field(default_factory=list)
+    structs: list[FbsType] = field(default_factory=list)
+    enums: list[FbsEnum] = field(default_factory=list)
+    unions: list[FbsUnion] = field(default_factory=list)
+    root_type: str | None = None
+
+
+_TOKEN_RE = re.compile(r'"(?:\\.|[^"\\])*"|[A-Za-z_][A-Za-z0-9_\.]*|-?\d+(?:\.\d+)?|[:;{},=\[\]()]')
+
+
+class FlatBuffersParser:
+    def __init__(self, text: str):
+        text = re.sub(r"//.*?$", "", text, flags=re.MULTILINE)
+        text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
+        self.tokens = _TOKEN_RE.findall(text)
+        self.pos = 0
+
+    def peek(self) -> str | None:
+        return self.tokens[self.pos] if self.pos < len(self.tokens) else None
+
+    def pop(self, expected: str | None = None) -> str:
+        tok = self.peek()
+        if tok is None:
+            raise ValueError("Unexpected end of FlatBuffers schema")
+        if expected is not None and tok != expected:
+            raise ValueError(f"Expected '{expected}', got '{tok}'")
+        self.pos += 1
+        return tok
+
+    def accept(self, token: str) -> bool:
+        if self.peek() == token:
+            self.pos += 1
+            return True
+        return False
+
+    def parse(self) -> FbsSchema:
+        schema = FbsSchema()
+        while self.peek() is not None:
+            tok = self.peek()
+            if tok == "namespace":
+                self.pop(); schema.namespace = self.pop(); self.accept(";")
+            elif tok == "table":
+                schema.tables.append(self.parse_type("table"))
+            elif tok == "struct":
+                schema.structs.append(self.parse_type("struct"))
+            elif tok == "enum":
+                schema.enums.append(self.parse_enum())
+            elif tok == "union":
+                schema.unions.append(self.parse_union())
+            elif tok == "root_type":
+                self.pop(); schema.root_type = self.pop(); self.accept(";")
+            elif tok in {"file_identifier", "file_extension", "attribute", "rpc_service", "include"}:
+                self.skip_statement_or_block()
+            else:
+                self.pop()
+        return schema
+
+    def skip_statement_or_block(self) -> None:
+        while self.peek() is not None:
+            tok = self.pop()
+            if tok == "{":
+                depth = 1
+                while self.peek() is not None and depth:
+                    t = self.pop()
+                    if t == "{": depth += 1
+                    elif t == "}": depth -= 1
+                self.accept(";")
+                return
+            if tok == ";":
+                return
+
+    def parse_type(self, kind: str) -> FbsType:
+        self.pop(kind)
+        typ = FbsType(self.pop(), kind)
+        self.pop("{")
+        while self.peek() and self.peek() != "}":
+            if self.peek() in {";", ","}:
+                self.pop(); continue
+            typ.fields.append(self.parse_field())
+        self.pop("}")
+        return typ
+
+    def parse_field(self) -> FbsField:
+        name = self.pop()
+        self.pop(":")
+        is_vector = self.accept("[")
+        type_name = self.pop()
+        if is_vector:
+            self.pop("]")
+        has_default = False
+        default: Any = None
+        if self.accept("="):
+            default_token = self.pop()
+            default, has_default = self.parse_default(default_token), True
+        attrs: set[str] = set()
+        if self.accept("("):
+            while self.peek() and self.peek() != ")":
+                attr = self.pop()
+                if attr not in {",", ":"}:
+                    attrs.add(attr)
+                    if self.peek() == ":":
+                        self.pop(); self.pop()
+                self.accept(",")
+            self.pop(")")
+        self.accept(";") or self.accept(",")
+        return FbsField(name, type_name, is_vector, default, has_default, attrs)
+
+    @staticmethod
+    def parse_default(token: str) -> Any:
+        if token.startswith('"'):
+            return token[1:-1]
+        if token in {"true", "false"}:
+            return token == "true"
+        if re.match(r"^-?\d+$", token):
+            return int(token)
+        if re.match(r"^-?\d+\.\d+$", token):
+            return float(token)
+        return token
+
+    def parse_enum(self) -> FbsEnum:
+        self.pop("enum")
+        enum = FbsEnum(self.pop())
+        if self.accept(":"):
+            enum.base_type = self.pop()
+        self.pop("{")
+        next_value = 0
+        while self.peek() and self.peek() != "}":
+            if self.peek() in {",", ";"}:
+                self.pop(); continue
+            name = self.pop()
+            value = None
+            if self.accept("="):
+                value = int(self.pop())
+                next_value = value + 1
+            else:
+                value = next_value
+                next_value += 1
+            enum.values.append((name, value))
+            self.accept(",") or self.accept(";")
+        self.pop("}")
+        return enum
+
+    def parse_union(self) -> FbsUnion:
+        self.pop("union")
+        union = FbsUnion(self.pop())
+        self.pop("{")
+        while self.peek() and self.peek() != "}":
+            if self.peek() in {",", ";"}:
+                self.pop(); continue
+            name = self.pop()
+            if self.accept(":"):
+                name = self.pop()
+            union.members.append(name)
+            self.accept(",") or self.accept(";")
+        self.pop("}")
+        return union
+
+
+class FlatBuffersToAvroConverter:
+    scalar_map = {
+        "bool": "boolean", "byte": "int", "int8": "int", "ubyte": "int", "uint8": "int",
+        "short": "int", "int16": "int", "ushort": "int", "uint16": "int",
+        "int": "int", "int32": "int", "uint": "long", "uint32": "long",
+        "long": "long", "int64": "long", "ulong": "long", "uint64": "long",
+        "float": "float", "float32": "float", "double": "double", "float64": "double",
+        "string": "string",
+    }
+
+    def __init__(self, namespace: str | None = None):
+        self.namespace = namespace
+        self.enums: dict[str, FbsEnum] = {}
+        self.unions: dict[str, FbsUnion] = {}
+        self.named: set[str] = set()
+
+    def convert_file(self, fbs_file_path: str) -> list[dict[str, Any]]:
+        with open(fbs_file_path, "r", encoding="utf-8") as f:
+            schema = FlatBuffersParser(f.read()).parse()
+        namespace = self.namespace if self.namespace is not None else schema.namespace
+        if not namespace:
+            namespace = pascal(os.path.basename(fbs_file_path).rsplit('.', 1)[0])
+        self.enums = {e.name: e for e in schema.enums}
+        self.unions = {u.name: u for u in schema.unions}
+        self.named = {e.name for e in schema.enums} | {t.name for t in schema.tables} | {s.name for s in schema.structs}
+        avro: list[dict[str, Any]] = []
+        for enum in schema.enums:
+            avro.append(self.convert_enum(enum, namespace))
+        for typ in [*schema.structs, *schema.tables]:
+            avro.append(self.convert_type(typ, namespace, schema.root_type == typ.name))
+        return self.sort_by_dependencies(avro)
+
+
+    @staticmethod
+    def sort_by_dependencies(schemas: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        by_name: dict[str, dict[str, Any]] = {}
+        for schema in schemas:
+            qn = f"{schema.get('namespace')}.{schema['name']}" if schema.get('namespace') else schema['name']
+            by_name[qn] = schema
+            by_name[schema['name']] = schema
+        ordered: list[dict[str, Any]] = []
+        visiting: set[int] = set()
+        visited: set[int] = set()
+
+        primitives = {"null", "boolean", "int", "long", "float", "double", "bytes", "string"}
+
+        def refs(avro_type: Any) -> list[str]:
+            if isinstance(avro_type, str):
+                return [] if avro_type in primitives else [avro_type]
+            if isinstance(avro_type, list):
+                out: list[str] = []
+                for item in avro_type:
+                    out.extend(refs(item))
+                return out
+            if isinstance(avro_type, dict):
+                typ = avro_type.get("type")
+                if typ == "array":
+                    return refs(avro_type.get("items"))
+                if typ == "map":
+                    return refs(avro_type.get("values"))
+                if typ in {"record", "enum"}:
+                    return []
+                return refs(typ)
+            return []
+
+        def visit(schema: dict[str, Any]) -> None:
+            key = id(schema)
+            if key in visited or key in visiting:
+                return
+            visiting.add(key)
+            for field in schema.get("fields", []):
+                for ref in refs(field.get("type")):
+                    dep = by_name.get(ref)
+                    if dep is not None and dep is not schema:
+                        visit(dep)
+            visiting.remove(key)
+            visited.add(key)
+            if schema not in ordered:
+                ordered.append(schema)
+
+        for schema in schemas:
+            visit(schema)
+        return ordered
+
+    def convert_enum(self, enum: FbsEnum, namespace: str) -> dict[str, Any]:
+        return {
+            "type": "enum",
+            "name": enum.name,
+            "namespace": namespace,
+            "symbols": [name for name, _ in enum.values],
+            "ordinals": {name: value for name, value in enum.values},
+            "doc": f"FlatBuffers enum base type {enum.base_type}; integer values are preserved in the non-standard ordinals annotation."
+        }
+
+    def convert_type(self, typ: FbsType, namespace: str, is_root: bool) -> dict[str, Any]:
+        record: dict[str, Any] = {"type": "record", "name": typ.name, "namespace": namespace, "fields": []}
+        notes = []
+        if typ.kind == "struct":
+            notes.append("FlatBuffers struct converted to an Avro record; fixed inline memory layout is not represented in Avro.")
+        if is_root:
+            notes.append("FlatBuffers root_type.")
+            record["root_type"] = True
+        if notes:
+            record["doc"] = " ".join(notes)
+        for f in typ.fields:
+            field_type = self.convert_field_type(f, namespace)
+            avro_field: dict[str, Any] = {"name": f.name, "type": field_type}
+            if typ.kind == "table" and "required" not in f.attributes:
+                avro_field["type"] = ["null", *field_type] if isinstance(field_type, list) else ["null", field_type]
+                avro_field["default"] = None
+            elif f.has_default:
+                avro_field["default"] = f.default
+            if f.has_default and typ.kind == "table" and "required" not in f.attributes:
+                avro_field["fbsDefault"] = f.default
+            if "required" in f.attributes:
+                avro_field["fbsRequired"] = True
+            record["fields"].append(avro_field)
+        return record
+
+    def convert_field_type(self, f: FbsField, namespace: str) -> Any:
+        base = self.convert_type_name(f.type_name, namespace)
+        if f.is_vector:
+            if f.type_name in {"ubyte", "uint8"}:
+                return "bytes"
+            return {"type": "array", "items": base}
+        return base
+
+    def convert_type_name(self, type_name: str, namespace: str) -> Any:
+        if type_name in self.scalar_map:
+            return self.scalar_map[type_name]
+        if type_name in self.unions:
+            return [self.qualify(member, namespace) for member in self.unions[type_name].members]
+        return self.qualify(type_name, namespace)
+
+    @staticmethod
+    def qualify(type_name: str, namespace: str) -> str:
+        return type_name if "." in type_name or not namespace else f"{namespace}.{type_name}"
+
+
+def convert_flatbuffers_to_avro(fbs_file_path: str, avro_schema_path: str, namespace: str | None = None):
+    if not os.path.exists(fbs_file_path):
+        raise FileNotFoundError(f"FlatBuffers schema file {fbs_file_path} does not exist.")
+    converter = FlatBuffersToAvroConverter(namespace)
+    avro_schema = converter.convert_file(fbs_file_path)
+    with open(avro_schema_path, "w", encoding="utf-8") as avro_file:
+        json.dump(avro_schema, avro_file, indent=2)
+
+

--- a/avrotize/flatbufferstojstruct.py
+++ b/avrotize/flatbufferstojstruct.py
@@ -1,0 +1,76 @@
+"""Convert FlatBuffers .fbs schemas to JSON Structure via Avrotize Schema."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import tempfile
+from typing import Any
+
+from avrotize.avrotojstruct import convert_avro_to_json_structure
+from avrotize.flatbufferstoavro import convert_flatbuffers_to_avro
+
+
+def _inline_root_schema(avro_schema: Any) -> Any:
+    if not isinstance(avro_schema, list):
+        return avro_schema
+    by_name: dict[str, dict[str, Any]] = {}
+    for schema in avro_schema:
+        if isinstance(schema, dict) and schema.get("type") in {"record", "enum"}:
+            qn = f"{schema.get('namespace')}.{schema['name']}" if schema.get("namespace") else schema["name"]
+            by_name[qn] = schema
+            by_name[schema["name"]] = schema
+    root = next((s for s in avro_schema if isinstance(s, dict) and s.get("type") == "record" and s.get("root_type")), None)
+    if root is None:
+        root = next((s for s in reversed(avro_schema) if isinstance(s, dict) and s.get("type") == "record"), avro_schema[0] if avro_schema else {})
+
+    primitives = {"null", "boolean", "int", "long", "float", "double", "bytes", "string"}
+
+    def inline_type(value: Any, stack: set[str]) -> Any:
+        if isinstance(value, str):
+            if value in primitives or value not in by_name or value in stack:
+                return value
+            schema = by_name[value]
+            qn = f"{schema.get('namespace')}.{schema['name']}" if schema.get("namespace") else schema["name"]
+            return inline_schema(schema, stack | {value, qn, schema["name"]})
+        if isinstance(value, list):
+            return [inline_type(item, stack) for item in value]
+        if isinstance(value, dict):
+            out = copy.deepcopy(value)
+            typ = out.get("type")
+            if typ == "array":
+                out["items"] = inline_type(out.get("items"), stack)
+            elif typ == "map":
+                out["values"] = inline_type(out.get("values"), stack)
+            elif isinstance(typ, str) and typ not in primitives:
+                return inline_type(typ, stack)
+            return out
+        return value
+
+    def inline_schema(schema: dict[str, Any], stack: set[str]) -> dict[str, Any]:
+        out = copy.deepcopy(schema)
+        if out.get("type") == "record":
+            for field in out.get("fields", []):
+                field["type"] = inline_type(field.get("type"), stack)
+        return out
+
+    return inline_schema(root, set())
+
+
+def convert_flatbuffers_to_json_structure(fbs_file_path: str, json_structure_file: str, namespace: str | None = None):
+    temp_dir = os.path.dirname(os.path.abspath(json_structure_file)) or os.getcwd()
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".avsc", dir=temp_dir, mode="w", encoding="utf-8") as temp:
+        temp_path = temp.name
+    try:
+        convert_flatbuffers_to_avro(fbs_file_path, temp_path, namespace=namespace)
+        with open(temp_path, "r", encoding="utf-8") as f:
+            avro_schema = json.load(f)
+        with open(temp_path, "w", encoding="utf-8") as f:
+            json.dump(_inline_root_schema(avro_schema), f, indent=2)
+        convert_avro_to_json_structure(temp_path, json_structure_file)
+    finally:
+        try:
+            os.remove(temp_path)
+        except OSError:
+            pass

--- a/avrotize/jstructtoflatbuffers.py
+++ b/avrotize/jstructtoflatbuffers.py
@@ -1,0 +1,23 @@
+"""Convert JSON Structure schemas to FlatBuffers .fbs via Avrotize Schema."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+from avrotize.avrotoflatbuffers import convert_avro_to_flatbuffers
+from avrotize.jstructtoavro import convert_json_structure_to_avro
+
+
+def convert_json_structure_to_flatbuffers(structure_file: str, fbs_file_path: str, namespace: str | None = None):
+    temp_dir = os.path.dirname(os.path.abspath(fbs_file_path)) or os.getcwd()
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".avsc", dir=temp_dir) as temp:
+        temp_path = temp.name
+    try:
+        convert_json_structure_to_avro(structure_file, temp_path)
+        convert_avro_to_flatbuffers(temp_path, fbs_file_path, namespace=namespace)
+    finally:
+        try:
+            os.remove(temp_path)
+        except OSError:
+            pass

--- a/test/fbs/monster.fbs
+++ b/test/fbs/monster.fbs
@@ -1,0 +1,17 @@
+namespace Example.Game;
+
+enum Color : byte { Red = 1, Green = 2, Blue = 4 }
+struct Vec3 { x:float = 0.0; y:float = 0.0; z:float = 0.0; }
+table Weapon { name:string (required); damage:int = 10; }
+table Monster {
+  id:ulong (required);
+  name:string (required);
+  hp:short = 100;
+  mana:ushort;
+  alive:bool = true;
+  color:Color = Blue;
+  pos:Vec3 (required);
+  inventory:[ubyte];
+  weapons:[Weapon];
+}
+root_type Monster;

--- a/test/fbs/scalars.fbs
+++ b/test/fbs/scalars.fbs
@@ -1,0 +1,16 @@
+namespace Example.Scalars;
+table Scalars {
+  b:bool (required);
+  i8:byte (required);
+  u8:ubyte (required);
+  i16:short (required);
+  u16:ushort (required);
+  i32:int (required);
+  u32:uint (required);
+  i64:long (required);
+  u64:ulong (required);
+  f32:float (required);
+  f64:double (required);
+  s:string (required);
+}
+root_type Scalars;

--- a/test/fbs/union.fbs
+++ b/test/fbs/union.fbs
@@ -1,0 +1,6 @@
+namespace Example.Union;
+table Sword { sharp:bool = true; }
+table Spell { cost:int = 1; }
+union Item { Sword, Spell }
+table Holder { item:Item; }
+root_type Holder;

--- a/test/test_flatbufferstoavro.py
+++ b/test/test_flatbufferstoavro.py
@@ -1,0 +1,190 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from fastavro import parse_schema
+
+from avrotize.avrotoflatbuffers import convert_avro_to_flatbuffers
+from avrotize.flatbufferstoavro import FlatBuffersParser, convert_flatbuffers_to_avro
+from avrotize.flatbufferstojstruct import convert_flatbuffers_to_json_structure
+from avrotize.jstructtoflatbuffers import convert_json_structure_to_flatbuffers
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FBS_DIR = ROOT / "test" / "fbs"
+
+
+class TestFlatBuffersConverters(unittest.TestCase):
+    def convert_fixture(self, fixture: str):
+        tmp = tempfile.TemporaryDirectory(dir=FBS_DIR)
+        self.addCleanup(tmp.cleanup)
+        out = Path(tmp.name) / "schema.avsc"
+        convert_flatbuffers_to_avro(str(FBS_DIR / fixture), str(out))
+        with out.open(encoding="utf-8") as f:
+            schema = json.load(f)
+        parse_schema(schema)
+        return schema, Path(tmp.name)
+
+    @staticmethod
+    def by_name(schema):
+        return {item["name"]: item for item in schema}
+
+    def test_imports_worktree_package(self):
+        import avrotize
+        self.assertTrue(str(Path(avrotize.__file__).resolve()).startswith(str(ROOT)))
+
+    def test_namespace_maps_to_avro_namespace(self):
+        schema, _ = self.convert_fixture("monster.fbs")
+        self.assertEqual(self.by_name(schema)["Monster"]["namespace"], "Example.Game")
+
+    def test_table_maps_to_avro_record(self):
+        schema, _ = self.convert_fixture("monster.fbs")
+        monster = self.by_name(schema)["Monster"]
+        self.assertEqual(monster["type"], "record")
+        self.assertIn("fields", monster)
+
+    def test_struct_maps_to_record_with_layout_doc(self):
+        schema, _ = self.convert_fixture("monster.fbs")
+        vec3 = self.by_name(schema)["Vec3"]
+        self.assertEqual(vec3["type"], "record")
+        self.assertIn("fixed inline memory layout", vec3["doc"])
+
+    def test_enum_symbols_and_explicit_ordinals(self):
+        schema, _ = self.convert_fixture("monster.fbs")
+        color = self.by_name(schema)["Color"]
+        self.assertEqual(color["symbols"], ["Red", "Green", "Blue"])
+        self.assertEqual(color["ordinals"], {"Red": 1, "Green": 2, "Blue": 4})
+
+    def test_required_field_is_not_nullable(self):
+        schema, _ = self.convert_fixture("monster.fbs")
+        fields = {f["name"]: f for f in self.by_name(schema)["Monster"]["fields"]}
+        self.assertEqual(fields["name"]["type"], "string")
+        self.assertTrue(fields["name"]["fbsRequired"])
+
+    def test_optional_field_is_nullable_with_null_default(self):
+        schema, _ = self.convert_fixture("monster.fbs")
+        fields = {f["name"]: f for f in self.by_name(schema)["Monster"]["fields"]}
+        self.assertEqual(fields["mana"]["type"], ["null", "int"])
+        self.assertIsNone(fields["mana"]["default"])
+
+    def test_field_defaults_are_preserved_as_fbs_default(self):
+        schema, _ = self.convert_fixture("monster.fbs")
+        fields = {f["name"]: f for f in self.by_name(schema)["Monster"]["fields"]}
+        self.assertEqual(fields["hp"]["fbsDefault"], 100)
+        self.assertEqual(fields["alive"]["fbsDefault"], True)
+
+    def test_ubyte_vector_maps_to_bytes(self):
+        schema, _ = self.convert_fixture("monster.fbs")
+        fields = {f["name"]: f for f in self.by_name(schema)["Monster"]["fields"]}
+        self.assertEqual(fields["inventory"]["type"], ["null", "bytes"])
+
+    def test_vector_of_table_maps_to_array(self):
+        schema, _ = self.convert_fixture("monster.fbs")
+        fields = {f["name"]: f for f in self.by_name(schema)["Monster"]["fields"]}
+        self.assertEqual(fields["weapons"]["type"][1], {"type": "array", "items": "Example.Game.Weapon"})
+
+    def test_nested_table_reference_is_qualified(self):
+        schema, _ = self.convert_fixture("monster.fbs")
+        fields = {f["name"]: f for f in self.by_name(schema)["Monster"]["fields"]}
+        self.assertEqual(fields["pos"]["type"], "Example.Game.Vec3")
+
+    def test_root_type_annotation_is_preserved(self):
+        schema, _ = self.convert_fixture("monster.fbs")
+        self.assertTrue(self.by_name(schema)["Monster"]["root_type"])
+
+    def test_all_required_scalars_map_to_avro_primitives(self):
+        schema, _ = self.convert_fixture("scalars.fbs")
+        fields = {f["name"]: f["type"] for f in self.by_name(schema)["Scalars"]["fields"]}
+        self.assertEqual(fields, {
+            "b": "boolean", "i8": "int", "u8": "int", "i16": "int", "u16": "int",
+            "i32": "int", "u32": "long", "i64": "long", "u64": "long",
+            "f32": "float", "f64": "double", "s": "string",
+        })
+
+    def test_flatbuffers_union_maps_to_avro_union(self):
+        schema, _ = self.convert_fixture("union.fbs")
+        holder = self.by_name(schema)["Holder"]
+        item = next(f for f in holder["fields"] if f["name"] == "item")
+        self.assertEqual(item["type"], ["null", "Example.Union.Sword", "Example.Union.Spell"])
+
+    def test_avro_to_flatbuffers_emits_parseable_schema(self):
+        schema, tmp = self.convert_fixture("monster.fbs")
+        avro_path = tmp / "schema.avsc"
+        fbs_path = tmp / "schema.fbs"
+        with avro_path.open("w", encoding="utf-8") as f:
+            json.dump(schema, f)
+        convert_avro_to_flatbuffers(str(avro_path), str(fbs_path))
+        parsed = FlatBuffersParser(fbs_path.read_text(encoding="utf-8")).parse()
+        self.assertEqual(parsed.namespace, "Example.Game")
+        self.assertEqual(parsed.root_type, "Monster")
+        self.assertIn("Monster", [t.name for t in parsed.tables])
+
+    def test_avro_to_flatbuffers_maps_arrays_and_enums(self):
+        schema, tmp = self.convert_fixture("monster.fbs")
+        avro_path = tmp / "schema.avsc"
+        fbs_path = tmp / "schema.fbs"
+        avro_path.write_text(json.dumps(schema), encoding="utf-8")
+        convert_avro_to_flatbuffers(str(avro_path), str(fbs_path))
+        text = fbs_path.read_text(encoding="utf-8")
+        self.assertIn("enum Color : int { Red = 1, Green = 2, Blue = 4 }", text)
+        self.assertIn("weapons: [Weapon];", text)
+        self.assertIn("inventory: [ubyte];", text)
+
+    def test_round_trip_preserves_names_and_root(self):
+        schema, tmp = self.convert_fixture("monster.fbs")
+        avro_path = tmp / "schema.avsc"
+        fbs_path = tmp / "schema.fbs"
+        roundtrip_path = tmp / "roundtrip.avsc"
+        avro_path.write_text(json.dumps(schema), encoding="utf-8")
+        convert_avro_to_flatbuffers(str(avro_path), str(fbs_path))
+        convert_flatbuffers_to_avro(str(fbs_path), str(roundtrip_path))
+        roundtrip = json.loads(roundtrip_path.read_text(encoding="utf-8"))
+        self.assertEqual(set(self.by_name(schema)), set(self.by_name(roundtrip)))
+        self.assertTrue(self.by_name(roundtrip)["Monster"].get("root_type"))
+
+    def test_flatbuffers_to_json_structure_bridge(self):
+        _, tmp = self.convert_fixture("monster.fbs")
+        out = tmp / "schema.struct.json"
+        convert_flatbuffers_to_json_structure(str(FBS_DIR / "monster.fbs"), str(out))
+        structure = json.loads(out.read_text(encoding="utf-8"))
+        self.assertEqual(structure["name"], "Monster")
+        self.assertIn("$root", structure)
+        self.assertIn("definitions", structure)
+
+    def test_json_structure_to_flatbuffers_bridge(self):
+        _, tmp = self.convert_fixture("monster.fbs")
+        struct_path = tmp / "schema.struct.json"
+        fbs_path = tmp / "from_structure.fbs"
+        convert_flatbuffers_to_json_structure(str(FBS_DIR / "monster.fbs"), str(struct_path))
+        convert_json_structure_to_flatbuffers(str(struct_path), str(fbs_path))
+        parsed = FlatBuffersParser(fbs_path.read_text(encoding="utf-8")).parse()
+        self.assertEqual(parsed.root_type, "Monster")
+        self.assertIn("Monster", [t.name for t in parsed.tables])
+
+    def test_cli_fbs2a_smoke(self):
+        with tempfile.TemporaryDirectory(dir=FBS_DIR) as tmp:
+            out = Path(tmp) / "cli.avsc"
+            result = subprocess.run(
+                [sys.executable, "-m", "avrotize", "fbs2a", str(FBS_DIR / "monster.fbs"), "--out", str(out)],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            parse_schema(json.loads(out.read_text(encoding="utf-8")))
+
+    def test_commands_json_is_valid_and_contains_flatbuffers_commands(self):
+        commands = json.loads((ROOT / "avrotize" / "commands.json").read_text(encoding="utf-8"))
+        by_command = {cmd["command"]: cmd for cmd in commands}
+        for command in ["fbs2a", "a2fbs", "fbs2s", "s2fbs"]:
+            self.assertIn(command, by_command)
+        self.assertEqual(by_command["fbs2a"]["extensions"], [".fbs"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #256 — FlatBuffers schema (.fbs) support.

## Commands
- `fbs2a` FlatBuffers → Avrotize (Avro) schema
- `a2fbs` Avro schema → FlatBuffers
- `fbs2s` FlatBuffers → JSON Structure (bridged via Avro)
- `s2fbs` JSON Structure → FlatBuffers (bridged via Avro)

## Mapping
table/struct→record, enum→enum, union→Avro union, `[T]`→array, scalars mapped to valid Avro (8/16/32-bit→int, 64-bit→long, float/double), `(required)` vs optional→nullability/defaults, namespaces & root_type preserved.

## Tests
21 tests (`test/test_flatbufferstoavro.py`): scalars, table, struct, enum w/ explicit values, union, vectors, required/optional, nested tables, namespace, reverse (avro→fbs), round-trip, JSON Structure bridge, Avro validity via `fastavro.parse_schema`, CLI smoke. **21 passed.**

## Documented limitations
struct fixed-layout loss; enum ordinal handling; `uint64` caveat; `[ubyte]`→`bytes`; unsupported metadata.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>