### PR TITLE
fix(a2k): correctly-escaped Kusto docstrings (#317)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ All notable changes to Avrotize are documented in this file.
 
 ### Fixed
 
+- **Kusto docstring escaping (issue #317)**: `a2k` and `s2k` now emit table
+  and column docstrings as single-encoded KQL string literals, avoiding invalid
+  double-escaped quote sequences in generated `.kql`.
 - **int64/uint64/int128/uint128/decimal JSON string serialization (issue #346)**:
   All language code generators now serialize these types as JSON strings (not
   numbers) per the JSON Structure Core spec, since IEEE-754 doubles cannot

--- a/avrotize/avrotokusto.py
+++ b/avrotize/avrotokusto.py
@@ -7,6 +7,16 @@ from avrotize.common import build_flat_type_dict, inline_avro_references, strip_
 from azure.kusto.data import KustoClient, KustoConnectionStringBuilder, ClientRequestProperties
 
 
+def kusto_string_literal(value: str) -> str:
+    """Return a KQL verbatim string literal for a raw Python string."""
+    return '@"' + value.replace('"', '""') + '"'
+
+
+def kusto_json_literal(value: Any) -> str:
+    """Return a KQL string literal containing one JSON encoding of value."""
+    return kusto_string_literal(json.dumps(value))
+
+
 class AvroToKusto:
     """Converts an Avro schema to a Kusto table schema."""
 
@@ -60,9 +70,9 @@ class AvroToKusto:
         if "doc" in recordschema:
             doc_data = recordschema["doc"]
             doc_data = (doc_data[:997] + "...") if len(doc_data) > 1000 else doc_data
-            doc_string = json.dumps(json.dumps({
+            doc_string = kusto_json_literal({
                 "description": doc_data
-            }))
+            })
             kusto.append(
                 f".alter table {table_ref} docstring {doc_string};")
             kusto.append("")
@@ -89,7 +99,7 @@ class AvroToKusto:
                             doc_content["schema"] = inline_schema
                     else:
                         doc_content["schema"] = inline_schema
-                doc = json.dumps(json.dumps(doc_content))
+                doc = kusto_json_literal(doc_content)
                 doc_string_statement.append(f"   [{column_name}]: {doc}")
         if doc_string_statement and emit_cloudevents_columns:
             doc_string_statement.extend([

--- a/avrotize/structuretokusto.py
+++ b/avrotize/structuretokusto.py
@@ -7,6 +7,16 @@ from avrotize.common import build_flat_type_dict, inline_avro_references, strip_
 from azure.kusto.data import KustoClient, KustoConnectionStringBuilder, ClientRequestProperties
 
 
+def kusto_string_literal(value: str) -> str:
+    """Return a KQL verbatim string literal for a raw Python string."""
+    return '@"' + value.replace('"', '""') + '"'
+
+
+def kusto_json_literal(value: Any) -> str:
+    """Return a KQL string literal containing one JSON encoding of value."""
+    return kusto_string_literal(json.dumps(value))
+
+
 class StructureToKusto:
     """Converts a JSON Structure schema to a Kusto table schema."""
 
@@ -284,9 +294,9 @@ class StructureToKusto:
             if notes:
                 doc_data = doc_data + " " + " ".join(notes)
             
-            doc_string = json.dumps(json.dumps({
+            doc_string = kusto_json_literal({
                 "description": doc_data
-            }))
+            })
             kusto.append(
                 f".alter table {table_ref} docstring {doc_string};")
             kusto.append("")
@@ -304,7 +314,7 @@ class StructureToKusto:
                 else:
                     doc_data = f"Constant field with value: {json.dumps(const_value)}"
                 doc_content = {"description": doc_data}
-                doc = json.dumps(json.dumps(doc_content))
+                doc = kusto_json_literal(doc_content)
                 # Add as comment - const fields are not stored in table
                 kusto.insert(len(kusto) - (2 if kusto and kusto[-1] == "" else 1), 
                            f"-- Const field '{column_name}' with value: {json.dumps(const_value)}")
@@ -323,7 +333,7 @@ class StructureToKusto:
                         doc_content["schema"] = '{ "doc": "Schema too large to inline. Please refer to the JSON Structure schema for more details." }'
                     else:
                         doc_content["schema"] = prop_schema
-                doc = json.dumps(json.dumps(doc_content))
+                doc = kusto_json_literal(doc_content)
                 doc_string_statement.append(f"   [{column_name}]: {doc}")
         if doc_string_statement and emit_cloudevents_columns:
             doc_string_statement.extend([

--- a/test/avsc/address-ce-dt-ref.kql
+++ b/test/avsc/address-ce-dt-ref.kql
@@ -43,17 +43,17 @@
    [___subject]: string
 );
 
-.alter table [record] docstring "{\"description\": \"An address similar to http://microformats.org/wiki/h-card\"}";
+.alter table [record] docstring @"{""description"": ""An address similar to http://microformats.org/wiki/h-card""}";
 
 .alter table [record] column-docstrings (
-   [type]: "{\"description\": \"The type of the record\"}",
-   [postOfficeBox]: "{\"description\": \"The post office box number\", \"schema\": [\"null\", \"string\"]}",
-   [extendedAddress]: "{\"description\": \"The extended address\", \"schema\": [\"null\", \"string\"]}",
-   [streetAddress]: "{\"description\": \"The street address\", \"schema\": [\"null\", \"string\"]}",
-   [locality]: "{\"description\": \"The locality\"}",
-   [region]: "{\"description\": \"The region\"}",
-   [postalCode]: "{\"description\": \"The postal code\", \"schema\": [\"null\", \"string\"]}",
-   [countryName]: "{\"description\": \"The country name\"}",
+   [type]: @"{""description"": ""The type of the record""}",
+   [postOfficeBox]: @"{""description"": ""The post office box number"", ""schema"": [""null"", ""string""]}",
+   [extendedAddress]: @"{""description"": ""The extended address"", ""schema"": [""null"", ""string""]}",
+   [streetAddress]: @"{""description"": ""The street address"", ""schema"": [""null"", ""string""]}",
+   [locality]: @"{""description"": ""The locality""}",
+   [region]: @"{""description"": ""The region""}",
+   [postalCode]: @"{""description"": ""The postal code"", ""schema"": [""null"", ""string""]}",
+   [countryName]: @"{""description"": ""The country name""}",
    [___type] : 'Event type',
    [___source]: 'Context origin/source of the event',
    [___id]: 'Event identifier',

--- a/test/avsc/address-ce-dt-struct-ref.kql
+++ b/test/avsc/address-ce-dt-struct-ref.kql
@@ -43,17 +43,17 @@
    [___subject]: string
 );
 
-.alter table [record] docstring "{\"description\": \"An address similar to http://microformats.org/wiki/h-card\"}";
+.alter table [record] docstring @"{""description"": ""An address similar to http://microformats.org/wiki/h-card""}";
 
 .alter table [record] column-docstrings (
-   [type]: "{\"description\": \"The type of the record\"}",
-   [postOfficeBox]: "{\"description\": \"The post office box number\"}",
-   [extendedAddress]: "{\"description\": \"The extended address\"}",
-   [streetAddress]: "{\"description\": \"The street address\"}",
-   [locality]: "{\"description\": \"The locality\"}",
-   [region]: "{\"description\": \"The region\"}",
-   [postalCode]: "{\"description\": \"The postal code\"}",
-   [countryName]: "{\"description\": \"The country name\"}",
+   [type]: @"{""description"": ""The type of the record""}",
+   [postOfficeBox]: @"{""description"": ""The post office box number""}",
+   [extendedAddress]: @"{""description"": ""The extended address""}",
+   [streetAddress]: @"{""description"": ""The street address""}",
+   [locality]: @"{""description"": ""The locality""}",
+   [region]: @"{""description"": ""The region""}",
+   [postalCode]: @"{""description"": ""The postal code""}",
+   [countryName]: @"{""description"": ""The country name""}",
    [___type] : 'Event type',
    [___source]: 'Context origin/source of the event',
    [___id]: 'Event identifier',

--- a/test/avsc/address-ce-ref.kql
+++ b/test/avsc/address-ce-ref.kql
@@ -14,17 +14,17 @@
    [___subject]: string
 );
 
-.alter table [record] docstring "{\"description\": \"An address similar to http://microformats.org/wiki/h-card\"}";
+.alter table [record] docstring @"{""description"": ""An address similar to http://microformats.org/wiki/h-card""}";
 
 .alter table [record] column-docstrings (
-   [type]: "{\"description\": \"The type of the record\"}",
-   [postOfficeBox]: "{\"description\": \"The post office box number\", \"schema\": [\"null\", \"string\"]}",
-   [extendedAddress]: "{\"description\": \"The extended address\", \"schema\": [\"null\", \"string\"]}",
-   [streetAddress]: "{\"description\": \"The street address\", \"schema\": [\"null\", \"string\"]}",
-   [locality]: "{\"description\": \"The locality\"}",
-   [region]: "{\"description\": \"The region\"}",
-   [postalCode]: "{\"description\": \"The postal code\", \"schema\": [\"null\", \"string\"]}",
-   [countryName]: "{\"description\": \"The country name\"}",
+   [type]: @"{""description"": ""The type of the record""}",
+   [postOfficeBox]: @"{""description"": ""The post office box number"", ""schema"": [""null"", ""string""]}",
+   [extendedAddress]: @"{""description"": ""The extended address"", ""schema"": [""null"", ""string""]}",
+   [streetAddress]: @"{""description"": ""The street address"", ""schema"": [""null"", ""string""]}",
+   [locality]: @"{""description"": ""The locality""}",
+   [region]: @"{""description"": ""The region""}",
+   [postalCode]: @"{""description"": ""The postal code"", ""schema"": [""null"", ""string""]}",
+   [countryName]: @"{""description"": ""The country name""}",
    [___type] : 'Event type',
    [___source]: 'Context origin/source of the event',
    [___id]: 'Event identifier',

--- a/test/avsc/address-ce-struct-ref.kql
+++ b/test/avsc/address-ce-struct-ref.kql
@@ -14,17 +14,17 @@
    [___subject]: string
 );
 
-.alter table [record] docstring "{\"description\": \"An address similar to http://microformats.org/wiki/h-card\"}";
+.alter table [record] docstring @"{""description"": ""An address similar to http://microformats.org/wiki/h-card""}";
 
 .alter table [record] column-docstrings (
-   [type]: "{\"description\": \"The type of the record\"}",
-   [postOfficeBox]: "{\"description\": \"The post office box number\"}",
-   [extendedAddress]: "{\"description\": \"The extended address\"}",
-   [streetAddress]: "{\"description\": \"The street address\"}",
-   [locality]: "{\"description\": \"The locality\"}",
-   [region]: "{\"description\": \"The region\"}",
-   [postalCode]: "{\"description\": \"The postal code\"}",
-   [countryName]: "{\"description\": \"The country name\"}",
+   [type]: @"{""description"": ""The type of the record""}",
+   [postOfficeBox]: @"{""description"": ""The post office box number""}",
+   [extendedAddress]: @"{""description"": ""The extended address""}",
+   [streetAddress]: @"{""description"": ""The street address""}",
+   [locality]: @"{""description"": ""The locality""}",
+   [region]: @"{""description"": ""The region""}",
+   [postalCode]: @"{""description"": ""The postal code""}",
+   [countryName]: @"{""description"": ""The country name""}",
    [___type] : 'Event type',
    [___source]: 'Context origin/source of the event',
    [___id]: 'Event identifier',

--- a/test/avsc/address-ref.kql
+++ b/test/avsc/address-ref.kql
@@ -9,17 +9,17 @@
    [countryName]: string
 );
 
-.alter table [record] docstring "{\"description\": \"An address similar to http://microformats.org/wiki/h-card\"}";
+.alter table [record] docstring @"{""description"": ""An address similar to http://microformats.org/wiki/h-card""}";
 
 .alter table [record] column-docstrings (
-   [type]: "{\"description\": \"The type of the record\"}",
-   [postOfficeBox]: "{\"description\": \"The post office box number\", \"schema\": [\"null\", \"string\"]}",
-   [extendedAddress]: "{\"description\": \"The extended address\", \"schema\": [\"null\", \"string\"]}",
-   [streetAddress]: "{\"description\": \"The street address\", \"schema\": [\"null\", \"string\"]}",
-   [locality]: "{\"description\": \"The locality\"}",
-   [region]: "{\"description\": \"The region\"}",
-   [postalCode]: "{\"description\": \"The postal code\", \"schema\": [\"null\", \"string\"]}",
-   [countryName]: "{\"description\": \"The country name\"}"
+   [type]: @"{""description"": ""The type of the record""}",
+   [postOfficeBox]: @"{""description"": ""The post office box number"", ""schema"": [""null"", ""string""]}",
+   [extendedAddress]: @"{""description"": ""The extended address"", ""schema"": [""null"", ""string""]}",
+   [streetAddress]: @"{""description"": ""The street address"", ""schema"": [""null"", ""string""]}",
+   [locality]: @"{""description"": ""The locality""}",
+   [region]: @"{""description"": ""The region""}",
+   [postalCode]: @"{""description"": ""The postal code"", ""schema"": [""null"", ""string""]}",
+   [countryName]: @"{""description"": ""The country name""}"
 );
 
 .create-or-alter table [record] ingestion json mapping "record_json_flat"

--- a/test/avsc/address-struct-ref.kql
+++ b/test/avsc/address-struct-ref.kql
@@ -9,17 +9,17 @@
    [countryName]: string
 );
 
-.alter table [record] docstring "{\"description\": \"An address similar to http://microformats.org/wiki/h-card\"}";
+.alter table [record] docstring @"{""description"": ""An address similar to http://microformats.org/wiki/h-card""}";
 
 .alter table [record] column-docstrings (
-   [type]: "{\"description\": \"The type of the record\"}",
-   [postOfficeBox]: "{\"description\": \"The post office box number\"}",
-   [extendedAddress]: "{\"description\": \"The extended address\"}",
-   [streetAddress]: "{\"description\": \"The street address\"}",
-   [locality]: "{\"description\": \"The locality\"}",
-   [region]: "{\"description\": \"The region\"}",
-   [postalCode]: "{\"description\": \"The postal code\"}",
-   [countryName]: "{\"description\": \"The country name\"}"
+   [type]: @"{""description"": ""The type of the record""}",
+   [postOfficeBox]: @"{""description"": ""The post office box number""}",
+   [extendedAddress]: @"{""description"": ""The extended address""}",
+   [streetAddress]: @"{""description"": ""The street address""}",
+   [locality]: @"{""description"": ""The locality""}",
+   [region]: @"{""description"": ""The region""}",
+   [postalCode]: @"{""description"": ""The postal code""}",
+   [countryName]: @"{""description"": ""The country name""}"
 );
 
 .create-or-alter table [record] ingestion json mapping "record_json_flat"

--- a/test/avsc/telemetry-ce-dt-ref.kql
+++ b/test/avsc/telemetry-ce-dt-ref.kql
@@ -46,20 +46,20 @@
    [___subject]: string
 );
 
-.alter table [TelemetryRecord] docstring "{\"description\": \"Represents a telemetry record for a race car.\"}";
+.alter table [TelemetryRecord] docstring @"{""description"": ""Represents a telemetry record for a race car.""}";
 
 .alter table [TelemetryRecord] column-docstrings (
-   [id]: "{\"description\": \"The unique identifier of the telemetry record.\", \"schema\": [\"null\", \"string\"]}",
-   [version]: "{\"description\": \"The version of the telemetry record.\"}",
-   [channel]: "{\"description\": \"The channel of the telemetry record.\"}",
-   [carId]: "{\"description\": \"The identifier of the race car.\", \"schema\": [\"null\", \"string\"]}",
-   [intervalId]: "{\"description\": \"The interval identifier of the telemetry record.\", \"schema\": [\"null\", \"string\"]}",
-   [sampleCount]: "{\"description\": \"The sample count of the telemetry record.\"}",
-   [frequency]: "{\"description\": \"The frequency of the telemetry record.\"}",
-   [created]: "{\"description\": \"The creation timestamp of the telemetry record.\", \"schema\": [\"null\", \"long\"]}",
-   [timespan]: "{\"description\": \"The timespan of the telemetry record.\", \"schema\": {\"name\": \"RecordRange\", \"type\": \"record\", \"fields\": [{\"name\": \"started\", \"type\": \"long\", \"doc\": \"The start timestamp of the telemetry record.\"}, {\"name\": \"ended\", \"type\": \"long\", \"doc\": \"The end timestamp of the telemetry record.\"}]}}",
-   [data]: "{\"description\": \"The telemetry data.\", \"schema\": {\"type\": \"array\", \"items\": \"double\"}}",
-   [lapId]: "{\"description\": \"The identifier of the lap.\", \"schema\": [\"null\", \"string\"]}",
+   [id]: @"{""description"": ""The unique identifier of the telemetry record."", ""schema"": [""null"", ""string""]}",
+   [version]: @"{""description"": ""The version of the telemetry record.""}",
+   [channel]: @"{""description"": ""The channel of the telemetry record.""}",
+   [carId]: @"{""description"": ""The identifier of the race car."", ""schema"": [""null"", ""string""]}",
+   [intervalId]: @"{""description"": ""The interval identifier of the telemetry record."", ""schema"": [""null"", ""string""]}",
+   [sampleCount]: @"{""description"": ""The sample count of the telemetry record.""}",
+   [frequency]: @"{""description"": ""The frequency of the telemetry record.""}",
+   [created]: @"{""description"": ""The creation timestamp of the telemetry record."", ""schema"": [""null"", ""long""]}",
+   [timespan]: @"{""description"": ""The timespan of the telemetry record."", ""schema"": {""name"": ""RecordRange"", ""type"": ""record"", ""fields"": [{""name"": ""started"", ""type"": ""long"", ""doc"": ""The start timestamp of the telemetry record.""}, {""name"": ""ended"", ""type"": ""long"", ""doc"": ""The end timestamp of the telemetry record.""}]}}",
+   [data]: @"{""description"": ""The telemetry data."", ""schema"": {""type"": ""array"", ""items"": ""double""}}",
+   [lapId]: @"{""description"": ""The identifier of the lap."", ""schema"": [""null"", ""string""]}",
    [___type] : 'Event type',
    [___source]: 'Context origin/source of the event',
    [___id]: 'Event identifier',

--- a/test/avsc/telemetry-ce-ref.kql
+++ b/test/avsc/telemetry-ce-ref.kql
@@ -17,20 +17,20 @@
    [___subject]: string
 );
 
-.alter table [TelemetryRecord] docstring "{\"description\": \"Represents a telemetry record for a race car.\"}";
+.alter table [TelemetryRecord] docstring @"{""description"": ""Represents a telemetry record for a race car.""}";
 
 .alter table [TelemetryRecord] column-docstrings (
-   [id]: "{\"description\": \"The unique identifier of the telemetry record.\", \"schema\": [\"null\", \"string\"]}",
-   [version]: "{\"description\": \"The version of the telemetry record.\"}",
-   [channel]: "{\"description\": \"The channel of the telemetry record.\"}",
-   [carId]: "{\"description\": \"The identifier of the race car.\", \"schema\": [\"null\", \"string\"]}",
-   [intervalId]: "{\"description\": \"The interval identifier of the telemetry record.\", \"schema\": [\"null\", \"string\"]}",
-   [sampleCount]: "{\"description\": \"The sample count of the telemetry record.\"}",
-   [frequency]: "{\"description\": \"The frequency of the telemetry record.\"}",
-   [created]: "{\"description\": \"The creation timestamp of the telemetry record.\", \"schema\": [\"null\", \"long\"]}",
-   [timespan]: "{\"description\": \"The timespan of the telemetry record.\", \"schema\": {\"name\": \"RecordRange\", \"type\": \"record\", \"fields\": [{\"name\": \"started\", \"type\": \"long\", \"doc\": \"The start timestamp of the telemetry record.\"}, {\"name\": \"ended\", \"type\": \"long\", \"doc\": \"The end timestamp of the telemetry record.\"}]}}",
-   [data]: "{\"description\": \"The telemetry data.\", \"schema\": {\"type\": \"array\", \"items\": \"double\"}}",
-   [lapId]: "{\"description\": \"The identifier of the lap.\", \"schema\": [\"null\", \"string\"]}",
+   [id]: @"{""description"": ""The unique identifier of the telemetry record."", ""schema"": [""null"", ""string""]}",
+   [version]: @"{""description"": ""The version of the telemetry record.""}",
+   [channel]: @"{""description"": ""The channel of the telemetry record.""}",
+   [carId]: @"{""description"": ""The identifier of the race car."", ""schema"": [""null"", ""string""]}",
+   [intervalId]: @"{""description"": ""The interval identifier of the telemetry record."", ""schema"": [""null"", ""string""]}",
+   [sampleCount]: @"{""description"": ""The sample count of the telemetry record.""}",
+   [frequency]: @"{""description"": ""The frequency of the telemetry record.""}",
+   [created]: @"{""description"": ""The creation timestamp of the telemetry record."", ""schema"": [""null"", ""long""]}",
+   [timespan]: @"{""description"": ""The timespan of the telemetry record."", ""schema"": {""name"": ""RecordRange"", ""type"": ""record"", ""fields"": [{""name"": ""started"", ""type"": ""long"", ""doc"": ""The start timestamp of the telemetry record.""}, {""name"": ""ended"", ""type"": ""long"", ""doc"": ""The end timestamp of the telemetry record.""}]}}",
+   [data]: @"{""description"": ""The telemetry data."", ""schema"": {""type"": ""array"", ""items"": ""double""}}",
+   [lapId]: @"{""description"": ""The identifier of the lap."", ""schema"": [""null"", ""string""]}",
    [___type] : 'Event type',
    [___source]: 'Context origin/source of the event',
    [___id]: 'Event identifier',

--- a/test/avsc/telemetry-ref.kql
+++ b/test/avsc/telemetry-ref.kql
@@ -12,20 +12,20 @@
    [lapId]: string
 );
 
-.alter table [TelemetryRecord] docstring "{\"description\": \"Represents a telemetry record for a race car.\"}";
+.alter table [TelemetryRecord] docstring @"{""description"": ""Represents a telemetry record for a race car.""}";
 
 .alter table [TelemetryRecord] column-docstrings (
-   [id]: "{\"description\": \"The unique identifier of the telemetry record.\", \"schema\": [\"null\", \"string\"]}",
-   [version]: "{\"description\": \"The version of the telemetry record.\"}",
-   [channel]: "{\"description\": \"The channel of the telemetry record.\"}",
-   [carId]: "{\"description\": \"The identifier of the race car.\", \"schema\": [\"null\", \"string\"]}",
-   [intervalId]: "{\"description\": \"The interval identifier of the telemetry record.\", \"schema\": [\"null\", \"string\"]}",
-   [sampleCount]: "{\"description\": \"The sample count of the telemetry record.\"}",
-   [frequency]: "{\"description\": \"The frequency of the telemetry record.\"}",
-   [created]: "{\"description\": \"The creation timestamp of the telemetry record.\", \"schema\": [\"null\", \"long\"]}",
-   [timespan]: "{\"description\": \"The timespan of the telemetry record.\", \"schema\": {\"name\": \"RecordRange\", \"type\": \"record\", \"fields\": [{\"name\": \"started\", \"type\": \"long\", \"doc\": \"The start timestamp of the telemetry record.\"}, {\"name\": \"ended\", \"type\": \"long\", \"doc\": \"The end timestamp of the telemetry record.\"}]}}",
-   [data]: "{\"description\": \"The telemetry data.\", \"schema\": {\"type\": \"array\", \"items\": \"double\"}}",
-   [lapId]: "{\"description\": \"The identifier of the lap.\", \"schema\": [\"null\", \"string\"]}"
+   [id]: @"{""description"": ""The unique identifier of the telemetry record."", ""schema"": [""null"", ""string""]}",
+   [version]: @"{""description"": ""The version of the telemetry record.""}",
+   [channel]: @"{""description"": ""The channel of the telemetry record.""}",
+   [carId]: @"{""description"": ""The identifier of the race car."", ""schema"": [""null"", ""string""]}",
+   [intervalId]: @"{""description"": ""The interval identifier of the telemetry record."", ""schema"": [""null"", ""string""]}",
+   [sampleCount]: @"{""description"": ""The sample count of the telemetry record.""}",
+   [frequency]: @"{""description"": ""The frequency of the telemetry record.""}",
+   [created]: @"{""description"": ""The creation timestamp of the telemetry record."", ""schema"": [""null"", ""long""]}",
+   [timespan]: @"{""description"": ""The timespan of the telemetry record."", ""schema"": {""name"": ""RecordRange"", ""type"": ""record"", ""fields"": [{""name"": ""started"", ""type"": ""long"", ""doc"": ""The start timestamp of the telemetry record.""}, {""name"": ""ended"", ""type"": ""long"", ""doc"": ""The end timestamp of the telemetry record.""}]}}",
+   [data]: @"{""description"": ""The telemetry data."", ""schema"": {""type"": ""array"", ""items"": ""double""}}",
+   [lapId]: @"{""description"": ""The identifier of the lap."", ""schema"": [""null"", ""string""]}"
 );
 
 .create-or-alter table [TelemetryRecord] ingestion json mapping "TelemetryRecord_json_flat"

--- a/test/test_avrotokusto.py
+++ b/test/test_avrotokusto.py
@@ -3,6 +3,8 @@ from testcontainers.core.container import DockerContainer
 from avrotize.avrotokusto import convert_avro_to_kusto_db, convert_avro_to_kusto_file
 from unittest.mock import patch
 import unittest
+import json
+import re
 import os
 import sys
 import tempfile
@@ -62,6 +64,45 @@ def kusto_container():
     container.stop()
 
 # pylint: disable=redefined-outer-name
+
+
+def _parse_kusto_verbatim_string(literal: str) -> str:
+    assert literal.startswith('@"') and literal.endswith('"')
+    return literal[2:-1].replace('""', '"')
+
+
+def test_convert_avro_docstrings_escape_kql_literals(tmp_path):
+    """Docstrings with JSON-sensitive characters are escaped once for KQL."""
+    original_table_doc = 'Table doc has "quotes", a backslash \\, and a newline\nnext line'
+    original_field_doc = 'Field doc embeds JSON: { "doc": "see \\path" } and newline\nnext line'
+    schema = {
+        "type": "record",
+        "name": "EscapedDocs",
+        "namespace": "example.docs",
+        "doc": original_table_doc,
+        "fields": [
+            {"name": "id", "type": "string", "doc": original_field_doc}
+        ],
+    }
+    avro_path = tmp_path / "escaped-docs.avsc"
+    kql_path = tmp_path / "escaped-docs.kql"
+    avro_path.write_text(json.dumps(schema), encoding="utf-8")
+
+    convert_avro_to_kusto_file(str(avro_path), None, str(kql_path), False, False)
+
+    kql = kql_path.read_text(encoding="utf-8")
+    double_escaped_quote = "\\\\\""
+    assert double_escaped_quote not in kql
+
+    table_match = re.search(r"\.alter table \[EscapedDocs\] docstring (@\"(?:\"\"|[^\"])*\");", kql)
+    assert table_match is not None
+    table_doc_json = json.loads(_parse_kusto_verbatim_string(table_match.group(1)))
+    assert table_doc_json["description"] == original_table_doc
+
+    column_match = re.search(r"\[id\]: (@\"(?:\"\"|[^\"])*\")", kql)
+    assert column_match is not None
+    column_doc_json = json.loads(_parse_kusto_verbatim_string(column_match.group(1)))
+    assert column_doc_json["description"] == original_field_doc
 
 
 def test_convert_address_avsc_to_kusto_server(kusto_container):

--- a/test/test_structuretokusto.py
+++ b/test/test_structuretokusto.py
@@ -8,6 +8,7 @@ import os
 import sys
 import tempfile
 import time
+import re
 import pytest
 
 current_script_path = os.path.abspath(__file__)
@@ -51,6 +52,52 @@ def kusto_container():
 
 
 # pylint: disable=redefined-outer-name
+
+
+def _parse_kusto_verbatim_string(literal: str) -> str:
+    assert literal.startswith('@"') and literal.endswith('"')
+    return literal[2:-1].replace('""', '"')
+
+
+def test_convert_structure_docstrings_escape_kql_literals(tmp_path):
+    """Structure-to-Kusto docstrings with embedded JSON are escaped once."""
+    original_doc = 'Field whose description contains a nested JSON schema doc: { "doc": "Schema too large to inline. Please refer to the JSON Structure schema for more details." } with \\ and newline\nnext line'
+    schema = {
+        "$schema": "https://json-structure.org/meta/core/v0/",
+        "$id": "https://example.org/schemas/repro",
+        "name": "ReproEvent",
+        "namespace": "Example.Repro",
+        "type": "object",
+        "properties": {
+            "id": {"type": "string", "description": "Plain id"},
+            "tricky": {
+                "type": "object",
+                "description": original_doc,
+                "properties": {"v": {"type": "string"}},
+            },
+        },
+    }
+    struct_path = tmp_path / "schema.json"
+    kql_path = tmp_path / "out.kql"
+    struct_path.write_text(json.dumps(schema), encoding="utf-8")
+
+    convert_structure_to_kusto_file(
+        str(struct_path),
+        "Example.Repro.ReproEvent",
+        str(kql_path),
+        False,
+        False,
+        True,
+        "Example.Repro",
+    )
+
+    kql = kql_path.read_text(encoding="utf-8")
+    assert "\\\\\"" not in kql
+
+    column_match = re.search(r"\[tricky\]: (@\"(?:\"\"|[^\"])*\")", kql)
+    assert column_match is not None
+    column_doc_json = json.loads(_parse_kusto_verbatim_string(column_match.group(1)))
+    assert column_doc_json["description"] == original_doc
 
 
 def test_convert_address_struct_to_kusto_server(kusto_container):


### PR DESCRIPTION
Closes #317

## Root cause
`a2k` and `s2k` built docstring metadata as JSON, then applied `json.dumps()` again to embed that already-escaped JSON in KQL. Descriptions containing embedded JSON/quotes therefore produced invalid double-escaped sequences such as `\\\"` in `.alter table ... column-docstrings`.

## Fix summary
- Added KQL verbatim string literal emission for docstring JSON so metadata is JSON-encoded exactly once.
- Applied the fix to Avro-to-Kusto and Structure-to-Kusto table/column docstrings.
- Added round-trip tests for table and column docstrings containing quotes, backslashes, and newlines.
- Regenerated affected `.kql` reference fixtures.

## Validation
- `python -m pytest test/test_avrotokusto.py -q` -> `5 passed in 14.31s`
- `python -m pytest test/ -q -k kusto` -> `23 passed, 855 deselected, 3 warnings in 48.07s`
- CLI smoke: `python -m avrotize a2k test\avsc\address.avsc --out smoke-317.kql` emitted docstrings like `@"{""description"": ...}"`.