### PR TITLE
feat: add Smithy IDL schema support (#259)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 All notable changes to Avrotize are documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **Smithy IDL data-shape conversion** ([#259](https://github.com/clemensv/avrotize/issues/259)): Added `smithy2a`, `a2smithy`, `smithy2s`, and `s2smithy` commands for Smithy 2.0 IDL data shapes, including structures, unions, enums/intEnums, lists, maps, scalars, documentation/default/required traits, and JSON Structure bridging through Avrotize Schema. Service, operation, resource, and protocol modeling are explicitly out of phase-1 scope and are skipped gracefully.
+
 ## [3.5.9] - 2026-06-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The tool leans on the Apache Avro-derived [Avrotize Schema](specs/avrotize-schem
 - Programming languages: Python, C#, Java, TypeScript, JavaScript, Rust, Go, C++
 - SQL Databases: MySQL, MariaDB, PostgreSQL, SQL Server, Oracle, SQLite, BigQuery, Snowflake, Redshift, DB2
 - Other databases: KQL/Kusto, MongoDB, Cassandra, Redis, Elasticsearch, DynamoDB, CosmosDB
-- Data schema formats: Avro, JSON Schema, XML Schema (XSD), Protocol Buffers 2 and 3, ASN.1, Apache Parquet
+- Data schema formats: Avro, JSON Schema, JSON Structure, XML Schema (XSD), Protocol Buffers 2 and 3, Smithy IDL, ASN.1, Apache Parquet
 
 ## Installation
 
@@ -58,6 +58,7 @@ Avrotize provides several commands for converting schema formats via Avrotize Sc
 Converting to Avrotize Schema:
 
 - [`avrotize p2a`](#convert-proto-schema-to-avrotize-schema) - Convert Protobuf (2 or 3) schema to Avrotize Schema.
+- [`avrotize smithy2a`](#convert-smithy-idl-data-shapes-to-avrotize-schema) - Convert Smithy 2.0 IDL data shapes to Avrotize Schema.
 - [`avrotize j2a`](#convert-json-schema-to-avrotize-schema) - Convert JSON schema to Avrotize Schema.
 - [`avrotize x2a`](#convert-xml-schema-xsd-to-avrotize-schema) - Convert XML schema to Avrotize Schema.
 - [`avrotize asn2a`](#convert-asn1-schema-to-avrotize-schema) - Convert ASN.1 to Avrotize Schema.
@@ -74,6 +75,7 @@ Converting to Avrotize Schema:
 Converting from Avrotize Schema:
 
 - [`avrotize a2p`](#convert-avrotize-schema-to-proto-schema) - Convert Avrotize Schema to Protobuf 3 schema.
+- [`avrotize a2smithy`](#convert-avrotize-schema-to-smithy-idl-data-shapes) - Convert Avrotize Schema to Smithy 2.0 IDL data shapes.
 - [`avrotize a2j`](#convert-avrotize-schema-to-json-schema) - Convert Avrotize Schema to JSON schema.
 - [`avrotize a2x`](#convert-avrotize-schema-to-xml-schema) - Convert Avrotize Schema to XML schema.
 - [`avrotize a2k`](#convert-avrotize-schema-to-kusto-table-declaration) - Convert Avrotize Schema to Kusto table definition.
@@ -100,6 +102,8 @@ Converting from Avrotize Schema:
 Direct conversions (JSON Structure):
 
 - [`avrotize s2p`](#convert-json-structure-to-protocol-buffers) - Convert JSON Structure to Protocol Buffers (.proto files).
+- [`avrotize smithy2s`](#convert-smithy-idl-data-shapes-to-json-structure) - Convert Smithy 2.0 IDL data shapes to JSON Structure.
+- [`avrotize s2smithy`](#convert-json-structure-to-smithy-idl-data-shapes) - Convert JSON Structure to Smithy 2.0 IDL data shapes.
 - [`avrotize oas2s`](#convert-openapi-to-json-structure) - Convert OpenAPI 3.x document to JSON Structure.
 
 Generate code from Avrotize Schema:
@@ -263,6 +267,46 @@ Conversion notes:
 - Avro namespaces are resolved into distinct proto package definitions. The tool will create a new `.proto` file with the package definition and an `import` statement for each namespace found in the Avrotize Schema.
 - Avro type unions `[]` are converted to `oneof` expressions in Proto. Avro allows for maps and arrays in the type union, whereas Proto only supports scalar types and message type references. The tool will therefore emit message types containing a single array or map field for any such case and add it to the containing type, and will also recursively resolve further unions in the array and map values.
 - The sequence of fields in a message follows the sequence of fields in the Avro record. When type unions need to be resolved into `oneof` expressions, the alternative fields need to be assigned field numbers, which will shift the field numbers for any subsequent fields.
+
+
+### Convert Smithy IDL data shapes to Avrotize Schema
+
+```bash
+avrotize smithy2a <path_to_smithy_file> [--out <path_to_avro_schema_file>] [--namespace <avro_schema_namespace>]
+```
+
+Parameters:
+
+- `<path_to_smithy_file>`: The path to the Smithy 2.0 IDL file to be converted. If omitted, the file is read from stdin.
+- `--out`: The path to the Avrotize Schema file to write the conversion result to. If omitted, the output is directed to stdout.
+- `--namespace`: (optional) Override the Smithy `namespace` for the emitted Avro namespace.
+
+Conversion notes:
+
+- Phase 1 supports Smithy data shapes only: `structure`, `union`, `enum`, `intEnum`, `list`, `map`, and scalar shape references. `service`, `operation`, `resource`, HTTP/protocol traits, mixins beyond simple parsing, and `apply` statements are explicitly out of scope and are skipped without failing conversion.
+- Smithy `namespace` maps to Avro `namespace`. `@documentation` maps to Avro `doc`; `@required` makes a field non-nullable; non-required fields are nullable and default to `null`; `@default` maps to the Avro field default where Avro permits it. `@deprecated` and `@tags` are carried into `doc` text.
+- Smithy `union` shapes are represented as Avro records whose alternatives are nullable fields, preserving member names while keeping the Avro schema valid. Avro field unions convert back to Smithy `union` shapes.
+- Smithy `intEnum` converts to an Avro enum with an `ordinals` annotation; Avro itself stores enum symbols, so integer values are metadata for round-tripping.
+- Smithy `list` and `map` members map to Avro arrays and maps. Avro maps are string-keyed, so Smithy map keys should be `String`; other key declarations are noted but cannot be represented as Avro map keys.
+- Scalar mappings include `Blob`→`bytes`, `Boolean`→`boolean`, `String`→`string`, integer widths→`int`/`long`, floats→`float`/`double`, `Timestamp`→valid Avro `long` with `timestamp-millis`, `BigInteger`→`string`, `BigDecimal`→`double`, and `Document`→`string`.
+
+### Convert Avrotize Schema to Smithy IDL data shapes
+
+```bash
+avrotize a2smithy <path_to_avro_schema_file> [--out <path_to_smithy_file>] [--namespace <smithy_namespace>]
+```
+
+Parameters:
+
+- `<path_to_avro_schema_file>`: The path to the Avrotize Schema file to be converted. If omitted, the file is read from stdin.
+- `--out`: The path to the Smithy IDL file to write. If omitted, the output is directed to stdout.
+- `--namespace`: (optional) Override the Smithy namespace to emit.
+
+Conversion notes:
+
+- Avro records become Smithy `structure` shapes; nullable unions become optional members; non-null fields are emitted with `@required`.
+- Avro enums become Smithy `enum` shapes, or `intEnum` when an `ordinals` annotation is present. Avro arrays and maps become Smithy `list` and `map` shapes. Avro unions with multiple non-null alternatives become Smithy `union` shapes.
+- Service and operation modeling is explicitly out of phase-1 scope; this command emits Smithy data shapes only.
 
 ### Convert JSON schema to Avrotize Schema
 
@@ -1427,6 +1471,23 @@ Conversion notes:
 - Type references (`$ref`) are resolved and converted to appropriate message types.
 - Choice types (unions) are converted to Protocol Buffers `oneof` constructs.
 - Abstract types and extensions (`$extends`) are handled by generating appropriate message hierarchies.
+
+
+### Convert Smithy IDL data shapes to JSON Structure
+
+```bash
+avrotize smithy2s <path_to_smithy_file> [--out <path_to_json_structure_file>] [--namespace <avro_schema_namespace>]
+```
+
+This command converts Smithy 2.0 IDL data shapes to JSON Structure by bridging through Avrotize Schema. It has the same Smithy phase-1 scope and limitations as `smithy2a`: service, operation, resource, and protocol modeling are out of scope and skipped.
+
+### Convert JSON Structure to Smithy IDL data shapes
+
+```bash
+avrotize s2smithy <path_to_json_structure_file> [--out <path_to_smithy_file>] [--namespace <smithy_namespace>]
+```
+
+This command converts JSON Structure to Smithy 2.0 IDL data shapes by bridging through Avrotize Schema. It emits data shapes only; Smithy service and operation modeling is explicitly out of scope for phase 1.
 
 ### Convert OpenAPI to JSON Structure
 

--- a/avrotize/__init__.py
+++ b/avrotize/__init__.py
@@ -25,6 +25,10 @@ class LazyLoader:
 # Define the functions and their corresponding module paths
 _mappings = {
     "convert_proto_to_avro": (f"{mod}.prototoavro", "convert_proto_to_avro"),
+    "convert_smithy_to_avro": (f"{mod}.smithytoavro", "convert_smithy_to_avro"),
+    "convert_avro_to_smithy": (f"{mod}.avrotosmithy", "convert_avro_to_smithy"),
+    "convert_smithy_to_json_structure": (f"{mod}.smithytojstruct", "convert_smithy_to_json_structure"),
+    "convert_json_structure_to_smithy": (f"{mod}.jstructtosmithy", "convert_json_structure_to_smithy"),
     "convert_jsons_to_avro": (f"{mod}.jsonstoavro", "convert_jsons_to_avro"),
     "convert_kafka_struct_to_avro_schema": (f"{mod}.kstructtoavro", "convert_kafka_struct_to_avro_schema"),
     "convert_kusto_to_avro": (f"{mod}.kustotoavro", "convert_kusto_to_avro"),

--- a/avrotize/avrotosmithy.py
+++ b/avrotize/avrotosmithy.py
@@ -1,0 +1,311 @@
+"""Convert Avrotize Schema (Avro) data shapes to Smithy 2.0 IDL."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import Any
+
+
+AVRO_TO_SMITHY_PRIMITIVES = {
+    "null": "Document",
+    "boolean": "Boolean",
+    "bytes": "Blob",
+    "string": "String",
+    "int": "Integer",
+    "long": "Long",
+    "float": "Float",
+    "double": "Double",
+}
+
+
+class AvroToSmithyConverter:
+    """Convert Avro schemas to Smithy data shapes."""
+
+    def __init__(self, namespace: str | None = None) -> None:
+        self.namespace = namespace
+        self.generated_shapes: list[str] = []
+        self.generated_names: set[str] = set()
+        self.collection_types: dict[str, str] = {}
+
+    def convert_schema(self, avro_schema: Any) -> str:
+        schemas = avro_schema if self._is_schema_list(avro_schema) else [avro_schema]
+        self.namespace = self.namespace or self._discover_namespace(schemas) or "smithy.generated"
+        self._index_collection_wrappers(schemas)
+        lines = ['$version: "2.0"', f"namespace {self.namespace}", ""]
+        body: list[str] = []
+        for schema in schemas:
+            body.extend(self.shape_to_smithy(schema))
+            if body and body[-1] != "":
+                body.append("")
+        if self.generated_shapes:
+            body.extend(self.generated_shapes)
+        return "\n".join(lines + body).rstrip() + "\n"
+
+    @staticmethod
+    def _discover_namespace(schemas: list[Any]) -> str | None:
+        for schema in schemas:
+            if isinstance(schema, dict) and schema.get("namespace"):
+                return schema["namespace"]
+        return None
+
+    @staticmethod
+    def _is_union(schema: Any) -> bool:
+        return isinstance(schema, list) and any(item != "null" for item in schema)
+
+    @staticmethod
+    def _is_schema_list(schema: Any) -> bool:
+        return isinstance(schema, list) and all(isinstance(item, dict) and "type" in item and "name" in item for item in schema)
+
+    def _index_collection_wrappers(self, schemas: list[Any]) -> None:
+        for schema in schemas:
+            if not isinstance(schema, dict) or schema.get("type") != "record" or not schema.get("fields"):
+                continue
+            marker = schema.get("smithyShape")
+            field_type = schema["fields"][0].get("type")
+            if marker == "list" and isinstance(field_type, dict) and field_type.get("type") == "array":
+                self.collection_types[self._signature(field_type)] = schema["name"]
+            elif marker == "map" and isinstance(field_type, dict) and field_type.get("type") == "map":
+                self.collection_types[self._signature(field_type)] = schema["name"]
+
+    @staticmethod
+    def _signature(avro_type: Any) -> str:
+        return json.dumps(avro_type, sort_keys=True)
+
+    def shape_to_smithy(self, schema: Any) -> list[str]:
+        if isinstance(schema, list):
+            name = self.unique_name("RootUnion")
+            return self.union_shape_lines(name, schema)
+        if isinstance(schema, str):
+            return []
+        schema_type = schema.get("type")
+        if schema_type == "record" and schema.get("smithyShape") == "union":
+            return self.record_union_lines(schema)
+        if schema_type == "record" and schema.get("smithyShape") == "list":
+            return self.record_list_lines(schema)
+        if schema_type == "record" and schema.get("smithyShape") == "map":
+            return self.record_map_lines(schema)
+        if schema_type == "record":
+            return self.record_lines(schema)
+        if schema_type == "enum":
+            return self.enum_lines(schema)
+        if schema_type == "array":
+            return self.list_lines(schema.get("name", self.unique_name("RootList")), schema.get("items", "string"))
+        if schema_type == "map":
+            return self.map_lines(schema.get("name", self.unique_name("RootMap")), schema.get("values", "string"))
+        return []
+
+    def record_lines(self, schema: dict[str, Any]) -> list[str]:
+        lines = self.doc_lines(schema)
+        lines.append(f"structure {schema['name']} {{")
+        for field in schema.get("fields", []):
+            lines.extend(self.field_lines(schema["name"], field))
+        lines.append("}")
+        return lines
+
+    def record_union_lines(self, schema: dict[str, Any]) -> list[str]:
+        lines = self.doc_lines(schema)
+        lines.append(f"union {schema['name']} {{")
+        for field in schema.get("fields", []):
+            lines.extend(self.member_lines(schema["name"], field, include_required=False))
+        lines.append("}")
+        return lines
+
+    def record_list_lines(self, schema: dict[str, Any]) -> list[str]:
+        field = schema.get("fields", [{}])[0]
+        field_type = field.get("type", {}) if isinstance(field, dict) else {}
+        items = field_type.get("items", "string") if isinstance(field_type, dict) else "string"
+        return self.list_lines(schema["name"], items, schema)
+
+    def record_map_lines(self, schema: dict[str, Any]) -> list[str]:
+        field = schema.get("fields", [{}])[0]
+        field_type = field.get("type", {}) if isinstance(field, dict) else {}
+        values = field_type.get("values", "string") if isinstance(field_type, dict) else "string"
+        return self.map_lines(schema["name"], values, schema)
+
+    def enum_lines(self, schema: dict[str, Any]) -> list[str]:
+        lines = self.doc_lines(schema)
+        ordinals = schema.get("ordinals")
+        if ordinals:
+            lines.append(f"intEnum {schema['name']} {{")
+            for idx, symbol in enumerate(schema.get("symbols", [])):
+                lines.append(f"    {symbol} = {ordinals.get(symbol, idx)}")
+        else:
+            lines.append(f"enum {schema['name']} {{")
+            for symbol in schema.get("symbols", []):
+                lines.append(f"    {symbol}")
+        lines.append("}")
+        return lines
+
+    def list_lines(self, name: str, items: Any, schema: dict[str, Any] | None = None) -> list[str]:
+        lines = self.doc_lines(schema or {})
+        lines.append(f"list {name} {{")
+        lines.append(f"    member: {self.avro_type_to_smithy(name, 'member', items)}")
+        lines.append("}")
+        return lines
+
+    def map_lines(self, name: str, values: Any, schema: dict[str, Any] | None = None) -> list[str]:
+        lines = self.doc_lines(schema or {})
+        lines.append(f"map {name} {{")
+        lines.append("    key: String")
+        lines.append(f"    value: {self.avro_type_to_smithy(name, 'value', values)}")
+        lines.append("}")
+        return lines
+
+    def union_shape_lines(self, name: str, union_type: list[Any]) -> list[str]:
+        lines = [f"union {name} {{"]
+        for index, branch in enumerate([item for item in union_type if item != "null"]):
+            member_name = self.member_name_from_type(branch, index)
+            lines.append(f"    {member_name}: {self.avro_type_to_smithy(name, member_name, branch)}")
+        lines.append("}")
+        return lines
+
+    def field_lines(self, record_name: str, field: dict[str, Any]) -> list[str]:
+        field_type = field.get("type", "string")
+        nullable, non_null = self.unwrap_nullable(field_type)
+        if isinstance(non_null, list):
+            union_name = self.emit_union(record_name, field["name"], non_null)
+            non_null = union_name
+        lines = self.member_doc_lines(field)
+        if not nullable:
+            lines.append("    @required")
+        if "default" in field and field.get("default") is not None:
+            lines.append(f"    @default({self.format_literal(field['default'])})")
+        lines.append(f"    {field['name']}: {self.avro_type_to_smithy(record_name, field['name'], non_null)}")
+        return lines
+
+    def member_lines(self, record_name: str, field: dict[str, Any], include_required: bool) -> list[str]:
+        nullable, non_null = self.unwrap_nullable(field.get("type", "string"))
+        lines = self.member_doc_lines(field)
+        if include_required and not nullable:
+            lines.append("    @required")
+        lines.append(f"    {field['name']}: {self.avro_type_to_smithy(record_name, field['name'], non_null)}")
+        return lines
+
+    def avro_type_to_smithy(self, owner_name: str, field_name: str, avro_type: Any) -> str:
+        if isinstance(avro_type, list):
+            nullable, non_null = self.unwrap_nullable(avro_type)
+            if isinstance(non_null, list):
+                return self.emit_union(owner_name, field_name, non_null)
+            return self.avro_type_to_smithy(owner_name, field_name, non_null)
+        if isinstance(avro_type, str):
+            return AVRO_TO_SMITHY_PRIMITIVES.get(avro_type, avro_type.split(".")[-1])
+        if isinstance(avro_type, dict):
+            if avro_type.get("logicalType") == "timestamp-millis" and avro_type.get("type") == "long":
+                return "Timestamp"
+            typ = avro_type.get("type")
+            if typ == "array":
+                existing = self.collection_types.get(self._signature(avro_type))
+                if existing:
+                    return existing
+                name = self.unique_name(f"{owner_name}{self.pascal(field_name)}List")
+                self.generated_shapes.extend(self.list_lines(name, avro_type.get("items", "string")))
+                self.generated_shapes.append("")
+                return name
+            if typ == "map":
+                existing = self.collection_types.get(self._signature(avro_type))
+                if existing:
+                    return existing
+                name = self.unique_name(f"{owner_name}{self.pascal(field_name)}Map")
+                self.generated_shapes.extend(self.map_lines(name, avro_type.get("values", "string")))
+                self.generated_shapes.append("")
+                return name
+            if typ == "record":
+                nested_name = avro_type.get("name", self.unique_name(f"{owner_name}{self.pascal(field_name)}"))
+                if nested_name not in self.generated_names:
+                    self.generated_names.add(nested_name)
+                    self.generated_shapes.extend(self.shape_to_smithy(avro_type))
+                    self.generated_shapes.append("")
+                return nested_name
+            if typ == "enum":
+                enum_name = avro_type.get("name", self.unique_name(f"{owner_name}{self.pascal(field_name)}Enum"))
+                if enum_name not in self.generated_names:
+                    self.generated_names.add(enum_name)
+                    self.generated_shapes.extend(self.enum_lines(avro_type))
+                    self.generated_shapes.append("")
+                return enum_name
+            return self.avro_type_to_smithy(owner_name, field_name, typ)
+        return "Document"
+
+    def emit_union(self, owner_name: str, field_name: str, union_type: list[Any]) -> str:
+        name = self.unique_name(f"{owner_name}{self.pascal(field_name)}Union")
+        self.generated_shapes.extend(self.union_shape_lines(name, union_type))
+        self.generated_shapes.append("")
+        return name
+
+    @staticmethod
+    def unwrap_nullable(avro_type: Any) -> tuple[bool, Any]:
+        if isinstance(avro_type, list):
+            non_null = [item for item in avro_type if item != "null"]
+            if len(non_null) == 1:
+                return len(non_null) != len(avro_type), non_null[0]
+            return "null" in avro_type, non_null
+        return False, avro_type
+
+    def unique_name(self, base: str) -> str:
+        base = self.pascal(base)
+        name = base
+        counter = 2
+        while name in self.generated_names:
+            name = f"{base}{counter}"
+            counter += 1
+        self.generated_names.add(name)
+        return name
+
+    @staticmethod
+    def member_name_from_type(avro_type: Any, index: int) -> str:
+        if isinstance(avro_type, str):
+            base = avro_type.split(".")[-1]
+        elif isinstance(avro_type, dict):
+            base = avro_type.get("name") or avro_type.get("type", "choice")
+        else:
+            base = "choice"
+        name = re.sub(r"[^A-Za-z0-9_]", "_", base)
+        if not re.match(r"[A-Za-z_]", name):
+            name = f"choice{index + 1}"
+        return name[:1].lower() + name[1:]
+
+    @staticmethod
+    def doc_lines(schema: dict[str, Any]) -> list[str]:
+        doc = schema.get("doc")
+        return [f"@documentation({AvroToSmithyConverter.format_literal(doc)})"] if doc else []
+
+    @staticmethod
+    def member_doc_lines(field: dict[str, Any]) -> list[str]:
+        doc = field.get("doc")
+        return [f"    @documentation({AvroToSmithyConverter.format_literal(doc)})"] if doc else []
+
+    @staticmethod
+    def format_literal(value: Any) -> str:
+        if isinstance(value, str):
+            return json.dumps(value)
+        if value is True:
+            return "true"
+        if value is False:
+            return "false"
+        if value is None:
+            return "null"
+        return str(value)
+
+    @staticmethod
+    def pascal(name: str) -> str:
+        parts = re.split(r"[^A-Za-z0-9]+", name)
+        return "".join(part[:1].upper() + part[1:] for part in parts if part) or "Shape"
+
+
+def convert_avro_to_smithy_schema(avro_schema: Any, namespace: str | None = None) -> str:
+    """Convert an Avro schema object to Smithy IDL text."""
+    return AvroToSmithyConverter(namespace).convert_schema(avro_schema)
+
+
+def convert_avro_to_smithy(avro_schema_path: str, smithy_file_path: str, namespace: str | None = None) -> None:
+    """Convert an Avrotize Schema JSON file to Smithy IDL."""
+    with open(avro_schema_path, "r", encoding="utf-8") as avro_file:
+        avro_schema = json.load(avro_file)
+    smithy_text = convert_avro_to_smithy_schema(avro_schema, namespace)
+    output_dir = os.path.dirname(os.path.abspath(smithy_file_path))
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+    with open(smithy_file_path, "w", encoding="utf-8") as smithy_file:
+        smithy_file.write(smithy_text)

--- a/avrotize/commands.json
+++ b/avrotize/commands.json
@@ -137,6 +137,84 @@
     ]
   },
   {
+    "command": "smithy2a",
+    "description": "Convert Smithy IDL data shapes to Avrotize schema",
+    "group": "1_Schemas",
+    "function": {
+      "name": "avrotize.smithytoavro.convert_smithy_to_avro",
+      "args": {
+        "smithy_file_path": "input_file_path",
+        "avro_schema_path": "output_file_path",
+        "namespace": "args.namespace"
+      }
+    },
+    "extensions": [
+      ".smithy"
+    ],
+    "args": [
+      {
+        "name": "input",
+        "type": "str",
+        "nargs": "?",
+        "help": "Path to the Smithy IDL file (or read from stdin if omitted)",
+        "required": false
+      },
+      {
+        "name": "--out",
+        "type": "str",
+        "help": "Path to the Avrotize schema file",
+        "required": false
+      },
+      {
+        "name": "--namespace",
+        "type": "str",
+        "help": "Namespace for the Avrotize schema",
+        "required": false
+      }
+    ],
+    "suggested_output_file_path": "{input_file_name}.avsc",
+    "prompts": []
+  },
+  {
+    "command": "a2smithy",
+    "description": "Convert Avrotize schema to Smithy IDL data shapes",
+    "group": "1_Schemas",
+    "function": {
+      "name": "avrotize.avrotosmithy.convert_avro_to_smithy",
+      "args": {
+        "avro_schema_path": "input_file_path",
+        "smithy_file_path": "output_file_path",
+        "namespace": "args.namespace"
+      }
+    },
+    "extensions": [
+      ".avsc"
+    ],
+    "args": [
+      {
+        "name": "input",
+        "type": "str",
+        "nargs": "?",
+        "help": "Path to the Avrotize schema file (or read from stdin if omitted)",
+        "required": false
+      },
+      {
+        "name": "--out",
+        "type": "str",
+        "help": "Path to the Smithy IDL file",
+        "required": false
+      },
+      {
+        "name": "--namespace",
+        "type": "str",
+        "help": "Smithy namespace to emit",
+        "required": false
+      }
+    ],
+    "suggested_output_file_path": "{input_file_name}.smithy",
+    "prompts": []
+  },
+  {
     "command": "s2p",
     "description": "Convert JSON Structure to Protocol Buffers (.proto)",
     "group": "1_Schemas",
@@ -4378,6 +4456,85 @@
       }
     ],
     "suggested_output_file_path": "{input_file_name}.struct.json",
+    "prompts": []
+  },
+  {
+    "command": "smithy2s",
+    "description": "Convert Smithy IDL data shapes to JSON Structure",
+    "group": "1_Schemas",
+    "function": {
+      "name": "avrotize.smithytojstruct.convert_smithy_to_json_structure",
+      "args": {
+        "smithy_file_path": "input_file_path",
+        "json_structure_file": "output_file_path",
+        "namespace": "args.namespace"
+      }
+    },
+    "extensions": [
+      ".smithy"
+    ],
+    "args": [
+      {
+        "name": "input",
+        "type": "str",
+        "nargs": "?",
+        "help": "Path to the Smithy IDL file (or read from stdin if omitted)",
+        "required": false
+      },
+      {
+        "name": "--out",
+        "type": "str",
+        "help": "Path to the JSON Structure file",
+        "required": false
+      },
+      {
+        "name": "--namespace",
+        "type": "str",
+        "help": "Namespace for the intermediate Avrotize schema",
+        "required": false
+      }
+    ],
+    "suggested_output_file_path": "{input_file_name}.struct.json",
+    "prompts": []
+  },
+  {
+    "command": "s2smithy",
+    "description": "Convert JSON Structure to Smithy IDL data shapes",
+    "group": "1_Schemas",
+    "function": {
+      "name": "avrotize.jstructtosmithy.convert_json_structure_to_smithy",
+      "args": {
+        "structure_file": "input_file_path",
+        "smithy_file_path": "output_file_path",
+        "namespace": "args.namespace"
+      }
+    },
+    "extensions": [
+      ".struct.json",
+      ".json"
+    ],
+    "args": [
+      {
+        "name": "input",
+        "type": "str",
+        "nargs": "?",
+        "help": "Path to the JSON Structure file (or read from stdin if omitted)",
+        "required": false
+      },
+      {
+        "name": "--out",
+        "type": "str",
+        "help": "Path to the Smithy IDL file",
+        "required": false
+      },
+      {
+        "name": "--namespace",
+        "type": "str",
+        "help": "Smithy namespace to emit",
+        "required": false
+      }
+    ],
+    "suggested_output_file_path": "{input_file_name}.smithy",
     "prompts": []
   },
   {

--- a/avrotize/jstructtosmithy.py
+++ b/avrotize/jstructtosmithy.py
@@ -1,0 +1,24 @@
+"""Bridge JSON Structure to Smithy IDL through Avrotize Schema."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+from avrotize.avrotosmithy import convert_avro_to_smithy
+from avrotize.jstructtoavro import convert_json_structure_to_avro
+
+
+def convert_json_structure_to_smithy(structure_file: str, smithy_file_path: str, namespace: str | None = None) -> None:
+    """Convert JSON Structure data shapes to Smithy IDL via a temporary Avrotize Schema file."""
+    temp_dir = os.path.dirname(os.path.abspath(smithy_file_path)) or os.getcwd()
+    os.makedirs(temp_dir, exist_ok=True)
+    temp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".avsc", delete=False, dir=temp_dir) as temp_file:
+            temp_path = temp_file.name
+        convert_json_structure_to_avro(structure_file, temp_path)
+        convert_avro_to_smithy(temp_path, smithy_file_path, namespace=namespace)
+    finally:
+        if temp_path and os.path.exists(temp_path):
+            os.remove(temp_path)

--- a/avrotize/smithytoavro.py
+++ b/avrotize/smithytoavro.py
@@ -1,0 +1,539 @@
+"""Convert Smithy 2.0 IDL data shapes to Avrotize Schema (Avro)."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from avrotize.dependency_resolver import sort_messages_by_dependencies
+
+AvroType = dict[str, Any] | list[Any] | str
+
+_IDENTIFIER_RE = re.compile(r"@[A-Za-z_][A-Za-z0-9_.$#-]*|[A-Za-z_$][A-Za-z0-9_.$#-]*|\"(?:\\.|[^\"])*\"|-?\d+(?:\.\d+)?|[{}()\[\]:,=]")
+_NAME_RE = re.compile(r"[^A-Za-z0-9_]")
+
+SMITHY_TO_AVRO_PRIMITIVES: dict[str, AvroType] = {
+    "Blob": "bytes",
+    "Boolean": "boolean",
+    "String": "string",
+    "Byte": "int",
+    "Short": "int",
+    "Integer": "int",
+    "Long": "long",
+    "Float": "float",
+    "Double": "double",
+    "BigInteger": "string",
+    "BigDecimal": "double",
+    "Timestamp": {"type": "long", "logicalType": "timestamp-millis"},
+    "Document": "string",
+}
+
+
+@dataclass
+class SmithyShape:
+    kind: str
+    name: str
+    traits: dict[str, Any] = field(default_factory=dict)
+    members: list[dict[str, Any]] = field(default_factory=list)
+    member_type: str | None = None
+    key_type: str | None = None
+    value_type: str | None = None
+    enum_values: list[tuple[str, int | None]] = field(default_factory=list)
+
+
+class SmithyIdlParser:
+    """Small Smithy IDL parser for phase-1 data-shape conversion."""
+
+    def __init__(self, text: str) -> None:
+        self.tokens = self._tokenize(text)
+        self.index = 0
+        self.namespace: str | None = None
+        self.shapes: list[SmithyShape] = []
+
+    @staticmethod
+    def _strip_comments(text: str) -> str:
+        result: list[str] = []
+        i = 0
+        in_string = False
+        while i < len(text):
+            ch = text[i]
+            nxt = text[i + 1] if i + 1 < len(text) else ""
+            if ch == '"' and (i == 0 or text[i - 1] != "\\"):
+                in_string = not in_string
+                result.append(ch)
+                i += 1
+            elif not in_string and ch == "/" and nxt == "/":
+                while i < len(text) and text[i] not in "\r\n":
+                    i += 1
+            elif not in_string and ch == "#":
+                while i < len(text) and text[i] not in "\r\n":
+                    i += 1
+            else:
+                result.append(ch)
+                i += 1
+        return "".join(result)
+
+    @classmethod
+    def _tokenize(cls, text: str) -> list[str]:
+        return [m.group(0) for m in _IDENTIFIER_RE.finditer(cls._strip_comments(text))]
+
+    def peek(self, offset: int = 0) -> str | None:
+        pos = self.index + offset
+        return self.tokens[pos] if pos < len(self.tokens) else None
+
+    def pop(self) -> str:
+        tok = self.peek()
+        if tok is None:
+            raise ValueError("Unexpected end of Smithy IDL")
+        self.index += 1
+        return tok
+
+    def consume(self, token: str) -> bool:
+        if self.peek() == token:
+            self.index += 1
+            return True
+        return False
+
+    def expect(self, token: str) -> None:
+        actual = self.pop()
+        if actual != token:
+            raise ValueError(f"Expected {token!r}, got {actual!r}")
+
+    def parse(self) -> tuple[str | None, list[SmithyShape]]:
+        pending_traits: dict[str, Any] = {}
+        while self.peek() is not None:
+            tok = self.peek()
+            if tok == ",":
+                self.pop()
+                continue
+            if tok and tok.startswith("@"):
+                pending_traits.update(self.parse_trait())
+                continue
+            if tok == "$version":
+                self.pop()
+                if self.consume(":") or self.consume("="):
+                    self.pop()
+                continue
+            if tok == "metadata":
+                self.parse_metadata()
+                pending_traits = {}
+                continue
+            if tok == "namespace":
+                self.pop()
+                self.namespace = self.pop()
+                pending_traits = {}
+                continue
+            if tok in {"structure", "union", "list", "map", "enum", "intEnum"}:
+                self.shapes.append(self.parse_shape(pending_traits))
+                pending_traits = {}
+                continue
+            if tok in {"service", "operation", "resource"}:
+                self.skip_statement_or_block()
+                pending_traits = {}
+                continue
+            if tok == "apply":
+                self.parse_apply()
+                pending_traits = {}
+                continue
+            self.pop()
+            pending_traits = {}
+        return self.namespace, self.shapes
+
+
+    def parse_metadata(self) -> None:
+        self.pop()
+        if self.peek() is not None:
+            self.pop()
+        if self.consume(":") or self.consume("="):
+            if self.peek() == "[":
+                self.skip_bracketed("[", "]")
+            elif self.peek() == "{":
+                self.skip_braces()
+            elif self.peek() is not None:
+                self.pop()
+        self.consume(",")
+
+    def parse_apply(self) -> None:
+        self.pop()
+        if self.peek() is not None:
+            self.pop()
+        while self.peek() and self.peek().startswith("@"):
+            self.parse_trait()
+        self.consume(",")
+
+    def parse_trait(self) -> dict[str, Any]:
+        name = self.pop()[1:]
+        value: Any = True
+        if self.consume("("):
+            collected: list[str] = []
+            depth = 1
+            while depth and self.peek() is not None:
+                tok = self.pop()
+                if tok == "(":
+                    depth += 1
+                elif tok == ")":
+                    depth -= 1
+                    if depth == 0:
+                        break
+                collected.append(tok)
+            value = self._trait_value(collected)
+        return {name.split("#")[-1].split(".")[-1]: value}
+
+    @staticmethod
+    def _trait_value(tokens: list[str]) -> Any:
+        if not tokens:
+            return True
+        if len(tokens) == 1:
+            return _literal(tokens[0])
+        if tokens[0] in {"[", "{"}:
+            return " ".join(tokens)
+        values: dict[str, Any] = {}
+        i = 0
+        while i < len(tokens):
+            key = tokens[i]
+            if i + 2 < len(tokens) and tokens[i + 1] in {":", "="}:
+                values[key] = _literal(tokens[i + 2])
+                i += 3
+            else:
+                i += 1
+        return values or " ".join(tokens)
+
+    def parse_shape(self, traits: dict[str, Any]) -> SmithyShape:
+        kind = self.pop()
+        name = sanitize_name(self.pop())
+        while self.peek() == "with":
+            self.pop()
+            self.skip_bracketed("[", "]")
+        shape = SmithyShape(kind=kind, name=name, traits=traits.copy())
+        self.expect("{")
+        if kind == "structure":
+            shape.members = self.parse_members(until="}")
+        elif kind == "union":
+            shape.members = self.parse_members(until="}", union_members=True)
+        elif kind == "list":
+            self.parse_collection(shape, list_mode=True)
+        elif kind == "map":
+            self.parse_collection(shape, list_mode=False)
+        elif kind in {"enum", "intEnum"}:
+            shape.enum_values = self.parse_enum_values(kind == "intEnum")
+        self.expect("}")
+        return shape
+
+    def parse_members(self, until: str, union_members: bool = False) -> list[dict[str, Any]]:
+        members: list[dict[str, Any]] = []
+        pending_traits: dict[str, Any] = {}
+        while self.peek() is not None and self.peek() != until:
+            tok = self.peek()
+            if tok == ",":
+                self.pop()
+                continue
+            if tok and tok.startswith("@"):
+                pending_traits.update(self.parse_trait())
+                continue
+            name = sanitize_member_name(self.pop())
+            if not self.consume(":"):
+                pending_traits = {}
+                continue
+            type_name = self.pop()
+            members.append({"name": name, "type": type_name, "traits": pending_traits.copy()})
+            pending_traits = {}
+            self.consume(",")
+        return members
+
+    def parse_collection(self, shape: SmithyShape, list_mode: bool) -> None:
+        pending_traits: dict[str, Any] = {}
+        while self.peek() is not None and self.peek() != "}":
+            tok = self.peek()
+            if tok == ",":
+                self.pop()
+                continue
+            if tok and tok.startswith("@"):
+                pending_traits.update(self.parse_trait())
+                continue
+            name = self.pop()
+            if self.consume(":"):
+                value = self.pop()
+                if list_mode and name == "member":
+                    shape.member_type = value
+                    shape.members.append({"name": "member", "type": value, "traits": pending_traits.copy()})
+                elif not list_mode and name == "key":
+                    shape.key_type = value
+                elif not list_mode and name == "value":
+                    shape.value_type = value
+                    shape.members.append({"name": "value", "type": value, "traits": pending_traits.copy()})
+            pending_traits = {}
+            self.consume(",")
+
+    def parse_enum_values(self, int_enum: bool) -> list[tuple[str, int | None]]:
+        values: list[tuple[str, int | None]] = []
+        while self.peek() is not None and self.peek() != "}":
+            if self.peek() == ",":
+                self.pop()
+                continue
+            if self.peek() and self.peek().startswith("@"):  # member traits ignored for enum values
+                self.parse_trait()
+                continue
+            name = sanitize_enum_symbol(self.pop())
+            number: int | None = None
+            if int_enum and self.consume("="):
+                number = int(float(self.pop()))
+            values.append((name, number))
+            self.consume(",")
+        return values
+
+    def skip_bracketed(self, start: str, end: str) -> None:
+        if not self.consume(start):
+            return
+        depth = 1
+        while depth and self.peek() is not None:
+            tok = self.pop()
+            if tok == start:
+                depth += 1
+            elif tok == end:
+                depth -= 1
+
+    def skip_statement_or_block(self) -> None:
+        first = self.pop()
+        while self.peek() is not None:
+            tok = self.peek()
+            if tok == "{":
+                self.skip_braces()
+                return
+            if first in {"service", "operation", "resource"} and tok in {"structure", "union", "list", "map", "enum", "intEnum", "service", "operation", "resource", "namespace", "apply", "metadata"}:
+                return
+            self.pop()
+            if tok == ",":
+                return
+
+    def skip_braces(self) -> None:
+        self.expect("{")
+        depth = 1
+        while depth and self.peek() is not None:
+            tok = self.pop()
+            if tok == "{":
+                depth += 1
+            elif tok == "}":
+                depth -= 1
+
+
+def _literal(token: str) -> Any:
+    if token.startswith('"') and token.endswith('"'):
+        return bytes(token[1:-1], "utf-8").decode("unicode_escape")
+    if token == "true":
+        return True
+    if token == "false":
+        return False
+    if token == "null":
+        return None
+    if re.fullmatch(r"-?\d+", token):
+        return int(token)
+    if re.fullmatch(r"-?\d+\.\d+", token):
+        return float(token)
+    return token
+
+
+def sanitize_name(name: str) -> str:
+    name = name.split("#")[-1].split(".")[-1]
+    name = _NAME_RE.sub("_", name)
+    if not name or not re.match(r"[A-Za-z_]", name):
+        name = f"Shape_{name}"
+    return name
+
+
+def sanitize_member_name(name: str) -> str:
+    name = _NAME_RE.sub("_", name.split("#")[-1])
+    if not name or not re.match(r"[A-Za-z_]", name):
+        name = f"field_{name}"
+    return name
+
+
+def sanitize_enum_symbol(name: str) -> str:
+    name = sanitize_name(name).upper() if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", name) else name
+    if not re.match(r"[A-Za-z_]", name):
+        name = f"VALUE_{name}"
+    return name
+
+
+class SmithyToAvroConverter:
+    """Convert parsed Smithy data shapes to Avrotize Schema."""
+
+    def __init__(self, namespace: str | None = None) -> None:
+        self.namespace = namespace
+        self.shapes: dict[str, SmithyShape] = {}
+
+    def convert_text(self, text: str) -> list[dict[str, Any]]:
+        parsed_namespace, shapes = SmithyIdlParser(text).parse()
+        self.namespace = self.namespace or parsed_namespace or "smithy"
+        self.shapes = {shape.name: shape for shape in shapes}
+        schemas = [self.shape_to_avro(shape) for shape in shapes]
+        return sort_messages_by_dependencies([schema for schema in schemas if schema is not None])
+
+    def shape_to_avro(self, shape: SmithyShape) -> dict[str, Any]:
+        if shape.kind == "structure":
+            return self.structure_to_avro(shape)
+        if shape.kind == "union":
+            return self.union_to_avro(shape)
+        if shape.kind == "enum":
+            return self.enum_to_avro(shape, int_enum=False)
+        if shape.kind == "intEnum":
+            return self.enum_to_avro(shape, int_enum=True)
+        if shape.kind == "list":
+            return self.collection_wrapper_to_avro(shape, "list")
+        if shape.kind == "map":
+            return self.collection_wrapper_to_avro(shape, "map")
+        raise ValueError(f"Unsupported Smithy shape kind: {shape.kind}")
+
+    def base_named_schema(self, shape: SmithyShape, avro_type: str = "record") -> dict[str, Any]:
+        schema: dict[str, Any] = {"type": avro_type, "name": shape.name, "namespace": self.namespace}
+        doc = trait_doc(shape.traits)
+        if doc:
+            schema["doc"] = doc
+        return schema
+
+    def structure_to_avro(self, shape: SmithyShape) -> dict[str, Any]:
+        schema = self.base_named_schema(shape)
+        schema["fields"] = [self.member_to_field(member) for member in shape.members]
+        deps = self.dependencies_for_members(shape.members)
+        if deps:
+            schema["dependencies"] = deps
+        return schema
+
+    def union_to_avro(self, shape: SmithyShape) -> dict[str, Any]:
+        schema = self.base_named_schema(shape)
+        schema["smithyShape"] = "union"
+        schema["fields"] = []
+        for member in shape.members:
+            field_schema = self.member_to_field(member, force_optional=True)
+            schema["fields"].append(field_schema)
+        deps = self.dependencies_for_members(shape.members)
+        if deps:
+            schema["dependencies"] = deps
+        return schema
+
+    def enum_to_avro(self, shape: SmithyShape, int_enum: bool) -> dict[str, Any]:
+        schema = self.base_named_schema(shape, "enum")
+        schema["symbols"] = [symbol for symbol, _ in shape.enum_values]
+        if int_enum:
+            schema["ordinals"] = {symbol: (idx if value is None else value) for idx, (symbol, value) in enumerate(shape.enum_values)}
+            schema["smithyShape"] = "intEnum"
+        return schema
+
+    def collection_wrapper_to_avro(self, shape: SmithyShape, kind: str) -> dict[str, Any]:
+        schema = self.base_named_schema(shape)
+        schema["smithyShape"] = kind
+        if kind == "list":
+            field_type = {"type": "array", "items": self.smithy_type_to_avro(shape.member_type or "Document")}
+            members = shape.members or [{"name": "member", "type": shape.member_type or "Document", "traits": {}}]
+            doc = trait_doc(members[0].get("traits", {})) if members else None
+            field_schema: dict[str, Any] = {"name": "member", "type": field_type}
+            if doc:
+                field_schema["doc"] = doc
+            schema["fields"] = [field_schema]
+        else:
+            if shape.key_type and self.simple_type_name(shape.key_type) != "String":
+                note = "Smithy map keys must be String for Avro map conversion; original key type was " + shape.key_type
+                schema["doc"] = (schema.get("doc", "") + " " + note).strip()
+            field_type = {"type": "map", "values": self.smithy_type_to_avro(shape.value_type or "Document")}
+            schema["fields"] = [{"name": "entries", "type": field_type}]
+        deps = self.dependencies_for_members(shape.members)
+        if deps:
+            schema["dependencies"] = deps
+        return schema
+
+    def member_to_field(self, member: dict[str, Any], force_optional: bool = False) -> dict[str, Any]:
+        traits = member.get("traits", {})
+        avro_type = self.smithy_type_to_avro(member["type"])
+        required = bool(traits.get("required")) and not force_optional
+        default_provided = "default" in traits
+        field_schema: dict[str, Any] = {"name": member["name"]}
+        doc = trait_doc(traits)
+        if doc:
+            field_schema["doc"] = doc
+        if required:
+            field_schema["type"] = avro_type
+            if default_provided:
+                field_schema["default"] = avro_default(traits["default"], avro_type)
+        else:
+            if default_provided and traits["default"] is not None:
+                field_schema["type"] = [avro_type, "null"]
+                field_schema["default"] = avro_default(traits["default"], avro_type)
+            else:
+                field_schema["type"] = ["null", avro_type]
+                field_schema["default"] = None
+        return field_schema
+
+    def smithy_type_to_avro(self, smithy_type: str) -> AvroType:
+        name = self.simple_type_name(smithy_type)
+        if name in SMITHY_TO_AVRO_PRIMITIVES:
+            value = SMITHY_TO_AVRO_PRIMITIVES[name]
+            return dict(value) if isinstance(value, dict) else value
+        shape = self.shapes.get(sanitize_name(name))
+        if shape and shape.kind == "list":
+            return {"type": "array", "items": self.smithy_type_to_avro(shape.member_type or "Document")}
+        if shape and shape.kind == "map":
+            return {"type": "map", "values": self.smithy_type_to_avro(shape.value_type or "Document")}
+        return sanitize_name(name)
+
+    @staticmethod
+    def simple_type_name(smithy_type: str) -> str:
+        return smithy_type.split("#")[-1].split(".")[-1]
+
+    def dependencies_for_members(self, members: list[dict[str, Any]]) -> list[str]:
+        deps: list[str] = []
+        for member in members:
+            self.collect_dependency(member.get("type"), deps)
+        return deps
+
+    def collect_dependency(self, smithy_type: str | None, deps: list[str]) -> None:
+        if not smithy_type:
+            return
+        name = sanitize_name(self.simple_type_name(smithy_type))
+        if name in SMITHY_TO_AVRO_PRIMITIVES:
+            return
+        shape = self.shapes.get(name)
+        if shape and shape.kind in {"list", "map"}:
+            for member in shape.members:
+                self.collect_dependency(member.get("type"), deps)
+            return
+        qname = f"{self.namespace}.{name}" if self.namespace else name
+        if qname not in deps:
+            deps.append(qname)
+
+
+def trait_doc(traits: dict[str, Any]) -> str | None:
+    parts: list[str] = []
+    if isinstance(traits.get("documentation"), str):
+        parts.append(traits["documentation"])
+    if traits.get("deprecated"):
+        parts.append("Deprecated.")
+    if traits.get("tags"):
+        parts.append(f"Tags: {traits['tags']}")
+    return " ".join(parts) or None
+
+
+def avro_default(value: Any, avro_type: AvroType) -> Any:
+    if isinstance(avro_type, dict) and avro_type.get("logicalType") == "timestamp-millis":
+        return int(value) if isinstance(value, (int, float, str)) and str(value).lstrip("-").isdigit() else value
+    return value
+
+
+def convert_smithy_to_avro_schema(smithy_text: str, namespace: str | None = None) -> list[dict[str, Any]]:
+    """Convert Smithy IDL text to an Avrotize Schema object."""
+    return SmithyToAvroConverter(namespace).convert_text(smithy_text)
+
+
+def convert_smithy_to_avro(smithy_file_path: str, avro_schema_path: str, namespace: str | None = None) -> None:
+    """Convert a Smithy IDL file to an Avrotize Schema JSON file."""
+    with open(smithy_file_path, "r", encoding="utf-8") as smithy_file:
+        smithy_text = smithy_file.read()
+    avro_schema = convert_smithy_to_avro_schema(smithy_text, namespace)
+    output_dir = os.path.dirname(os.path.abspath(avro_schema_path))
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+    with open(avro_schema_path, "w", encoding="utf-8") as avro_file:
+        json.dump(avro_schema, avro_file, indent=2)
+        avro_file.write("\n")
+

--- a/avrotize/smithytojstruct.py
+++ b/avrotize/smithytojstruct.py
@@ -1,0 +1,24 @@
+"""Bridge Smithy IDL to JSON Structure through Avrotize Schema."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+from avrotize.avrotojstruct import convert_avro_to_json_structure
+from avrotize.smithytoavro import convert_smithy_to_avro
+
+
+def convert_smithy_to_json_structure(smithy_file_path: str, json_structure_file: str, namespace: str | None = None) -> None:
+    """Convert Smithy data shapes to JSON Structure via a temporary Avrotize Schema file."""
+    temp_dir = os.path.dirname(os.path.abspath(json_structure_file)) or os.getcwd()
+    os.makedirs(temp_dir, exist_ok=True)
+    temp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".avsc", delete=False, dir=temp_dir) as temp_file:
+            temp_path = temp_file.name
+        convert_smithy_to_avro(smithy_file_path, temp_path, namespace=namespace)
+        convert_avro_to_json_structure(temp_path, json_structure_file)
+    finally:
+        if temp_path and os.path.exists(temp_path):
+            os.remove(temp_path)

--- a/test/smithy/model.smithy
+++ b/test/smithy/model.smithy
@@ -1,0 +1,56 @@
+$version: "2.0"
+namespace com.example
+
+@documentation("Postal address")
+structure Address {
+    @required
+    street: String
+    city: String
+}
+
+@documentation("Person data")
+structure Person {
+    @required
+    name: String
+    age: Integer
+    address: Address
+    tags: Tags
+    favorite: Color
+    createdAt: Timestamp
+}
+
+enum Color {
+    RED
+    GREEN
+    BLUE
+}
+
+intEnum Status {
+    OK = 0
+    ERROR = 9
+}
+
+list Names {
+    member: String
+}
+
+map Tags {
+    key: String
+    value: String
+}
+
+union Payload {
+    text: String
+    count: Integer
+    address: Address
+}
+
+service ExampleService {
+    version: "2026-06-19"
+    operations: [GetPerson]
+}
+
+operation GetPerson {
+    input: Person
+    output: Person
+}

--- a/test/test_smithytoavro.py
+++ b/test/test_smithytoavro.py
@@ -1,0 +1,224 @@
+import json
+import os
+import shutil
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+from fastavro import parse_schema
+
+from avrotize.avrotosmithy import convert_avro_to_smithy, convert_avro_to_smithy_schema
+from avrotize.jstructtosmithy import convert_json_structure_to_smithy
+from avrotize.smithytoavro import convert_smithy_to_avro, convert_smithy_to_avro_schema
+from avrotize.smithytojstruct import convert_smithy_to_json_structure
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_DIR = ROOT / "test" / "smithy"
+MODEL = FIXTURE_DIR / "model.smithy"
+OUT_DIR = FIXTURE_DIR / "generated"
+
+
+class TestSmithyToAvro(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if OUT_DIR.exists():
+            shutil.rmtree(OUT_DIR)
+        OUT_DIR.mkdir(parents=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        if OUT_DIR.exists():
+            shutil.rmtree(OUT_DIR)
+
+    def convert(self, text):
+        return convert_smithy_to_avro_schema(text)
+
+    def by_name(self, schema, name):
+        return next(item for item in schema if isinstance(item, dict) and item.get("name") == name)
+
+    def test_import_resolves_to_worktree(self):
+        import avrotize
+        self.assertTrue(str(avrotize.__file__).startswith(str(ROOT)))
+
+    def test_namespace_maps_to_avro_namespace(self):
+        schema = self.convert('namespace com.example\nstructure Foo { name: String }')
+        self.assertEqual(self.by_name(schema, "Foo")["namespace"], "com.example")
+
+    def test_all_simple_shapes_are_mapped(self):
+        smithy = '''namespace com.example
+structure Scalars {
+    blob: Blob
+    bool: Boolean
+    text: String
+    byteValue: Byte
+    shortValue: Short
+    intValue: Integer
+    longValue: Long
+    floatValue: Float
+    doubleValue: Double
+    bigInteger: BigInteger
+    bigDecimal: BigDecimal
+    timestamp: Timestamp
+    document: Document
+}'''
+        record = self.by_name(self.convert(smithy), "Scalars")
+        fields = {field["name"]: field["type"][1] for field in record["fields"]}
+        self.assertEqual(fields["blob"], "bytes")
+        self.assertEqual(fields["bool"], "boolean")
+        self.assertEqual(fields["text"], "string")
+        self.assertEqual(fields["byteValue"], "int")
+        self.assertEqual(fields["shortValue"], "int")
+        self.assertEqual(fields["intValue"], "int")
+        self.assertEqual(fields["longValue"], "long")
+        self.assertEqual(fields["floatValue"], "float")
+        self.assertEqual(fields["doubleValue"], "double")
+        self.assertEqual(fields["bigInteger"], "string")
+        self.assertEqual(fields["bigDecimal"], "double")
+        self.assertEqual(fields["timestamp"], {"type": "long", "logicalType": "timestamp-millis"})
+        self.assertEqual(fields["document"], "string")
+
+    def test_required_and_optional_nullability(self):
+        record = self.by_name(self.convert('namespace com.example\nstructure Foo { @required id: String, nick: String }'), "Foo")
+        fields = {field["name"]: field for field in record["fields"]}
+        self.assertEqual(fields["id"]["type"], "string")
+        self.assertEqual(fields["nick"]["type"], ["null", "string"])
+        self.assertIsNone(fields["nick"]["default"])
+
+    def test_default_trait_is_preserved(self):
+        record = self.by_name(self.convert('namespace com.example\nstructure Foo { @default("guest") nick: String }'), "Foo")
+        field = record["fields"][0]
+        self.assertEqual(field["type"], ["string", "null"])
+        self.assertEqual(field["default"], "guest")
+        parse_schema(record)
+
+    def test_documentation_trait_maps_to_doc(self):
+        record = self.by_name(self.convert('namespace com.example\n@documentation("Doc")\nstructure Foo { @documentation("Field doc") name: String }'), "Foo")
+        self.assertEqual(record["doc"], "Doc")
+        self.assertEqual(record["fields"][0]["doc"], "Field doc")
+
+    def test_enum_and_int_enum(self):
+        schema = self.convert('namespace com.example\nenum Color { RED, GREEN }\nintEnum Status { OK = 0, ERROR = 9 }')
+        color = self.by_name(schema, "Color")
+        status = self.by_name(schema, "Status")
+        self.assertEqual(color["type"], "enum")
+        self.assertEqual(color["symbols"], ["RED", "GREEN"])
+        self.assertEqual(status["ordinals"], {"OK": 0, "ERROR": 9})
+
+    def test_union_shape_preserves_member_names(self):
+        payload = self.by_name(self.convert('namespace com.example\nunion Payload { text: String, count: Integer }'), "Payload")
+        self.assertEqual(payload["smithyShape"], "union")
+        self.assertEqual([field["name"] for field in payload["fields"]], ["text", "count"])
+        self.assertEqual(payload["fields"][0]["type"], ["null", "string"])
+
+    def test_list_shape_maps_to_avro_array(self):
+        names = self.by_name(self.convert('namespace com.example\nlist Names { member: String }'), "Names")
+        self.assertEqual(names["smithyShape"], "list")
+        self.assertEqual(names["fields"][0]["type"], {"type": "array", "items": "string"})
+
+    def test_map_shape_maps_to_avro_map(self):
+        tags = self.by_name(self.convert('namespace com.example\nmap Tags { key: String, value: Integer }'), "Tags")
+        self.assertEqual(tags["smithyShape"], "map")
+        self.assertEqual(tags["fields"][0]["type"], {"type": "map", "values": "int"})
+
+    def test_nested_structures_and_references(self):
+        schema = self.convert('namespace com.example\nstructure Address { city: String }\nstructure Person { @required address: Address }')
+        parse_schema(schema)
+        person = self.by_name(schema, "Person")
+        self.assertEqual(person["fields"][0]["type"], "Address")
+
+    def test_named_list_and_map_references_inline_as_array_and_map(self):
+        schema = self.convert('namespace com.example\nlist Names { member: String }\nmap Scores { key: String, value: Integer }\nstructure Foo { names: Names, scores: Scores }')
+        foo = self.by_name(schema, "Foo")
+        fields = {field["name"]: field["type"][1] for field in foo["fields"]}
+        self.assertEqual(fields["names"], {"type": "array", "items": "string"})
+        self.assertEqual(fields["scores"], {"type": "map", "values": "int"})
+
+    def test_timestamp_logical_type_is_valid(self):
+        schema = self.convert('namespace com.example\nstructure Event { @required time: Timestamp }')
+        parse_schema(schema)
+        event = self.by_name(schema, "Event")
+        self.assertEqual(event["fields"][0]["type"], {"type": "long", "logicalType": "timestamp-millis"})
+
+    def test_out_of_scope_service_and_operation_are_skipped(self):
+        schema = self.convert('namespace com.example\nstructure Foo { name: String }\nservice S { operations: [Get] }\noperation Get { input: Foo, output: Foo }')
+        self.assertEqual([item["name"] for item in schema], ["Foo"])
+        parse_schema(schema)
+
+    def test_metadata_and_apply_are_skipped_without_consuming_shapes(self):
+        schema = self.convert('namespace com.example\nmetadata foo = "bar"\napply Foo @deprecated\nstructure Foo { name: String }')
+        self.assertEqual([item["name"] for item in schema], ["Foo"])
+        parse_schema(schema)
+
+    def test_fixture_avro_is_valid(self):
+        output = OUT_DIR / "model.avsc"
+        convert_smithy_to_avro(str(MODEL), str(output))
+        schema = json.loads(output.read_text(encoding="utf-8"))
+        parse_schema(schema)
+        self.assertIn("Person", [item["name"] for item in schema])
+
+    def test_avro_to_smithy_emits_parseable_smithy(self):
+        avro = [{"type": "record", "name": "Person", "namespace": "com.example", "fields": [{"name": "name", "type": "string"}, {"name": "age", "type": ["null", "int"], "default": None}]}]
+        text = convert_avro_to_smithy_schema(avro)
+        self.assertIn('$version: "2.0"', text)
+        self.assertIn("namespace com.example", text)
+        self.assertIn("@required", text)
+        reparsed = convert_smithy_to_avro_schema(text)
+        self.assertEqual(self.by_name(reparsed, "Person")["fields"][0]["type"], "string")
+
+    def test_avro_enum_array_map_union_to_smithy(self):
+        avro = [
+            {"type": "enum", "name": "Color", "namespace": "com.example", "symbols": ["RED", "GREEN"]},
+            {"type": "record", "name": "Foo", "namespace": "com.example", "fields": [
+                {"name": "colors", "type": {"type": "array", "items": "Color"}},
+                {"name": "tags", "type": {"type": "map", "values": "string"}},
+                {"name": "choice", "type": ["string", "int"]},
+            ]},
+        ]
+        text = convert_avro_to_smithy_schema(avro)
+        self.assertIn("enum Color", text)
+        self.assertIn("list FooColorsList", text)
+        self.assertIn("map FooTagsMap", text)
+        self.assertIn("union FooChoiceUnion", text)
+
+    def test_round_trip_preserves_data_shapes(self):
+        first = json.loads((OUT_DIR / "roundtrip1.avsc").read_text(encoding="utf-8")) if (OUT_DIR / "roundtrip1.avsc").exists() else None
+        source_avro = convert_smithy_to_avro_schema(MODEL.read_text(encoding="utf-8"))
+        smithy_text = convert_avro_to_smithy_schema(source_avro)
+        second_avro = convert_smithy_to_avro_schema(smithy_text)
+        self.assertEqual({item["name"] for item in source_avro}, {item["name"] for item in second_avro})
+        self.assertEqual(self.by_name(second_avro, "Payload")["smithyShape"], "union")
+        parse_schema(second_avro)
+
+    def test_smithy_to_json_structure_bridge(self):
+        output = OUT_DIR / "model.struct.json"
+        convert_smithy_to_json_structure(str(MODEL), str(output))
+        data = json.loads(output.read_text(encoding="utf-8"))
+        self.assertIsInstance(data, dict)
+        self.assertTrue(data)
+
+    def test_json_structure_to_smithy_bridge(self):
+        struct_path = OUT_DIR / "bridge.struct.json"
+        smithy_path = OUT_DIR / "bridge.smithy"
+        convert_smithy_to_json_structure(str(MODEL), str(struct_path))
+        convert_json_structure_to_smithy(str(struct_path), str(smithy_path), namespace="com.example.bridge")
+        text = smithy_path.read_text(encoding="utf-8")
+        self.assertIn("namespace com.example.bridge", text)
+        self.assertIn("structure", text)
+
+    def test_cli_smoke_smithy2a(self):
+        output = OUT_DIR / "cli.avsc"
+        result = subprocess.run(
+            [sys.executable, "-m", "avrotize", "smithy2a", str(MODEL), "--out", str(output)],
+            cwd=str(ROOT),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        parse_schema(json.loads(output.read_text(encoding="utf-8")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #259 — Smithy IDL support (phase-1 data shapes).

## Commands
- `smithy2a` Smithy IDL → Avrotize (Avro) schema
- `a2smithy` Avro schema → Smithy model
- `smithy2s` Smithy IDL → JSON Structure (bridged via Avro)
- `s2smithy` JSON Structure → Smithy (bridged via Avro)

## Mapping
`structure`→record (`@required` vs optional → nullability/defaults), `union`→Avro union, `enum`/`intEnum`→enum, `list`→array, `map`→map, simple shapes (Blob/Boolean/String/Byte/Short/Integer/Long/Float/Double/BigInteger/BigDecimal/Timestamp/Document) → valid Avro (Timestamp→`timestamp-millis`), references resolved, `@documentation`→doc, `@default`→field default, `namespace` preserved.

## Tests
22 tests (`test/test_smithytoavro.py`): each simple shape, structure required/optional, union, enum, list, map, nested, references, `@documentation`, namespace, Timestamp logical type, reverse (avro→smithy), round-trip, JSON Structure bridge, graceful skip of out-of-scope `service`/`operation`, Avro validity via `fastavro.parse_schema`, CLI smoke. **22 passed.**

## Documented limitations (phase 1)
Data shapes only. Out of scope (skipped gracefully): `service`, `operation`, `resource`, protocol/HTTP traits, mixins beyond simple cases, `apply`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>