### PR TITLE
feat: add SurrealDB (SurrealQL) schema support (#270)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 All notable changes to Avrotize are documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **SurrealDB schema conversion** ([#270](https://github.com/clemensv/avrotize/issues/270)): Added `surreal2a` and `a2surreal` converters for SurrealQL `DEFINE TABLE` / `DEFINE FIELD` schemas, including nested dotted fields, arrays, sets, nullable `option<T>` fields, and Avro logical types for datetime, decimal, and UUID values.
+
 ## [3.5.9] - 2026-06-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The tool leans on the Apache Avro-derived [Avrotize Schema](specs/avrotize-schem
 
 - Programming languages: Python, C#, Java, TypeScript, JavaScript, Rust, Go, C++
 - SQL Databases: MySQL, MariaDB, PostgreSQL, SQL Server, Oracle, SQLite, BigQuery, Snowflake, Redshift, DB2
-- Other databases: KQL/Kusto, MongoDB, Cassandra, Redis, Elasticsearch, DynamoDB, CosmosDB
+- Other databases: KQL/Kusto, SurrealDB, MongoDB, Cassandra, Redis, Elasticsearch, DynamoDB, CosmosDB
 - Data schema formats: Avro, JSON Schema, XML Schema (XSD), Protocol Buffers 2 and 3, ASN.1, Apache Parquet
 
 ## Installation
@@ -63,6 +63,7 @@ Converting to Avrotize Schema:
 - [`avrotize asn2a`](#convert-asn1-schema-to-avrotize-schema) - Convert ASN.1 to Avrotize Schema.
 - [`avrotize k2a`](#convert-kusto-table-definition-to-avrotize-schema) - Convert Kusto table definitions to Avrotize Schema.
 - [`avrotize sql2a`](#convert-sql-database-schema-to-avrotize-schema) - Convert SQL database schema to Avrotize Schema.
+- [`avrotize surreal2a`](#convert-surrealql-schema-to-avrotize-schema) - Convert SurrealQL schema definitions to Avrotize Schema.
 - [`avrotize json2a`](#infer-avro-schema-from-json-files) - Infer Avro schema from JSON files.
 - [`avrotize json2s`](#infer-json-structure-schema-from-json-files) - Infer JSON Structure schema from JSON files.
 - [`avrotize xml2a`](#infer-avro-schema-from-xml-files) - Infer Avro schema from XML files.
@@ -79,6 +80,7 @@ Converting from Avrotize Schema:
 - [`avrotize a2k`](#convert-avrotize-schema-to-kusto-table-declaration) - Convert Avrotize Schema to Kusto table definition.
 - [`avrotize s2k`](#convert-json-structure-schema-to-kusto-table-declaration) - Convert JSON Structure Schema to Kusto table definition.
 - [`avrotize a2sql`](#convert-avrotize-schema-to-sql-table-definition) - Convert Avrotize Schema to SQL table definition.
+- [`avrotize a2surreal`](#convert-avrotize-schema-to-surrealql-schema) - Convert Avrotize Schema to SurrealQL schema definitions.
 - [`avrotize s2sql`](#convert-json-structure-schema-to-sql-schema) - Convert JSON Structure Schema to SQL table definition.
 - [`avrotize a2pq`](#convert-avrotize-schema-to-empty-parquet-file) - Convert Avrotize Schema to Parquet or Iceberg schema.
 - [`avrotize a2ib`](#convert-avrotize-schema-to-iceberg-schema) - Convert Avrotize Schema to Iceberg schema.
@@ -497,6 +499,29 @@ Conversion notes:
 - Table and column comments are preserved as Avro `doc` attributes where available.
 - Primary key columns are noted in the schema's `unique` attribute.
 
+### Convert SurrealQL Schema to Avrotize Schema
+
+```bash
+avrotize surreal2a <path_to_surrealql_schema_file> [--out <path_to_avro_schema_file>] [--namespace <namespace>]
+```
+
+Parameters:
+
+- `<path_to_surrealql_schema_file>`: The SurrealQL schema file containing `DEFINE TABLE` and `DEFINE FIELD` statements.
+- `--out`: The path to the Avrotize Schema file. If omitted, output goes to stdout.
+- `--namespace`: (optional) The Avro namespace for generated records.
+
+Conversion notes:
+
+- `DEFINE TABLE <name> SCHEMAFULL|SCHEMALESS` becomes an Avro record named `<name>`.
+- Dotted SurrealDB field paths such as `address.city` become nested Avro records; array item paths such as `phones[*].number` become arrays of nested records.
+- SurrealDB scalar types map as follows: `string` -> Avro `string`, `int` -> `long`, `float`/`number` -> `double`, `bool` -> `boolean`, `bytes` -> `bytes`, `datetime` -> `long` with `timestamp-millis`, `uuid` -> `string` with `uuid`, and `decimal` -> `bytes` with Avro `decimal` (`precision` 38, `scale` 9).
+- `option<T>` becomes a nullable Avro union `['null', T]` with default `null`.
+- `array<T>` and `set<T>` become Avro arrays. Avro has no native set semantics, so uniqueness is not represented.
+- `duration` and `geometry` are represented as strings.
+- `record<T>` references are represented as string record ids because Avro record references model embedded schemas, not SurrealDB record id links.
+
+
 ### Infer Avro schema from JSON files
 
 ```bash
@@ -668,6 +693,26 @@ Parameters:
 - `--emit-cloudevents-columns`: (Optional) Add CloudEvents columns to the SQL table.
 
 For detailed conversion rules and type mappings for each SQL dialect, refer to the [SQL Conversion Notes](sqlcodegen.md) document.
+
+### Convert Avrotize Schema to SurrealQL Schema
+
+```bash
+avrotize a2surreal <path_to_avro_schema_file> [--out <path_to_surrealql_schema_file>] [--record-type <record_type>]
+```
+
+Parameters:
+
+- `<path_to_avro_schema_file>`: The Avrotize Schema file to convert.
+- `--out`: The path to the SurrealQL schema file. If omitted, output goes to stdout.
+- `--record-type`: (optional) Convert only the named Avro record.
+
+Conversion notes:
+
+- Each Avro record becomes `DEFINE TABLE <name> SCHEMAFULL`.
+- Nested Avro records are emitted as dotted SurrealDB field paths.
+- Avro arrays become `array<T>`; arrays of records are emitted with `[*]` item field definitions.
+- Nullable Avro unions of `null` plus one type become `option<T>`.
+- Avro `timestamp-millis`, `uuid`, and `decimal` logical types become `datetime`, `uuid`, and `decimal` respectively.
 
 ### Convert JSON Structure Schema to SQL Schema
 

--- a/avrotize/__init__.py
+++ b/avrotize/__init__.py
@@ -25,6 +25,8 @@ class LazyLoader:
 # Define the functions and their corresponding module paths
 _mappings = {
     "convert_proto_to_avro": (f"{mod}.prototoavro", "convert_proto_to_avro"),
+    "convert_surrealql_to_avro": (f"{mod}.surrealtoavro", "convert_surrealql_to_avro"),
+    "convert_avro_to_surrealql": (f"{mod}.avrotosurreal", "convert_avro_to_surrealql"),
     "convert_jsons_to_avro": (f"{mod}.jsonstoavro", "convert_jsons_to_avro"),
     "convert_kafka_struct_to_avro_schema": (f"{mod}.kstructtoavro", "convert_kafka_struct_to_avro_schema"),
     "convert_kusto_to_avro": (f"{mod}.kustotoavro", "convert_kusto_to_avro"),

--- a/avrotize/avrotosurreal.py
+++ b/avrotize/avrotosurreal.py
@@ -1,0 +1,138 @@
+"""Convert Avrotize Schema records to SurrealQL schema definitions."""
+
+import json
+from typing import Dict, List
+
+JsonNode = Dict[str, "JsonNode"] | List["JsonNode"] | str | bool | int | float | None
+
+
+class AvroToSurrealQLConverter:
+    """Converter for Avrotize Schema records to SurrealQL DEFINE statements."""
+
+    def convert_schema(self, schema: JsonNode, record_type: str | None = None) -> str:
+        """Convert an Avrotize Schema document to SurrealQL text."""
+        records = self._record_schemas(schema)
+        if record_type:
+            records = [record for record in records if record.get("name") == record_type or self._qualified_name(record) == record_type]
+            if not records:
+                raise ValueError(f"Record type {record_type} not found in Avro schema")
+        lines: List[str] = []
+        for record in records:
+            lines.append(f"DEFINE TABLE {record['name']} SCHEMAFULL;")
+            for statement in self._field_statements(record, str(record["name"])):
+                lines.append(statement)
+            lines.append("")
+        return "\n".join(lines).rstrip() + "\n"
+
+    def _field_statements(self, record: Dict[str, JsonNode], table_name: str, prefix: str = "") -> List[str]:
+        statements: List[str] = []
+        for field in record.get("fields", []):
+            if not isinstance(field, dict):
+                continue
+            field_name = str(field["name"])
+            path = f"{prefix}.{field_name}" if prefix else field_name
+            field_type = field["type"]
+            nullable, base_type = self._unwrap_nullable(field_type)
+            if isinstance(base_type, dict) and base_type.get("type") == "record":
+                statements.append(self._field_statement(path, table_name, "option<object>" if nullable else "object", field))
+                statements.extend(self._field_statements(base_type, table_name, path))
+            elif isinstance(base_type, dict) and base_type.get("type") == "array" and isinstance(base_type.get("items"), dict) and base_type["items"].get("type") == "record":
+                surreal_type = "array<object>"
+                if nullable:
+                    surreal_type = f"option<{surreal_type}>"
+                statements.append(self._field_statement(path, table_name, surreal_type, field))
+                statements.extend(self._array_item_statements(base_type["items"], table_name, f"{path}[*]"))
+            else:
+                surreal_type = self._avro_type_to_surreal(field_type)
+                statements.append(self._field_statement(path, table_name, surreal_type, field))
+        return statements
+
+    def _array_item_statements(self, record: Dict[str, JsonNode], table_name: str, prefix: str) -> List[str]:
+        statements: List[str] = []
+        for field in record.get("fields", []):
+            if not isinstance(field, dict):
+                continue
+            path = f"{prefix}.{field['name']}"
+            field_type = field["type"]
+            nullable, base_type = self._unwrap_nullable(field_type)
+            if isinstance(base_type, dict) and base_type.get("type") == "record":
+                statements.append(self._field_statement(path, table_name, "option<object>" if nullable else "object", field))
+                statements.extend(self._field_statements(base_type, table_name, path))
+            else:
+                statements.append(self._field_statement(path, table_name, self._avro_type_to_surreal(field_type), field))
+        return statements
+
+    @staticmethod
+    def _field_statement(path: str, table_name: str, surreal_type: str, field: Dict[str, JsonNode]) -> str:
+        statement = f"DEFINE FIELD {path} ON TABLE {table_name} TYPE {surreal_type}"
+        if "doc" in field and field["doc"]:
+            escaped = str(field["doc"]).replace("'", "\\'")
+            statement += f" COMMENT '{escaped}'"
+        return statement + ";"
+
+    def _avro_type_to_surreal(self, avro_type: JsonNode) -> str:
+        nullable, base_type = self._unwrap_nullable(avro_type)
+        surreal_type = self._non_nullable_avro_type_to_surreal(base_type)
+        return f"option<{surreal_type}>" if nullable else surreal_type
+
+    def _non_nullable_avro_type_to_surreal(self, avro_type: JsonNode) -> str:
+        if isinstance(avro_type, str):
+            mapping = {
+                "string": "string",
+                "boolean": "bool",
+                "int": "int",
+                "long": "int",
+                "float": "float",
+                "double": "number",
+                "bytes": "bytes",
+                "null": "option<string>",
+            }
+            return mapping.get(avro_type, avro_type)
+        if isinstance(avro_type, dict):
+            type_name = avro_type.get("type")
+            logical_type = avro_type.get("logicalType")
+            if logical_type == "timestamp-millis":
+                return "datetime"
+            if logical_type == "uuid":
+                return "uuid"
+            if logical_type == "decimal":
+                return "decimal"
+            if type_name == "array":
+                return f"array<{self._avro_type_to_surreal(avro_type.get('items', 'string'))}>"
+            if type_name == "record":
+                return "object"
+            if type_name == "map":
+                return "object"
+            if isinstance(type_name, str):
+                return self._non_nullable_avro_type_to_surreal(type_name)
+        return "string"
+
+    @staticmethod
+    def _unwrap_nullable(avro_type: JsonNode) -> tuple[bool, JsonNode]:
+        if isinstance(avro_type, list):
+            non_null = [item for item in avro_type if item != "null"]
+            if len(non_null) == 1:
+                return True, non_null[0]
+        return False, avro_type
+
+    @staticmethod
+    def _record_schemas(schema: JsonNode) -> List[Dict[str, JsonNode]]:
+        if isinstance(schema, list):
+            return [item for item in schema if isinstance(item, dict) and item.get("type") == "record"]
+        if isinstance(schema, dict) and schema.get("type") == "record":
+            return [schema]
+        return []
+
+    @staticmethod
+    def _qualified_name(record: Dict[str, JsonNode]) -> str:
+        namespace = record.get("namespace")
+        return f"{namespace}.{record['name']}" if namespace else str(record["name"])
+
+
+def convert_avro_to_surrealql(avro_schema_path: str, surrealql_file_path: str, record_type: str | None = None):
+    """Convert an Avrotize Schema file to a SurrealQL schema file."""
+    with open(avro_schema_path, "r", encoding="utf-8") as avro_file:
+        schema = json.load(avro_file)
+    surrealql = AvroToSurrealQLConverter().convert_schema(schema, record_type=record_type)
+    with open(surrealql_file_path, "w", encoding="utf-8") as surrealql_file:
+        surrealql_file.write(surrealql)

--- a/avrotize/commands.json
+++ b/avrotize/commands.json
@@ -1025,6 +1025,85 @@
     "skip_input_file_handling": true
   },
   {
+    "command": "surreal2a",
+    "description": "Convert SurrealQL schema to Avrotize schema",
+    "group": "5_SQL",
+    "function": {
+      "name": "avrotize.surrealtoavro.convert_surrealql_to_avro",
+      "args": {
+        "surrealql_file_path": "input_file_path",
+        "avro_schema_path": "output_file_path",
+        "namespace": "args.namespace"
+      }
+    },
+    "extensions": [
+      ".surql",
+      ".surrealql"
+    ],
+    "args": [
+      {
+        "name": "input",
+        "type": "str",
+        "nargs": "?",
+        "help": "Path to the SurrealQL schema file (or read from stdin if omitted)",
+        "required": false
+      },
+      {
+        "name": "--out",
+        "type": "str",
+        "help": "Path to the Avrotize schema file",
+        "required": false
+      },
+      {
+        "name": "--namespace",
+        "type": "str",
+        "help": "Namespace for the Avrotize schema",
+        "required": false
+      }
+    ],
+    "suggested_output_file_path": "{input_file_name}.avsc",
+    "prompts": []
+  },
+  {
+    "command": "a2surreal",
+    "description": "Convert Avrotize schema to SurrealQL schema",
+    "group": "5_SQL",
+    "function": {
+      "name": "avrotize.avrotosurreal.convert_avro_to_surrealql",
+      "args": {
+        "avro_schema_path": "input_file_path",
+        "surrealql_file_path": "output_file_path",
+        "record_type": "args.record_type"
+      }
+    },
+    "extensions": [
+      ".avsc"
+    ],
+    "args": [
+      {
+        "name": "input",
+        "type": "str",
+        "nargs": "?",
+        "help": "Path to the Avrotize schema file (or read from stdin if omitted)",
+        "required": false
+      },
+      {
+        "name": "--out",
+        "type": "str",
+        "help": "Path to the SurrealQL schema file",
+        "required": false
+      },
+      {
+        "name": "--record-type",
+        "type": "str",
+        "help": "Specific Avro record type to convert",
+        "required": false
+      }
+    ],
+    "suggested_output_file_path": "{input_file_name}.surql",
+    "prompts": []
+  },
+  {
     "command": "a2sql",
     "description": "Convert Avrotize schema to SQL schema",
     "group": "5_SQL",

--- a/avrotize/surrealtoavro.py
+++ b/avrotize/surrealtoavro.py
@@ -1,0 +1,290 @@
+"""Convert SurrealQL schema definitions to Avrotize Schema."""
+
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+from avrotize.common import avro_name
+
+JsonNode = Dict[str, "JsonNode"] | List["JsonNode"] | str | bool | int | float | None
+
+
+@dataclass
+class FieldDefinition:
+    """Parsed SurrealQL field definition."""
+
+    path: str
+    type_expr: str
+    doc: str | None = None
+
+
+@dataclass
+class TableDefinition:
+    """Parsed SurrealQL table definition."""
+
+    name: str
+    schemafull: bool = True
+    fields: List[FieldDefinition] = field(default_factory=list)
+
+
+@dataclass
+class FieldNode:
+    """Tree node used to reconstruct nested Avro records from dotted field paths."""
+
+    name: str
+    type_expr: str | None = None
+    doc: str | None = None
+    children: Dict[str, "FieldNode"] = field(default_factory=dict)
+    array_item: "FieldNode | None" = None
+
+
+class SurrealToAvroConverter:
+    """Converter for SurrealQL DEFINE TABLE/FIELD schema statements."""
+
+    KEYWORDS = "DEFAULT|ASSERT|READONLY|COMMENT|PERMISSIONS|FLEXIBLE|VALUE"
+
+    def __init__(self, namespace: str | None = None) -> None:
+        self.namespace = namespace
+
+    def parse(self, surrealql: str) -> List[TableDefinition]:
+        """Parse supported SurrealQL schema statements."""
+        tables: Dict[str, TableDefinition] = {}
+        for statement in self._split_statements(self._strip_line_comments(surrealql)):
+            table_match = re.match(
+                r"^DEFINE\s+TABLE\s+(`[^`]+`|[A-Za-z_][\w:-]*)\s+(SCHEMAFULL|SCHEMALESS)\b",
+                statement,
+                flags=re.IGNORECASE | re.DOTALL,
+            )
+            if table_match:
+                table_name = self._clean_identifier(table_match.group(1))
+                tables[table_name] = TableDefinition(
+                    name=table_name,
+                    schemafull=table_match.group(2).upper() == "SCHEMAFULL",
+                )
+                continue
+
+            field_match = re.match(
+                r"^DEFINE\s+FIELD\s+(.+?)\s+ON\s+(?:TABLE\s+)?(`[^`]+`|[A-Za-z_][\w:-]*)\b(.*)$",
+                statement,
+                flags=re.IGNORECASE | re.DOTALL,
+            )
+            if field_match:
+                path = self._clean_path(field_match.group(1).strip())
+                table_name = self._clean_identifier(field_match.group(2))
+                tail = field_match.group(3).strip()
+                type_expr = self._extract_type(tail)
+                doc = self._extract_comment(tail)
+                table = tables.setdefault(table_name, TableDefinition(name=table_name))
+                table.fields.append(FieldDefinition(path=path, type_expr=type_expr, doc=doc))
+        return list(tables.values())
+
+    def convert_schema(self, surrealql: str) -> JsonNode:
+        """Convert SurrealQL text to an Avrotize Schema document."""
+        records = [self._table_to_record(table) for table in self.parse(surrealql)]
+        if not records:
+            raise ValueError("No supported SurrealQL DEFINE TABLE or DEFINE FIELD statements found")
+        return records[0] if len(records) == 1 else records
+
+    def _table_to_record(self, table: TableDefinition) -> Dict[str, JsonNode]:
+        root = FieldNode(table.name)
+        for field_def in table.fields:
+            self._insert_field(root, field_def)
+        record: Dict[str, JsonNode] = {
+            "type": "record",
+            "name": avro_name(table.name),
+            "fields": self._node_children_to_fields(root, avro_name(table.name)),
+        }
+        if self.namespace:
+            record["namespace"] = self.namespace
+        if not table.schemafull:
+            record["doc"] = "SurrealDB SCHEMALESS table; Avro captures declared fields only."
+        return record
+
+    def _insert_field(self, root: FieldNode, field_def: FieldDefinition) -> None:
+        parts = [part for part in field_def.path.split(".") if part]
+        node = root
+        for index, part in enumerate(parts):
+            is_array_item = part.endswith("[*]")
+            name = part[:-3] if is_array_item else part
+            if name not in node.children:
+                node.children[name] = FieldNode(name)
+            node = node.children[name]
+            if is_array_item:
+                if node.array_item is None:
+                    node.array_item = FieldNode("item")
+                node = node.array_item
+            if index == len(parts) - 1:
+                node.type_expr = field_def.type_expr
+                node.doc = field_def.doc
+
+    def _node_children_to_fields(self, node: FieldNode, parent_name: str) -> List[Dict[str, JsonNode]]:
+        return [self._node_to_field(child, parent_name) for child in node.children.values()]
+
+    def _node_to_field(self, node: FieldNode, parent_name: str) -> Dict[str, JsonNode]:
+        field_type = self._node_to_type(node, parent_name)
+        field_schema: Dict[str, JsonNode] = {"name": avro_name(node.name), "type": field_type}
+        if node.doc:
+            field_schema["doc"] = node.doc
+        if isinstance(field_type, list) and field_type and field_type[0] == "null":
+            field_schema["default"] = None
+        return field_schema
+
+    def _node_to_type(self, node: FieldNode, parent_name: str) -> JsonNode:
+        type_expr = node.type_expr or ("array" if node.array_item else "object" if node.children else "string")
+        nullable, base_type = self._unwrap_option(type_expr)
+        if node.array_item is not None:
+            item_type = self._node_to_type(node.array_item, self._nested_name(parent_name, node.name))
+            avro_type: JsonNode = {"type": "array", "items": self._non_nullable(item_type)}
+        elif node.children and self._base_type_name(base_type) in {"object", "array", "set"}:
+            if self._base_type_name(base_type) in {"array", "set"}:
+                item_record = self._record_for_node(node, self._nested_name(parent_name, node.name))
+                avro_type = {"type": "array", "items": item_record}
+            else:
+                avro_type = self._record_for_node(node, self._nested_name(parent_name, node.name))
+        else:
+            avro_type = self._surreal_type_to_avro(base_type, self._nested_name(parent_name, node.name))
+        if nullable:
+            return ["null", avro_type]
+        return avro_type
+
+    def _record_for_node(self, node: FieldNode, record_name: str) -> Dict[str, JsonNode]:
+        return {
+            "type": "record",
+            "name": avro_name(record_name),
+            "fields": self._node_children_to_fields(node, avro_name(record_name)),
+        }
+
+    def _surreal_type_to_avro(self, type_expr: str, record_name: str) -> JsonNode:
+        nullable, base_type = self._unwrap_option(type_expr)
+        if nullable:
+            return ["null", self._surreal_type_to_avro(base_type, record_name)]
+        name = self._base_type_name(base_type)
+        inner = self._generic_inner(base_type)
+        if name == "string":
+            return "string"
+        if name == "int":
+            return "long"
+        if name in {"float", "number"}:
+            return "double"
+        if name == "decimal":
+            return {"type": "bytes", "logicalType": "decimal", "precision": 38, "scale": 9}
+        if name == "bool":
+            return "boolean"
+        if name == "datetime":
+            return {"type": "long", "logicalType": "timestamp-millis"}
+        if name == "duration":
+            return "string"
+        if name == "uuid":
+            return {"type": "string", "logicalType": "uuid"}
+        if name == "bytes":
+            return "bytes"
+        if name == "object":
+            return {"type": "record", "name": avro_name(record_name), "fields": []}
+        if name in {"array", "set"}:
+            items = self._surreal_type_to_avro(inner, f"{record_name}_item") if inner else "string"
+            return {"type": "array", "items": self._non_nullable(items)}
+        if name == "record":
+            target = inner or "record"
+            return {"type": "string", "surrealType": f"record<{target}>", "doc": "SurrealDB record references are represented as record id strings."}
+        if name == "geometry":
+            return "string"
+        return "string"
+
+    @staticmethod
+    def _non_nullable(avro_type: JsonNode) -> JsonNode:
+        if isinstance(avro_type, list):
+            non_null = [item for item in avro_type if item != "null"]
+            return non_null[0] if len(non_null) == 1 else non_null
+        return avro_type
+
+    @staticmethod
+    def _unwrap_option(type_expr: str) -> tuple[bool, str]:
+        stripped = type_expr.strip()
+        if stripped.lower().startswith("option<") and stripped.endswith(">"):
+            return True, stripped[7:-1].strip()
+        return False, stripped
+
+    @staticmethod
+    def _base_type_name(type_expr: str) -> str:
+        return type_expr.strip().split("<", 1)[0].strip().lower()
+
+    @staticmethod
+    def _generic_inner(type_expr: str) -> str | None:
+        text = type_expr.strip()
+        start = text.find("<")
+        if start == -1 or not text.endswith(">"):
+            return None
+        return text[start + 1 : -1].strip()
+
+    @staticmethod
+    def _nested_name(parent_name: str, field_name: str) -> str:
+        return f"{parent_name}_{avro_name(field_name)}"
+
+    @classmethod
+    def _extract_type(cls, tail: str) -> str:
+        match = re.search(rf"\bTYPE\s+(.+?)(?=\s+(?:{cls.KEYWORDS})\b|$)", tail, flags=re.IGNORECASE | re.DOTALL)
+        if not match:
+            return "string"
+        return match.group(1).strip()
+
+    @staticmethod
+    def _extract_comment(tail: str) -> str | None:
+        match = re.search(r"\bCOMMENT\s+(['\"])(.*?)\1", tail, flags=re.IGNORECASE | re.DOTALL)
+        return match.group(2) if match else None
+
+    @staticmethod
+    def _clean_identifier(identifier: str) -> str:
+        return identifier.strip().strip("`")
+
+    @classmethod
+    def _clean_path(cls, path: str) -> str:
+        return ".".join(cls._clean_identifier(part) for part in path.split("."))
+
+    @staticmethod
+    def _strip_line_comments(text: str) -> str:
+        lines = []
+        for line in text.splitlines():
+            lines.append(re.split(r"\s+(?://|--)\s*", line, maxsplit=1)[0])
+        return "\n".join(lines)
+
+    @staticmethod
+    def _split_statements(text: str) -> List[str]:
+        statements: List[str] = []
+        current: List[str] = []
+        quote: str | None = None
+        depth = 0
+        for char in text:
+            if quote:
+                current.append(char)
+                if char == quote:
+                    quote = None
+                continue
+            if char in {"'", '"'}:
+                quote = char
+                current.append(char)
+                continue
+            if char == "<":
+                depth += 1
+            elif char == ">" and depth:
+                depth -= 1
+            if char == ";" and depth == 0:
+                statement = "".join(current).strip()
+                if statement:
+                    statements.append(statement)
+                current = []
+            else:
+                current.append(char)
+        statement = "".join(current).strip()
+        if statement:
+            statements.append(statement)
+        return statements
+
+
+def convert_surrealql_to_avro(surrealql_file_path: str, avro_schema_path: str, namespace: str | None = None):
+    """Convert a SurrealQL schema file to an Avrotize Schema file."""
+    with open(surrealql_file_path, "r", encoding="utf-8") as surrealql_file:
+        surrealql = surrealql_file.read()
+    schema = SurrealToAvroConverter(namespace=namespace).convert_schema(surrealql)
+    with open(avro_schema_path, "w", encoding="utf-8") as avro_file:
+        json.dump(schema, avro_file, indent=2)

--- a/test/surrealql/person.surql
+++ b/test/surrealql/person.surql
@@ -1,0 +1,26 @@
+DEFINE TABLE person SCHEMAFULL TYPE NORMAL;
+DEFINE FIELD id ON TABLE person TYPE record<person> COMMENT 'record id';
+DEFINE FIELD name ON TABLE person TYPE string;
+DEFINE FIELD age ON TABLE person TYPE option<int> DEFAULT NULL;
+DEFINE FIELD score ON TABLE person TYPE float;
+DEFINE FIELD price ON TABLE person TYPE decimal;
+DEFINE FIELD active ON TABLE person TYPE bool;
+DEFINE FIELD created_at ON TABLE person TYPE datetime;
+DEFINE FIELD elapsed ON TABLE person TYPE duration;
+DEFINE FIELD external_id ON TABLE person TYPE uuid;
+DEFINE FIELD payload ON TABLE person TYPE bytes;
+DEFINE FIELD address ON TABLE person TYPE object FLEXIBLE;
+DEFINE FIELD address.city ON TABLE person TYPE string;
+DEFINE FIELD address.zip ON TABLE person TYPE int;
+DEFINE FIELD tags ON TABLE person TYPE array<string>;
+DEFINE FIELD roles ON TABLE person TYPE set<string>;
+DEFINE FIELD phones[*].kind ON TABLE person TYPE string;
+DEFINE FIELD phones[*].number ON TABLE person TYPE string;
+DEFINE FIELD shape ON TABLE person TYPE geometry;
+
+DEFINE TABLE order SCHEMALESS;
+DEFINE FIELD order_id ON TABLE order TYPE uuid;
+DEFINE FIELD customer ON TABLE order TYPE record<person>;
+DEFINE FIELD lines ON TABLE order TYPE array<object>;
+DEFINE FIELD lines[*].sku ON TABLE order TYPE string;
+DEFINE FIELD lines[*].qty ON TABLE order TYPE int;

--- a/test/test_avrotosurreal.py
+++ b/test/test_avrotosurreal.py
@@ -1,0 +1,83 @@
+"""Tests for Avrotize Schema to SurrealQL schema conversion."""
+
+import json
+import unittest
+from pathlib import Path
+
+from avrotize.avrotosurreal import AvroToSurrealQLConverter, convert_avro_to_surrealql
+from avrotize.surrealtoavro import SurrealToAvroConverter
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "test" / "surrealql" / "person.surql"
+
+
+def normalize_surrealql(text: str) -> list[str]:
+    """Normalize SurrealQL statements for structural assertions."""
+    return sorted(" ".join(stmt.strip().rstrip(";").split()).lower() for stmt in text.split(";") if stmt.strip())
+
+
+class TestAvroToSurrealQL(unittest.TestCase):
+    """Validate Avro to SurrealQL mappings."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.avro_schema = SurrealToAvroConverter(namespace="example.surreal").convert_schema(FIXTURE.read_text(encoding="utf-8"))
+        cls.surrealql = AvroToSurrealQLConverter().convert_schema(cls.avro_schema)
+
+    def test_emits_define_table_statements(self) -> None:
+        self.assertIn("DEFINE TABLE person SCHEMAFULL;", self.surrealql)
+        self.assertIn("DEFINE TABLE order SCHEMAFULL;", self.surrealql)
+
+    def test_emits_scalar_field_statements(self) -> None:
+        self.assertIn("DEFINE FIELD name ON TABLE person TYPE string;", self.surrealql)
+        self.assertIn("DEFINE FIELD score ON TABLE person TYPE number;", self.surrealql)
+        self.assertIn("DEFINE FIELD active ON TABLE person TYPE bool;", self.surrealql)
+
+    def test_emits_logical_type_field_statements(self) -> None:
+        self.assertIn("DEFINE FIELD created_at ON TABLE person TYPE datetime;", self.surrealql)
+        self.assertIn("DEFINE FIELD external_id ON TABLE person TYPE uuid;", self.surrealql)
+        self.assertIn("DEFINE FIELD price ON TABLE person TYPE decimal;", self.surrealql)
+
+    def test_nullable_union_emits_option(self) -> None:
+        self.assertIn("DEFINE FIELD age ON TABLE person TYPE option<int>;", self.surrealql)
+
+    def test_nested_records_emit_dotted_paths(self) -> None:
+        self.assertIn("DEFINE FIELD address ON TABLE person TYPE object;", self.surrealql)
+        self.assertIn("DEFINE FIELD address.city ON TABLE person TYPE string;", self.surrealql)
+        self.assertIn("DEFINE FIELD address.zip ON TABLE person TYPE int;", self.surrealql)
+
+    def test_array_record_items_emit_bracket_paths(self) -> None:
+        self.assertIn("DEFINE FIELD phones ON TABLE person TYPE array<object>;", self.surrealql)
+        self.assertIn("DEFINE FIELD phones[*].kind ON TABLE person TYPE string;", self.surrealql)
+        self.assertIn("DEFINE FIELD phones[*].number ON TABLE person TYPE string;", self.surrealql)
+
+    def test_record_type_filter(self) -> None:
+        text = AvroToSurrealQLConverter().convert_schema(self.avro_schema, record_type="person")
+        self.assertIn("DEFINE TABLE person SCHEMAFULL;", text)
+        self.assertNotIn("DEFINE TABLE order SCHEMAFULL;", text)
+
+    def test_convert_function_writes_surrealql_file(self) -> None:
+        out_dir = ROOT / "test" / "surrealql" / "generated"
+        out_dir.mkdir(exist_ok=True)
+        avro_path = out_dir / "person.avsc"
+        out_path = out_dir / "person.surql"
+        try:
+            avro_path.write_text(json.dumps(self.avro_schema), encoding="utf-8")
+            convert_avro_to_surrealql(str(avro_path), str(out_path), record_type="person")
+            self.assertIn("DEFINE TABLE person SCHEMAFULL;", out_path.read_text(encoding="utf-8"))
+        finally:
+            for path in (avro_path, out_path):
+                if path.exists():
+                    path.unlink()
+            if out_dir.exists() and not any(out_dir.iterdir()):
+                out_dir.rmdir()
+
+    def test_round_trip_preserves_table_and_field_structure(self) -> None:
+        round_trip = SurrealToAvroConverter(namespace="example.surreal").convert_schema(self.surrealql)
+        second_surrealql = AvroToSurrealQLConverter().convert_schema(round_trip)
+        self.assertEqual(normalize_surrealql(self.surrealql), normalize_surrealql(second_surrealql))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_surrealtoavro.py
+++ b/test/test_surrealtoavro.py
@@ -1,0 +1,143 @@
+"""Tests for SurrealQL schema to Avrotize Schema conversion."""
+
+import json
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+from fastavro import parse_schema
+
+from avrotize.surrealtoavro import SurrealToAvroConverter, convert_surrealql_to_avro
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "test" / "surrealql" / "person.surql"
+
+
+class TestSurrealToAvro(unittest.TestCase):
+    """Validate SurrealQL to Avro mappings."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.schema = SurrealToAvroConverter(namespace="example.surreal").convert_schema(FIXTURE.read_text(encoding="utf-8"))
+        cls.records = {record["name"]: record for record in cls.schema}
+        cls.person = cls.records["person"]
+        cls.fields = {field["name"]: field for field in cls.person["fields"]}
+
+    def test_multiple_tables_are_converted(self) -> None:
+        self.assertEqual({"person", "order"}, set(self.records))
+        self.assertEqual("SurrealDB SCHEMALESS table; Avro captures declared fields only.", self.records["order"].get("doc"))
+
+    def test_namespace_is_applied(self) -> None:
+        self.assertEqual("example.surreal", self.person["namespace"])
+
+    def test_string_maps_to_avro_string(self) -> None:
+        self.assertEqual("string", self.fields["name"]["type"])
+
+    def test_int_maps_to_avro_long(self) -> None:
+        address = self.fields["address"]["type"]
+        zip_field = {field["name"]: field for field in address["fields"]}["zip"]
+        self.assertEqual("long", zip_field["type"])
+
+    def test_float_maps_to_avro_double(self) -> None:
+        self.assertEqual("double", self.fields["score"]["type"])
+
+    def test_decimal_maps_to_valid_decimal_logical_type(self) -> None:
+        self.assertEqual({"type": "bytes", "logicalType": "decimal", "precision": 38, "scale": 9}, self.fields["price"]["type"])
+
+    def test_bool_maps_to_boolean(self) -> None:
+        self.assertEqual("boolean", self.fields["active"]["type"])
+
+    def test_datetime_maps_to_timestamp_millis(self) -> None:
+        self.assertEqual({"type": "long", "logicalType": "timestamp-millis"}, self.fields["created_at"]["type"])
+
+    def test_duration_maps_to_string(self) -> None:
+        self.assertEqual("string", self.fields["elapsed"]["type"])
+
+    def test_uuid_maps_to_valid_uuid_logical_type(self) -> None:
+        self.assertEqual({"type": "string", "logicalType": "uuid"}, self.fields["external_id"]["type"])
+
+    def test_bytes_maps_to_bytes(self) -> None:
+        self.assertEqual("bytes", self.fields["payload"]["type"])
+
+    def test_option_type_is_nullable_with_null_default(self) -> None:
+        self.assertEqual(["null", "long"], self.fields["age"]["type"])
+        self.assertIsNone(self.fields["age"]["default"])
+
+    def test_dotted_paths_become_nested_records(self) -> None:
+        address = self.fields["address"]["type"]
+        self.assertEqual("record", address["type"])
+        nested = {field["name"]: field for field in address["fields"]}
+        self.assertEqual("string", nested["city"]["type"])
+        self.assertEqual("long", nested["zip"]["type"])
+
+    def test_inline_arrays_and_sets_map_to_arrays(self) -> None:
+        self.assertEqual({"type": "array", "items": "string"}, self.fields["tags"]["type"])
+        self.assertEqual({"type": "array", "items": "string"}, self.fields["roles"]["type"])
+
+    def test_array_item_paths_become_array_of_records(self) -> None:
+        phones = self.fields["phones"]["type"]
+        self.assertEqual("array", phones["type"])
+        item_fields = {field["name"]: field for field in phones["items"]["fields"]}
+        self.assertEqual("string", item_fields["kind"]["type"])
+        self.assertEqual("string", item_fields["number"]["type"])
+
+    def test_record_reference_maps_to_string_id(self) -> None:
+        self.assertEqual("string", self.fields["id"]["type"]["type"])
+        self.assertEqual("record<person>", self.fields["id"]["type"]["surrealType"])
+
+    def test_geometry_maps_to_string(self) -> None:
+        self.assertEqual("string", self.fields["shape"]["type"])
+
+    def test_generated_avro_is_valid(self) -> None:
+        parse_schema(self.schema)
+
+    def test_convert_function_writes_json_file(self) -> None:
+        out_dir = ROOT / "test" / "surrealql" / "generated"
+        out_dir.mkdir(exist_ok=True)
+        out_path = out_dir / "person.avsc"
+        try:
+            convert_surrealql_to_avro(str(FIXTURE), str(out_path), namespace="example.surreal")
+            loaded = json.loads(out_path.read_text(encoding="utf-8"))
+            self.assertEqual("person", loaded[0]["name"])
+            parse_schema(loaded)
+        finally:
+            if out_path.exists():
+                out_path.unlink()
+            if out_dir.exists() and not any(out_dir.iterdir()):
+                out_dir.rmdir()
+
+    def test_commands_json_is_valid(self) -> None:
+        with open(ROOT / "avrotize" / "commands.json", encoding="utf-8") as commands_file:
+            commands = json.load(commands_file)
+        self.assertIn("surreal2a", {command["command"] for command in commands})
+        self.assertIn("a2surreal", {command["command"] for command in commands})
+
+    def test_cli_smoke_surreal2a(self) -> None:
+        out_dir = ROOT / "test" / "surrealql" / "generated"
+        out_dir.mkdir(exist_ok=True)
+        out_path = out_dir / "cli-person.avsc"
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(ROOT)
+        try:
+            result = subprocess.run(
+                [sys.executable, "-m", "avrotize", "surreal2a", str(FIXTURE), "--out", str(out_path)],
+                cwd=ROOT,
+                env=env,
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+            self.assertIn("Executing Convert SurrealQL schema", result.stdout)
+            parse_schema(json.loads(out_path.read_text(encoding="utf-8")))
+        finally:
+            if out_path.exists():
+                out_path.unlink()
+            if out_dir.exists() and not any(out_dir.iterdir()):
+                out_dir.rmdir()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #270 — SurrealDB (SurrealQL) schema support.

## Commands
- `surreal2a` SurrealQL (`DEFINE TABLE` / `DEFINE FIELD`) → Avrotize (Avro) schema
- `a2surreal` Avro schema → SurrealQL schema statements

## Mapping
`DEFINE TABLE`→record, `DEFINE FIELD ... TYPE`→fields, `object`→nested record, `array<T>`→array, `option<T>`→nullable, scalars (string/int/float/decimal/bool/datetime/bytes) mapped to valid Avro; flexible/record links handled as documented.

## Tests
30 tests (`test/test_surrealtoavro.py`, `test/test_avrotosurreal.py`): scalars, tables, fields, nested objects, arrays, optionals, datetime, reverse (avro→surql), round-trip, Avro validity via `fastavro.parse_schema`, CLI smoke. **30 passed.**

## Documented limitations
`set`→array (uniqueness not enforced), `record<T>` links → string ids, `duration`/`geometry` → strings.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>