### PR TITLE
feat: add RAML Data Types schema support (#261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 All notable changes to Avrotize are documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **RAML 1.0 Data Types support** ([#261](https://github.com/clemensv/avrotize/issues/261)): Added `raml2a`, `a2raml`, `raml2s`, and `s2raml` converters for RAML Data Types via Avrotize Schema and JSON Structure. Phase 1 intentionally excludes full RAML API resource/method conversion, traits, resourceTypes, security schemes, annotations, and external `!include` expansion.
+
 ## [3.5.9] - 2026-06-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The tool leans on the Apache Avro-derived [Avrotize Schema](specs/avrotize-schem
 - Programming languages: Python, C#, Java, TypeScript, JavaScript, Rust, Go, C++
 - SQL Databases: MySQL, MariaDB, PostgreSQL, SQL Server, Oracle, SQLite, BigQuery, Snowflake, Redshift, DB2
 - Other databases: KQL/Kusto, MongoDB, Cassandra, Redis, Elasticsearch, DynamoDB, CosmosDB
-- Data schema formats: Avro, JSON Schema, XML Schema (XSD), Protocol Buffers 2 and 3, ASN.1, Apache Parquet
+- Data schema formats: Avro, JSON Schema, JSON Structure, RAML 1.0 Data Types, XML Schema (XSD), Protocol Buffers 2 and 3, ASN.1, Apache Parquet
 
 ## Installation
 
@@ -58,6 +58,7 @@ Avrotize provides several commands for converting schema formats via Avrotize Sc
 Converting to Avrotize Schema:
 
 - [`avrotize p2a`](#convert-proto-schema-to-avrotize-schema) - Convert Protobuf (2 or 3) schema to Avrotize Schema.
+- [`avrotize raml2a`](#convert-raml-data-types-to-avrotize-schema) - Convert RAML 1.0 Data Types to Avrotize Schema.
 - [`avrotize j2a`](#convert-json-schema-to-avrotize-schema) - Convert JSON schema to Avrotize Schema.
 - [`avrotize x2a`](#convert-xml-schema-xsd-to-avrotize-schema) - Convert XML schema to Avrotize Schema.
 - [`avrotize asn2a`](#convert-asn1-schema-to-avrotize-schema) - Convert ASN.1 to Avrotize Schema.
@@ -74,6 +75,7 @@ Converting to Avrotize Schema:
 Converting from Avrotize Schema:
 
 - [`avrotize a2p`](#convert-avrotize-schema-to-proto-schema) - Convert Avrotize Schema to Protobuf 3 schema.
+- [`avrotize a2raml`](#convert-avrotize-schema-to-raml-data-types) - Convert Avrotize Schema to RAML 1.0 Data Types.
 - [`avrotize a2j`](#convert-avrotize-schema-to-json-schema) - Convert Avrotize Schema to JSON schema.
 - [`avrotize a2x`](#convert-avrotize-schema-to-xml-schema) - Convert Avrotize Schema to XML schema.
 - [`avrotize a2k`](#convert-avrotize-schema-to-kusto-table-declaration) - Convert Avrotize Schema to Kusto table definition.
@@ -101,6 +103,8 @@ Direct conversions (JSON Structure):
 
 - [`avrotize s2p`](#convert-json-structure-to-protocol-buffers) - Convert JSON Structure to Protocol Buffers (.proto files).
 - [`avrotize oas2s`](#convert-openapi-to-json-structure) - Convert OpenAPI 3.x document to JSON Structure.
+- [`avrotize raml2s`](#convert-raml-data-types-to-json-structure) - Convert RAML 1.0 Data Types to JSON Structure.
+- [`avrotize s2raml`](#convert-json-structure-to-raml-data-types) - Convert JSON Structure to RAML 1.0 Data Types.
 
 Generate code from Avrotize Schema:
 
@@ -263,6 +267,47 @@ Conversion notes:
 - Avro namespaces are resolved into distinct proto package definitions. The tool will create a new `.proto` file with the package definition and an `import` statement for each namespace found in the Avrotize Schema.
 - Avro type unions `[]` are converted to `oneof` expressions in Proto. Avro allows for maps and arrays in the type union, whereas Proto only supports scalar types and message type references. The tool will therefore emit message types containing a single array or map field for any such case and add it to the containing type, and will also recursively resolve further unions in the array and map values.
 - The sequence of fields in a message follows the sequence of fields in the Avro record. When type unions need to be resolved into `oneof` expressions, the alternative fields need to be assigned field numbers, which will shift the field numbers for any subsequent fields.
+
+
+### Convert RAML Data Types to Avrotize Schema
+
+```bash
+avrotize raml2a <path_to_raml_file> [--out <path_to_avro_schema_file>] [--namespace <avro_schema_namespace>]
+```
+
+Parameters:
+
+- `<path_to_raml_file>`: The path to the RAML 1.0 file or library. If omitted, the file is read from stdin.
+- `--out`: The path to the Avrotize Schema file to write. If omitted, the output is directed to stdout.
+- `--namespace`: (optional) Namespace for generated Avro named types.
+
+Conversion notes:
+
+- Phase 1 supports RAML 1.0 **Data Types** in the `types:` section only. API resources, methods, traits, resourceTypes, securitySchemes, annotations, and external `!include` expansion are explicitly out of scope and are ignored or left as inert YAML values.
+- Object types with `properties:` become Avro records. Optional properties (`name?` or `required: false`) become nullable Avro fields with `null` first and default `null`.
+- Scalar mappings are `string`→`string`, `number`→`double`, `integer`→`long`, `boolean`→`boolean`, `file`→`bytes`, and `nil`→`null`.
+- RAML date/time precision is normalized to valid Avro logical types: `date-only`→`int`/`date`, `time-only`→`int`/`time-millis`, and `datetime-only`/`datetime`→`long`/`timestamp-millis`.
+- Arrays use `T[]` or `type: array` with `items`. Unions use `A | B`; nullable `T?` is treated as `nil | T`.
+- Maps use the documented RAML convention `properties: { "//": T }` or `additionalProperties: T` and become Avro maps.
+- RAML enums become Avro enums; symbols are sanitized to Avro identifiers. Non-string enum base types are emitted as Avro enum symbols, so literal value typing is not preserved.
+
+### Convert Avrotize Schema to RAML Data Types
+
+```bash
+avrotize a2raml <path_to_avro_schema_file> [--out <path_to_raml_file>] [--namespace <namespace_to_strip>]
+```
+
+Parameters:
+
+- `<path_to_avro_schema_file>`: The path to the Avrotize Schema file. If omitted, the file is read from stdin.
+- `--out`: The path to the RAML file to write. If omitted, the output is directed to stdout.
+- `--namespace`: (optional) Namespace to strip from generated RAML type references.
+
+Conversion notes:
+
+- The converter emits a `#%RAML 1.0 Library` with a `types:` map. Full RAML API resource/method conversion is explicitly out of scope.
+- Avro records become RAML `object` types, nullable fields are emitted with the `name?` optional-property form, enums become `enum:`, arrays become `T[]`, maps use `properties: { "//": T }`, and unions become `A | B`.
+- Avro logical types map back to RAML `date-only`, `time-only`, or `datetime`. `datetime-only` cannot be distinguished from Avro timestamp logical types on reverse conversion.
 
 ### Convert JSON schema to Avrotize Schema
 
@@ -1404,6 +1449,23 @@ Conversion notes:
 - Avro logical types (date, timestamp-millis, decimal, uuid) are preserved in the output.
 - Complex types (records, arrays, maps) are represented as strings in CSV schema, as CSV format doesn't have native support for nested structures.
 - Only single record types can be converted to CSV schema.
+
+
+### Convert RAML Data Types to JSON Structure
+
+```bash
+avrotize raml2s <path_to_raml_file> [--out <path_to_json_structure_file>] [--namespace <avro_schema_namespace>]
+```
+
+Converts RAML 1.0 Data Types to JSON Structure by bridging through Avrotize Schema. The same RAML phase-1 limitations apply: only inline `types:` data types are in scope; API resources, methods, traits, resourceTypes, securitySchemes, annotations, and external `!include` expansion are out of scope.
+
+### Convert JSON Structure to RAML Data Types
+
+```bash
+avrotize s2raml <path_to_json_structure_file> [--out <path_to_raml_file>] [--namespace <namespace_to_strip>]
+```
+
+Converts JSON Structure to a RAML 1.0 Library by bridging through Avrotize Schema. The output contains RAML Data Types only and does not generate API resources or methods.
 
 ### Convert JSON Structure to Protocol Buffers
 

--- a/avrotize/__init__.py
+++ b/avrotize/__init__.py
@@ -25,6 +25,10 @@ class LazyLoader:
 # Define the functions and their corresponding module paths
 _mappings = {
     "convert_proto_to_avro": (f"{mod}.prototoavro", "convert_proto_to_avro"),
+    "convert_raml_to_avro": (f"{mod}.ramltoavro", "convert_raml_to_avro"),
+    "convert_avro_to_raml": (f"{mod}.avrotoraml", "convert_avro_to_raml"),
+    "convert_raml_to_json_structure": (f"{mod}.ramltojstruct", "convert_raml_to_json_structure"),
+    "convert_json_structure_to_raml": (f"{mod}.jstructtoraml", "convert_json_structure_to_raml"),
     "convert_jsons_to_avro": (f"{mod}.jsonstoavro", "convert_jsons_to_avro"),
     "convert_kafka_struct_to_avro_schema": (f"{mod}.kstructtoavro", "convert_kafka_struct_to_avro_schema"),
     "convert_kusto_to_avro": (f"{mod}.kustotoavro", "convert_kusto_to_avro"),

--- a/avrotize/avrotoraml.py
+++ b/avrotize/avrotoraml.py
@@ -1,0 +1,144 @@
+"""Convert Avrotize/Avro schema to RAML 1.0 Data Types."""
+
+import json
+import os
+from typing import Any
+
+import yaml
+
+from avrotize.common import avro_name
+
+AvroSchema = dict[str, Any] | list[Any] | str | None
+
+
+class AvroToRamlConverter:
+    """Converter for emitting a RAML 1.0 Library with Data Types only."""
+
+    def __init__(self, namespace: str | None = None) -> None:
+        self.namespace = namespace
+        self.defined_names: set[str] = set()
+
+    def convert_file(self, avro_schema_path: str) -> dict[str, Any]:
+        with open(avro_schema_path, "r", encoding="utf-8") as avro_file:
+            avro_schema = json.load(avro_file)
+        return self.convert_schema(avro_schema)
+
+    def convert_schema(self, avro_schema: AvroSchema) -> dict[str, Any]:
+        types: dict[str, Any] = {}
+        schemas = avro_schema if isinstance(avro_schema, list) else [avro_schema]
+        for schema in schemas:
+            if isinstance(schema, dict) and schema.get("type") in {"record", "enum"}:
+                self.defined_names.add(schema["name"])
+        for schema in schemas:
+            if isinstance(schema, dict) and schema.get("type") in {"record", "enum"}:
+                types[schema["name"]] = self.convert_named(schema)
+        return {"types": types}
+
+    def convert_named(self, schema: dict[str, Any]) -> dict[str, Any]:
+        if schema.get("type") == "enum":
+            result: dict[str, Any] = {"type": "string", "enum": schema.get("symbols", [])}
+            if schema.get("doc"):
+                result["description"] = schema["doc"]
+            return result
+        result = {"type": "object", "properties": {}}
+        if schema.get("doc"):
+            result["description"] = schema["doc"]
+        for field in schema.get("fields", []):
+            field_name = field.get("name", "field")
+            field_type = field.get("type", "string")
+            nullable, non_null_type = self.split_nullable(field_type)
+            raml_name = f"{field_name}?" if nullable else field_name
+            result["properties"][raml_name] = self.convert_type(non_null_type)
+            if field.get("doc"):
+                if isinstance(result["properties"][raml_name], dict):
+                    result["properties"][raml_name]["description"] = field["doc"]
+                else:
+                    result["properties"][raml_name] = {"type": result["properties"][raml_name], "description": field["doc"]}
+            if not nullable and "default" in field:
+                if not isinstance(result["properties"][raml_name], dict):
+                    result["properties"][raml_name] = {"type": result["properties"][raml_name]}
+                result["properties"][raml_name]["default"] = field["default"]
+        return result
+
+    def convert_type(self, avro_type: AvroSchema) -> Any:
+        nullable, non_null = self.split_nullable(avro_type)
+        suffix = "?" if nullable else ""
+        if isinstance(non_null, str):
+            return f"{self.primitive_to_raml(non_null)}{suffix}"
+        if isinstance(non_null, list):
+            return " | ".join(self.type_name(item) for item in non_null)
+        if isinstance(non_null, dict):
+            logical = self.logical_to_raml(non_null)
+            if logical:
+                return f"{logical}{suffix}"
+            type_name = non_null.get("type")
+            if type_name == "array":
+                return f"{self.type_name(non_null.get('items', 'string'))}[]{suffix}"
+            if type_name == "map":
+                return {"type": "object", "properties": {"//": self.convert_type(non_null.get("values", "string"))}}
+            if type_name == "enum":
+                result: dict[str, Any] = {"type": "string", "enum": non_null.get("symbols", [])}
+                if non_null.get("doc"):
+                    result["description"] = non_null["doc"]
+                return result
+            if type_name == "record":
+                return self.convert_named(non_null)
+            if isinstance(type_name, str):
+                return f"{self.primitive_to_raml(type_name)}{suffix}"
+        return "string"
+
+    def type_name(self, avro_type: AvroSchema) -> str:
+        converted = self.convert_type(avro_type)
+        if isinstance(converted, str):
+            return converted
+        if isinstance(avro_type, dict) and avro_type.get("name"):
+            return avro_type["name"]
+        return "object"
+
+    def primitive_to_raml(self, avro_type: str) -> str:
+        mapping = {
+            "null": "nil",
+            "boolean": "boolean",
+            "int": "integer",
+            "long": "integer",
+            "float": "number",
+            "double": "number",
+            "bytes": "file",
+            "string": "string",
+        }
+        return self.strip_namespace(mapping.get(avro_type, avro_type))
+
+    @staticmethod
+    def logical_to_raml(avro_type: dict[str, Any]) -> str | None:
+        logical = avro_type.get("logicalType")
+        if logical == "date":
+            return "date-only"
+        if logical in {"time-millis", "time-micros"}:
+            return "time-only"
+        if logical in {"timestamp-millis", "timestamp-micros"}:
+            return "datetime"
+        return None
+
+    def strip_namespace(self, name: str) -> str:
+        if self.namespace and name.startswith(f"{self.namespace}."):
+            return name[len(self.namespace) + 1:]
+        return name.split(".")[-1] if name.split(".")[-1] in self.defined_names else name
+
+    @staticmethod
+    def split_nullable(avro_type: AvroSchema) -> tuple[bool, AvroSchema]:
+        if isinstance(avro_type, list) and "null" in avro_type:
+            non_null = [item for item in avro_type if item != "null"]
+            if len(non_null) == 1:
+                return True, non_null[0]
+            return True, non_null
+        return False, avro_type
+
+
+def convert_avro_to_raml(avro_schema_path: str, raml_file_path: str, namespace: str | None = None) -> None:
+    """Convert Avrotize/Avro schema to a RAML 1.0 Library containing Data Types only."""
+    converter = AvroToRamlConverter(namespace)
+    raml_doc = converter.convert_file(avro_schema_path)
+    os.makedirs(os.path.dirname(os.path.abspath(raml_file_path)) or ".", exist_ok=True)
+    with open(raml_file_path, "w", encoding="utf-8") as raml_file:
+        raml_file.write("#%RAML 1.0 Library\n")
+        yaml.safe_dump(raml_doc, raml_file, sort_keys=False, allow_unicode=True)

--- a/avrotize/commands.json
+++ b/avrotize/commands.json
@@ -137,6 +137,84 @@
     ]
   },
   {
+    "command": "raml2a",
+    "description": "Convert RAML Data Types to Avrotize schema",
+    "group": "1_Schemas",
+    "function": {
+      "name": "avrotize.ramltoavro.convert_raml_to_avro",
+      "args": {
+        "raml_file_path": "input_file_path",
+        "avro_schema_path": "output_file_path",
+        "namespace": "args.namespace"
+      }
+    },
+    "extensions": [
+      ".raml"
+    ],
+    "args": [
+      {
+        "name": "input",
+        "type": "str",
+        "nargs": "?",
+        "help": "Path of the RAML file (or read from stdin if omitted)",
+        "required": false
+      },
+      {
+        "name": "--out",
+        "type": "str",
+        "help": "Path to the Avrotize schema file",
+        "required": false
+      },
+      {
+        "name": "--namespace",
+        "type": "str",
+        "help": "Namespace for the Avrotize schema",
+        "required": false
+      }
+    ],
+    "suggested_output_file_path": "{input_file_name}.avsc",
+    "prompts": []
+  },
+  {
+    "command": "a2raml",
+    "description": "Convert Avrotize schema to RAML Data Types",
+    "group": "1_Schemas",
+    "function": {
+      "name": "avrotize.avrotoraml.convert_avro_to_raml",
+      "args": {
+        "avro_schema_path": "input_file_path",
+        "raml_file_path": "output_file_path",
+        "namespace": "args.namespace"
+      }
+    },
+    "extensions": [
+      ".avsc"
+    ],
+    "args": [
+      {
+        "name": "input",
+        "type": "str",
+        "nargs": "?",
+        "help": "Path to the Avrotize schema file (or read from stdin if omitted)",
+        "required": false
+      },
+      {
+        "name": "--out",
+        "type": "str",
+        "help": "Path to the RAML file",
+        "required": false
+      },
+      {
+        "name": "--namespace",
+        "type": "str",
+        "help": "Namespace to strip from RAML type references",
+        "required": false
+      }
+    ],
+    "suggested_output_file_path": "{input_file_name}.raml",
+    "prompts": []
+  },
+  {
     "command": "s2p",
     "description": "Convert JSON Structure to Protocol Buffers (.proto)",
     "group": "1_Schemas",
@@ -4292,6 +4370,85 @@
         "default": false
       }
     ]
+  },
+  {
+    "command": "raml2s",
+    "description": "Convert RAML Data Types to JSON Structure",
+    "group": "1_Schemas",
+    "function": {
+      "name": "avrotize.ramltojstruct.convert_raml_to_json_structure",
+      "args": {
+        "raml_file_path": "input_file_path",
+        "json_structure_file": "output_file_path",
+        "namespace": "args.namespace"
+      }
+    },
+    "extensions": [
+      ".raml"
+    ],
+    "args": [
+      {
+        "name": "input",
+        "type": "str",
+        "nargs": "?",
+        "help": "Path of the RAML file (or read from stdin if omitted)",
+        "required": false
+      },
+      {
+        "name": "--out",
+        "type": "str",
+        "help": "Path to the JSON Structure file",
+        "required": false
+      },
+      {
+        "name": "--namespace",
+        "type": "str",
+        "help": "Namespace for the intermediate Avrotize schema",
+        "required": false
+      }
+    ],
+    "suggested_output_file_path": "{input_file_name}.struct.json",
+    "prompts": []
+  },
+  {
+    "command": "s2raml",
+    "description": "Convert JSON Structure to RAML Data Types",
+    "group": "1_Schemas",
+    "function": {
+      "name": "avrotize.jstructtoraml.convert_json_structure_to_raml",
+      "args": {
+        "structure_file": "input_file_path",
+        "raml_file_path": "output_file_path",
+        "namespace": "args.namespace"
+      }
+    },
+    "extensions": [
+      ".struct.json",
+      ".json"
+    ],
+    "args": [
+      {
+        "name": "input",
+        "type": "str",
+        "nargs": "?",
+        "help": "Path to the JSON Structure file (or read from stdin if omitted)",
+        "required": false
+      },
+      {
+        "name": "--out",
+        "type": "str",
+        "help": "Path to the RAML file",
+        "required": false
+      },
+      {
+        "name": "--namespace",
+        "type": "str",
+        "help": "Namespace to strip from RAML type references",
+        "required": false
+      }
+    ],
+    "suggested_output_file_path": "{input_file_name}.raml",
+    "prompts": []
   },
   {
     "command": "s2a",

--- a/avrotize/jstructtoraml.py
+++ b/avrotize/jstructtoraml.py
@@ -1,0 +1,20 @@
+"""Bridge JSON Structure to RAML Data Types through Avrotize/Avro schema."""
+
+import os
+import uuid
+
+from avrotize.avrotoraml import convert_avro_to_raml
+from avrotize.jstructtoavro import convert_json_structure_to_avro
+
+
+def convert_json_structure_to_raml(structure_file: str, raml_file_path: str, namespace: str | None = None) -> None:
+    """Convert JSON Structure to RAML 1.0 Data Types via a temporary Avro schema."""
+    out_dir = os.path.dirname(os.path.abspath(raml_file_path)) or os.getcwd()
+    os.makedirs(out_dir, exist_ok=True)
+    temp_avro = os.path.join(out_dir, f".s2raml-{uuid.uuid4().hex}.avsc")
+    try:
+        convert_json_structure_to_avro(structure_file, temp_avro)
+        convert_avro_to_raml(temp_avro, raml_file_path, namespace=namespace)
+    finally:
+        if os.path.exists(temp_avro):
+            os.remove(temp_avro)

--- a/avrotize/ramltoavro.py
+++ b/avrotize/ramltoavro.py
@@ -1,0 +1,240 @@
+"""Convert RAML 1.0 Data Types to Avrotize/Avro schema."""
+
+import json
+import os
+from typing import Any
+
+import yaml
+
+from avrotize.common import avro_name, avro_namespace
+from avrotize.dependency_resolver import sort_messages_by_dependencies
+
+AvroSchema = dict[str, Any] | list[Any] | str | None
+
+
+class _RamlLoader(yaml.SafeLoader):
+    """YAML loader that keeps unsupported RAML tags such as !include inert."""
+
+
+def _unknown_tag(loader: _RamlLoader, tag_suffix: str, node: yaml.Node) -> Any:
+    if isinstance(node, yaml.ScalarNode):
+        return loader.construct_scalar(node)
+    if isinstance(node, yaml.SequenceNode):
+        return loader.construct_sequence(node)
+    if isinstance(node, yaml.MappingNode):
+        return loader.construct_mapping(node)
+    return None
+
+
+_RamlLoader.add_multi_constructor("!", _unknown_tag)
+
+
+class RamlToAvroConverter:
+    """Converter for the RAML 1.0 Data Types subset."""
+
+    scalar_types: dict[str, AvroSchema] = {
+        "string": "string",
+        "number": "double",
+        "integer": "long",
+        "boolean": "boolean",
+        "date-only": {"type": "int", "logicalType": "date"},
+        "time-only": {"type": "int", "logicalType": "time-millis"},
+        "datetime-only": {"type": "long", "logicalType": "timestamp-millis"},
+        "datetime": {"type": "long", "logicalType": "timestamp-millis"},
+        "file": "bytes",
+        "nil": "null",
+        "null": "null",
+        "any": "string",
+    }
+
+    def __init__(self, namespace: str | None = None) -> None:
+        self.namespace = avro_namespace(namespace) if namespace else None
+        self.known_types: set[str] = set()
+
+    def load_raml(self, raml_file_path: str) -> dict[str, Any]:
+        with open(raml_file_path, "r", encoding="utf-8") as raml_file:
+            data = yaml.load(raml_file, Loader=_RamlLoader)
+        return data or {}
+
+    def convert_file(self, raml_file_path: str) -> AvroSchema:
+        data = self.load_raml(raml_file_path)
+        if not isinstance(data, dict):
+            raise ValueError("RAML document must be a mapping")
+        types = data.get("types", {}) or {}
+        if not isinstance(types, dict):
+            raise ValueError("RAML types section must be a mapping")
+        self.known_types = {avro_name(str(name).rstrip("?")) for name in types}
+        avro_types: list[dict[str, Any]] = []
+        for type_name, definition in types.items():
+            avro_type = self.convert_named_type(str(type_name), definition)
+            if isinstance(avro_type, dict) and avro_type.get("type") in {"record", "enum"}:
+                avro_types.append(avro_type)
+        return sort_messages_by_dependencies(avro_types) if len(avro_types) > 1 else (avro_types[0] if avro_types else [])
+
+    def convert_named_type(self, type_name: str, definition: Any) -> AvroSchema:
+        name = avro_name(type_name.rstrip("?"))
+        definition = self.normalize_definition(definition)
+        if "enum" in definition:
+            return self.convert_enum(name, definition)
+        raml_type = definition.get("type", "object" if "properties" in definition else "string")
+        if self.is_map_definition(definition):
+            return self.convert_record(name, {**definition, "type": "object"})
+        if raml_type == "object" or "properties" in definition:
+            return self.convert_record(name, definition)
+        avro_type = self.convert_type(raml_type, name)
+        if isinstance(avro_type, dict) and avro_type.get("type") in {"record", "enum"}:
+            avro_type.setdefault("name", name)
+            avro_type.setdefault("namespace", self.namespace)
+            return avro_type
+        return {"type": "record", "name": name, **({"namespace": self.namespace} if self.namespace else {}), "fields": [{"name": "value", "type": avro_type}]}
+
+    def normalize_definition(self, definition: Any) -> dict[str, Any]:
+        if definition is None:
+            return {"type": "string"}
+        if isinstance(definition, str):
+            return {"type": definition}
+        if isinstance(definition, list):
+            return {"type": " | ".join(str(item) for item in definition)}
+        if isinstance(definition, dict):
+            return dict(definition)
+        return {"type": str(definition)}
+
+    def convert_record(self, name: str, definition: dict[str, Any]) -> dict[str, Any]:
+        record: dict[str, Any] = {"type": "record", "name": avro_name(name), "fields": []}
+        if self.namespace:
+            record["namespace"] = self.namespace
+        if definition.get("description"):
+            record["doc"] = str(definition["description"])
+        deps: list[str] = []
+        properties = definition.get("properties", {}) or {}
+        if self.is_map_definition(definition):
+            map_type = self.map_value_type(definition)
+            record["fields"].append({"name": "additionalProperties", "type": {"type": "map", "values": map_type}})
+            self.collect_dependencies(map_type, deps)
+        elif isinstance(properties, dict):
+            for prop_name, prop_def in properties.items():
+                if self.is_out_of_scope_key(str(prop_name)):
+                    continue
+                field = self.convert_property(avro_name(name), str(prop_name), prop_def)
+                self.collect_dependencies(field["type"], deps)
+                record["fields"].append(field)
+        if deps:
+            record["dependencies"] = sorted(set(deps))
+        return record
+
+    @staticmethod
+    def is_out_of_scope_key(name: str) -> bool:
+        return name.startswith("/") or name.lower() in {"get", "post", "put", "patch", "delete", "head", "options", "trace"}
+
+    def convert_property(self, record_name: str, prop_name: str, prop_def: Any) -> dict[str, Any]:
+        optional_by_name = prop_name.endswith("?")
+        clean_name = prop_name.rstrip("?")
+        definition = self.normalize_definition(prop_def)
+        optional = optional_by_name or definition.get("required") is False
+        field_type = self.convert_type(definition.get("type", "object" if "properties" in definition else "string"), f"{record_name}_{clean_name}", definition)
+        if optional and not self.is_nullable(field_type):
+            field_type = ["null", field_type]
+        field: dict[str, Any] = {"name": avro_name(clean_name), "type": field_type}
+        if definition.get("description"):
+            field["doc"] = str(definition["description"])
+        if optional:
+            field["default"] = None
+        elif "default" in definition:
+            field["default"] = definition["default"]
+        return field
+
+    def convert_enum(self, name: str, definition: dict[str, Any]) -> dict[str, Any]:
+        enum_type: dict[str, Any] = {"type": "enum", "name": avro_name(name), "symbols": [avro_name(str(symbol)) for symbol in definition.get("enum", [])]}
+        if self.namespace:
+            enum_type["namespace"] = self.namespace
+        if definition.get("description"):
+            enum_type["doc"] = str(definition["description"])
+        return enum_type
+
+    def convert_type(self, raml_type: Any, context_name: str, definition: dict[str, Any] | None = None) -> AvroSchema:
+        definition = definition or {}
+        if "enum" in definition:
+            return self.convert_enum(context_name, definition)
+        if self.is_map_definition(definition):
+            return {"type": "map", "values": self.map_value_type(definition)}
+        if isinstance(raml_type, list):
+            return self.union([self.convert_type(item, context_name, definition) for item in raml_type])
+        if isinstance(raml_type, dict):
+            return self.convert_type(raml_type.get("type", "object"), context_name, raml_type)
+        type_text = str(raml_type).strip() if raml_type is not None else "string"
+        if type_text.endswith("?") and " | " not in type_text and "|" not in type_text:
+            return self.union(["null", self.convert_type(type_text[:-1], context_name, definition)])
+        if "|" in type_text:
+            return self.union([self.convert_type(part.strip(), context_name, definition) for part in type_text.split("|")])
+        if type_text.endswith("[]"):
+            return {"type": "array", "items": self.convert_type(type_text[:-2].strip(), context_name, definition)}
+        if type_text == "array":
+            return {"type": "array", "items": self.convert_type(definition.get("items", "string"), context_name, {})}
+        if type_text == "object" or "properties" in definition:
+            nested = self.convert_record(context_name, {**definition, "type": "object"})
+            nested.pop("dependencies", None)
+            return nested
+        if type_text in self.scalar_types:
+            value = self.scalar_types[type_text]
+            return dict(value) if isinstance(value, dict) else value
+        return self.reference_name(type_text)
+
+    def reference_name(self, type_name: str) -> str:
+        name = avro_name(type_name)
+        if self.namespace and name in self.known_types:
+            return f"{self.namespace}.{name}"
+        return name
+
+    @staticmethod
+    def union(items: list[AvroSchema]) -> list[AvroSchema]:
+        result: list[AvroSchema] = []
+        seen: set[str] = set()
+        for item in items:
+            if isinstance(item, list):
+                nested = item
+            else:
+                nested = [item]
+            for nested_item in nested:
+                key = json.dumps(nested_item, sort_keys=True) if isinstance(nested_item, (dict, list)) else str(nested_item)
+                if key not in seen:
+                    seen.add(key)
+                    result.append(nested_item)
+        if "null" in result:
+            result.insert(0, result.pop(result.index("null")))
+        return result
+
+    @staticmethod
+    def is_nullable(avro_type: AvroSchema) -> bool:
+        return avro_type == "null" or (isinstance(avro_type, list) and "null" in avro_type)
+
+    def is_map_definition(self, definition: dict[str, Any]) -> bool:
+        props = definition.get("properties")
+        return "additionalProperties" in definition or (isinstance(props, dict) and set(props.keys()) == {"//"})
+
+    def map_value_type(self, definition: dict[str, Any]) -> AvroSchema:
+        if "additionalProperties" in definition:
+            return self.convert_type(definition["additionalProperties"], "MapValue", {})
+        props = definition.get("properties", {}) or {}
+        return self.convert_type(props.get("//", "string"), "MapValue", {})
+
+    def collect_dependencies(self, avro_type: AvroSchema, deps: list[str]) -> None:
+        if isinstance(avro_type, str):
+            if self.namespace and avro_type.startswith(f"{self.namespace}."):
+                deps.append(avro_type)
+        elif isinstance(avro_type, list):
+            for item in avro_type:
+                self.collect_dependencies(item, deps)
+        elif isinstance(avro_type, dict):
+            for key in ("items", "values", "type"):
+                if key in avro_type and key != "type" or key == "type" and isinstance(avro_type.get(key), (dict, list, str)):
+                    self.collect_dependencies(avro_type[key], deps)
+
+
+def convert_raml_to_avro(raml_file_path: str, avro_schema_path: str, namespace: str | None = None) -> None:
+    """Convert RAML 1.0 Data Types from ``raml_file_path`` to Avrotize/Avro schema."""
+    converter = RamlToAvroConverter(namespace)
+    avro_schema = converter.convert_file(raml_file_path)
+    os.makedirs(os.path.dirname(os.path.abspath(avro_schema_path)) or ".", exist_ok=True)
+    with open(avro_schema_path, "w", encoding="utf-8") as avro_file:
+        json.dump(avro_schema, avro_file, indent=2)
+        avro_file.write("\n")

--- a/avrotize/ramltojstruct.py
+++ b/avrotize/ramltojstruct.py
@@ -1,0 +1,20 @@
+"""Bridge RAML Data Types to JSON Structure through Avrotize/Avro schema."""
+
+import os
+import uuid
+
+from avrotize.avrotojstruct import convert_avro_to_json_structure
+from avrotize.ramltoavro import convert_raml_to_avro
+
+
+def convert_raml_to_json_structure(raml_file_path: str, json_structure_file: str, namespace: str | None = None) -> None:
+    """Convert RAML 1.0 Data Types to JSON Structure via a temporary Avro schema."""
+    out_dir = os.path.dirname(os.path.abspath(json_structure_file)) or os.getcwd()
+    os.makedirs(out_dir, exist_ok=True)
+    temp_avro = os.path.join(out_dir, f".raml2s-{uuid.uuid4().hex}.avsc")
+    try:
+        convert_raml_to_avro(raml_file_path, temp_avro, namespace=namespace)
+        convert_avro_to_json_structure(temp_avro, json_structure_file)
+    finally:
+        if os.path.exists(temp_avro):
+            os.remove(temp_avro)

--- a/test/raml/api-with-types.raml
+++ b/test/raml/api-with-types.raml
@@ -1,0 +1,10 @@
+#%RAML 1.0
+title: Ignored API
+/resource:
+  get:
+    responses: {}
+types:
+  Item:
+    type: object
+    properties:
+      id: string

--- a/test/raml/library.raml
+++ b/test/raml/library.raml
@@ -1,0 +1,42 @@
+#%RAML 1.0 Library
+types:
+  Address:
+    type: object
+    properties:
+      street: string
+      city: string
+  Status:
+    type: string
+    enum: [new, active, suspended]
+  Person:
+    type: object
+    description: Person record
+    properties:
+      id:
+        type: integer
+        description: Identifier
+      name: string
+      nickname?: string
+      active:
+        type: boolean
+        required: false
+      score: number
+      birthday: date-only
+      alarm: time-only
+      created: datetime
+      avatar: file
+      tags: string[]
+      values:
+        type: array
+        items: integer
+      status: Status
+      address: Address
+      choice: string | integer
+      metadata:
+        type: object
+        properties:
+          "//": string
+      child:
+        type: object
+        properties:
+          value: string

--- a/test/test_ramltoavro.py
+++ b/test/test_ramltoavro.py
@@ -1,0 +1,183 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+from fastavro import parse_schema
+
+from avrotize.avrotoraml import convert_avro_to_raml
+from avrotize.jstructtoraml import convert_json_structure_to_raml
+from avrotize.ramltoavro import convert_raml_to_avro
+from avrotize.ramltojstruct import convert_raml_to_json_structure
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "test" / "raml" / "library.raml"
+API_FIXTURE = ROOT / "test" / "raml" / "api-with-types.raml"
+
+
+class RamlDataTypesConversionTests(unittest.TestCase):
+    def convert_fixture(self):
+        tmp = tempfile.TemporaryDirectory(dir=ROOT)
+        self.addCleanup(tmp.cleanup)
+        out = Path(tmp.name) / "schema.avsc"
+        convert_raml_to_avro(str(FIXTURE), str(out), namespace="example.raml")
+        with open(out, "r", encoding="utf-8") as handle:
+            return json.load(handle), out, Path(tmp.name)
+
+    def named(self, schema, name):
+        items = schema if isinstance(schema, list) else [schema]
+        return next(item for item in items if item["name"] == name)
+
+    def field(self, record, name):
+        return next(field for field in record["fields"] if field["name"] == name)
+
+    def test_scalar_mappings(self):
+        schema, _, _ = self.convert_fixture()
+        person = self.named(schema, "Person")
+        self.assertEqual(self.field(person, "id")["type"], "long")
+        self.assertEqual(self.field(person, "name")["type"], "string")
+        self.assertEqual(self.field(person, "score")["type"], "double")
+        self.assertEqual(self.field(person, "active")["type"], ["null", "boolean"])
+        self.assertEqual(self.field(person, "avatar")["type"], "bytes")
+
+    def test_date_time_datetime_logical_types_are_valid(self):
+        schema, _, _ = self.convert_fixture()
+        person = self.named(schema, "Person")
+        self.assertEqual(self.field(person, "birthday")["type"], {"type": "int", "logicalType": "date"})
+        self.assertEqual(self.field(person, "alarm")["type"], {"type": "int", "logicalType": "time-millis"})
+        self.assertEqual(self.field(person, "created")["type"], {"type": "long", "logicalType": "timestamp-millis"})
+        parse_schema(schema)
+
+    def test_object_properties_to_record(self):
+        schema, _, _ = self.convert_fixture()
+        person = self.named(schema, "Person")
+        self.assertEqual(person["type"], "record")
+        self.assertIn("id", [field["name"] for field in person["fields"]])
+
+    def test_optional_question_mark_property(self):
+        schema, _, _ = self.convert_fixture()
+        nickname = self.field(self.named(schema, "Person"), "nickname")
+        self.assertEqual(nickname["type"], ["null", "string"])
+        self.assertIsNone(nickname["default"])
+
+    def test_optional_required_false_property(self):
+        schema, _, _ = self.convert_fixture()
+        active = self.field(self.named(schema, "Person"), "active")
+        self.assertEqual(active["type"], ["null", "boolean"])
+        self.assertIsNone(active["default"])
+
+    def test_arrays_shorthand_and_items(self):
+        schema, _, _ = self.convert_fixture()
+        person = self.named(schema, "Person")
+        self.assertEqual(self.field(person, "tags")["type"], {"type": "array", "items": "string"})
+        self.assertEqual(self.field(person, "values")["type"], {"type": "array", "items": "long"})
+
+    def test_union_string_syntax(self):
+        schema, _, _ = self.convert_fixture()
+        choice = self.field(self.named(schema, "Person"), "choice")
+        self.assertEqual(choice["type"], ["string", "long"])
+
+    def test_enum_conversion(self):
+        schema, _, _ = self.convert_fixture()
+        status = self.named(schema, "Status")
+        self.assertEqual(status["type"], "enum")
+        self.assertEqual(status["symbols"], ["new", "active", "suspended"])
+
+    def test_map_convention_conversion(self):
+        schema, _, _ = self.convert_fixture()
+        metadata = self.field(self.named(schema, "Person"), "metadata")
+        self.assertEqual(metadata["type"], {"type": "map", "values": "string"})
+
+    def test_nested_object_conversion(self):
+        schema, _, _ = self.convert_fixture()
+        child = self.field(self.named(schema, "Person"), "child")
+        self.assertEqual(child["type"]["type"], "record")
+        self.assertEqual(child["type"]["name"], "Person_child")
+
+    def test_named_reference_conversion(self):
+        schema, _, _ = self.convert_fixture()
+        person = self.named(schema, "Person")
+        self.assertEqual(self.field(person, "address")["type"], "example.raml.Address")
+        self.assertEqual(self.field(person, "status")["type"], "example.raml.Status")
+
+    def test_description_maps_to_doc(self):
+        schema, _, _ = self.convert_fixture()
+        person = self.named(schema, "Person")
+        self.assertEqual(person["doc"], "Person record")
+        self.assertEqual(self.field(person, "id")["doc"], "Identifier")
+
+    def test_reverse_emits_parseable_raml_library(self):
+        schema, avro_path, work = self.convert_fixture()
+        raml_path = work / "schema.raml"
+        convert_avro_to_raml(str(avro_path), str(raml_path), namespace="example.raml")
+        text = raml_path.read_text(encoding="utf-8")
+        self.assertTrue(text.startswith("#%RAML 1.0 Library"))
+        parsed = yaml.safe_load("\n".join(text.splitlines()[1:]))
+        self.assertIn("Person", parsed["types"])
+
+    def test_round_trip_preserves_normalized_data_types(self):
+        _, avro_path, work = self.convert_fixture()
+        raml_path = work / "roundtrip.raml"
+        avro_again = work / "roundtrip.avsc"
+        convert_avro_to_raml(str(avro_path), str(raml_path), namespace="example.raml")
+        convert_raml_to_avro(str(raml_path), str(avro_again), namespace="example.raml")
+        with open(avro_again, "r", encoding="utf-8") as handle:
+            schema_again = json.load(handle)
+        person = self.named(schema_again, "Person")
+        self.assertEqual(self.field(person, "birthday")["type"], {"type": "int", "logicalType": "date"})
+        self.assertEqual(self.field(person, "tags")["type"], {"type": "array", "items": "string"})
+        parse_schema(schema_again)
+
+    def test_json_structure_bridge_raml_to_structure(self):
+        _, _, work = self.convert_fixture()
+        struct_path = work / "schema.struct.json"
+        convert_raml_to_json_structure(str(FIXTURE), str(struct_path), namespace="example.raml")
+        data = json.loads(struct_path.read_text(encoding="utf-8"))
+        self.assertTrue(data)
+
+    def test_json_structure_bridge_structure_to_raml(self):
+        _, _, work = self.convert_fixture()
+        struct_path = work / "schema.struct.json"
+        raml_path = work / "from-structure.raml"
+        convert_raml_to_json_structure(str(FIXTURE), str(struct_path), namespace="example.raml")
+        convert_json_structure_to_raml(str(struct_path), str(raml_path), namespace="example.raml")
+        self.assertTrue(raml_path.read_text(encoding="utf-8").startswith("#%RAML 1.0 Library"))
+
+    def test_out_of_scope_resource_method_keys_do_not_crash(self):
+        tmp = tempfile.TemporaryDirectory(dir=ROOT)
+        self.addCleanup(tmp.cleanup)
+        out = Path(tmp.name) / "api.avsc"
+        convert_raml_to_avro(str(API_FIXTURE), str(out), namespace="example.raml")
+        schema = json.loads(out.read_text(encoding="utf-8"))
+        self.assertEqual(self.named(schema, "Item")["fields"][0]["name"], "id")
+
+    def test_cli_smoke_raml2a(self):
+        tmp = tempfile.TemporaryDirectory(dir=ROOT)
+        self.addCleanup(tmp.cleanup)
+        out = Path(tmp.name) / "cli.avsc"
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(ROOT)
+        result = subprocess.run(
+            [sys.executable, "-m", "avrotize", "raml2a", str(FIXTURE), "--out", str(out), "--namespace", "example.raml"],
+            cwd=ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        parse_schema(json.loads(out.read_text(encoding="utf-8")))
+
+    def test_avro_schema_validity(self):
+        schema, _, _ = self.convert_fixture()
+        parsed = parse_schema(schema)
+        self.assertTrue(parsed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #261 — RAML 1.0 Data Types support.

## Commands
- `raml2a` RAML Data Types → Avrotize (Avro) schema
- `a2raml` Avro schema → RAML Data Types library
- `raml2s` RAML Data Types → JSON Structure (bridged via Avro)
- `s2raml` JSON Structure → RAML Data Types (bridged via Avro)

## Mapping
`type: object` + `properties`→record (`name?`/`required: false`→nullable), scalars (string/number/integer/boolean/date-only/time-only/datetime/file/nil) mapped to valid Avro logical types, `array`/`T[]`→array, `A | B`→union, `enum`→enum, type references→named-type refs, `default`/`description` carried.

## Tests
19 tests (`test/test_ramltoavro.py`): each scalar, object/properties, required/optional, both array forms, union, enum, map, nested objects, references, date/time logical types, reverse (avro→raml), round-trip, JSON Structure bridge, graceful skip of out-of-scope constructs, Avro validity via `fastavro.parse_schema`, CLI smoke. **19 passed.**

## Documented limitations (phase 1)
RAML **Data Types only**. Out of scope: resources/methods, traits, resourceTypes, securitySchemes, annotations, and external `!include` expansion (inline types supported).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>