### PR TITLE
fix(s2a): valid standard Avro for temporal types via rfc3339-* logical types (#335)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@ All notable changes to Avrotize are documented in this file.
 
 ## [3.5.9] - 2026-06-04
 
+### Fixed
+
+- **`s2a` temporal types now emit valid standard Avro (#335)**: JSON Structure
+  temporal types (`date`, `time`, `datetime`, `timestamp`, `duration`) previously
+  mapped to a `string` base annotated with a reserved Avro logical type (e.g.
+  `{"type":"string","logicalType":"timestamp-millis"}`), which is invalid Avro
+  and is rejected by strict validators (e.g. Microsoft Fabric EventSchemaSet).
+  They now use a new `rfc3339-*` logical-type family (e.g.
+  `{"type":"string","logicalType":"rfc3339-timestamp-millis"}`). Because
+  `rfc3339-*` names are not reserved Avro logical types, the output is valid
+  standard Avro while the RFC 3339 textual value is preserved. `avrotojstruct`,
+  `avrotojsons`, and the Avrotize validator recognize the new names (the legacy
+  `string` + reserved-name form is still accepted on input). See
+  `specs/avrotize-schema.md` §3.8.11.
+
 ### Changed
 
 - **Extensible `AnyValue` record for the Avro "any" type**: The generic type

--- a/avrotize/avrotojsons.py
+++ b/avrotize/avrotojsons.py
@@ -98,21 +98,33 @@ class AvroToJsonSchemaConverter:
                     json_type['type'] = 'integer'
                     json_type['format'] = 'int64'
                     return json_type
-                # Avrotize schema extensions: string-based logical types
-                elif base_type == 'string' and logical_type == 'date':
+                # Avrotize schema extensions: string-based logical types.
+                # The rfc3339-* family is the current emission; the bare reserved
+                # names on a string base are still recognized for backward compat.
+                elif base_type == 'string' and logical_type in ['date', 'rfc3339-date']:
                     # Avrotize extension: string with date logicalType
                     json_type['type'] = 'string'
                     json_type['format'] = 'date'
                     return json_type
-                elif base_type == 'string' and logical_type in ['timestamp-millis', 'timestamp-micros', 'datetime']:
+                elif base_type == 'string' and logical_type in [
+                        'timestamp-millis', 'timestamp-micros', 'datetime',
+                        'rfc3339-timestamp-millis', 'rfc3339-timestamp-micros',
+                        'rfc3339-local-timestamp-millis', 'rfc3339-local-timestamp-micros']:
                     # Avrotize extension: string with datetime logicalType
                     json_type['type'] = 'string'
                     json_type['format'] = 'date-time'
                     return json_type
-                elif base_type == 'string' and logical_type in ['time-millis', 'time-micros', 'time']:
+                elif base_type == 'string' and logical_type in [
+                        'time-millis', 'time-micros', 'time',
+                        'rfc3339-time-millis', 'rfc3339-time-micros']:
                     # Avrotize extension: string with time logicalType
                     json_type['type'] = 'string'
                     json_type['format'] = 'time'
+                    return json_type
+                elif base_type == 'string' and logical_type in ['duration', 'rfc3339-duration']:
+                    # Avrotize extension: string with duration logicalType (RFC 3339)
+                    json_type['type'] = 'string'
+                    json_type['format'] = 'duration'
                     return json_type
                 elif logical_type == 'decimal':
                     json_type['type'] = 'number'

--- a/avrotize/avrotojstruct.py
+++ b/avrotize/avrotojstruct.py
@@ -305,6 +305,16 @@ class AvroToJsonStructure:
             "timestamp-millis": {"type": "int64", "logicalType": "timestampMillis"},
             "date": {"type": "int32", "logicalType": "date"},
             "uuid": {"type": "string", "format": "uuid"},
+            # Avrotize Schema rfc3339-* string temporal family -> JSON Structure native
+            # temporal types (round-trips with jstructtoavro). See issue #335.
+            "rfc3339-date": {"type": "date"},
+            "rfc3339-time-millis": {"type": "time"},
+            "rfc3339-time-micros": {"type": "time"},
+            "rfc3339-timestamp-millis": {"type": "datetime"},
+            "rfc3339-timestamp-micros": {"type": "datetime"},
+            "rfc3339-local-timestamp-millis": {"type": "datetime"},
+            "rfc3339-local-timestamp-micros": {"type": "datetime"},
+            "rfc3339-duration": {"type": "duration"},
         }
         return mapping.get(logical_type, {"type": "string"})
 

--- a/avrotize/avrovalidator.py
+++ b/avrotize/avrovalidator.py
@@ -414,6 +414,33 @@ class AvroValidator:
         """
         base_type = schema.get('type')
 
+        # Avrotize Schema rfc3339-* string temporal family (issue #335). These are
+        # valid standard Avro because rfc3339-* is not a reserved Avro logical type;
+        # the value is an RFC 3339 textual string on a string base.
+        if isinstance(logical_type, str) and logical_type.startswith('rfc3339-'):
+            if base_type != 'string':
+                raise AvroValidationError(
+                    f"{logical_type} logical type requires string base type", path)
+            if not isinstance(instance, str):
+                raise AvroValidationError(
+                    f"Expected string for {logical_type}, got {type(instance).__name__}", path)
+            core = logical_type[len('rfc3339-'):]
+            if core == 'date':
+                pattern = self.DATE_PATTERN
+            elif core in ('time-millis', 'time-micros'):
+                pattern = self.TIME_PATTERN
+            elif core in ('timestamp-millis', 'timestamp-micros',
+                          'local-timestamp-millis', 'local-timestamp-micros'):
+                pattern = self.DATETIME_PATTERN
+            elif core == 'duration':
+                pattern = self.DURATION_PATTERN
+            else:
+                pattern = None
+            if pattern is not None and not pattern.match(instance):
+                raise AvroValidationError(
+                    f"Invalid {logical_type} format: {instance}", path)
+            return
+
         if logical_type == 'decimal':
             self._validate_decimal(instance, schema, path)
 

--- a/avrotize/jstructtoavro.py
+++ b/avrotize/jstructtoavro.py
@@ -767,8 +767,13 @@ class JsonStructureToAvro:
     def _map_primitive_type(self, struct_type: str) -> Union[str, Dict[str, Any]]:
         """Map JSON Structure primitive type to Avro primitive type.
         
-        For temporal types, returns Avrotize Schema format with string base type 
-        and logical type annotation (RFC 3339 format).
+        For temporal types, returns Avrotize Schema format with a string base type
+        and an ``rfc3339-*`` logical-type annotation carrying the RFC 3339 textual
+        value. The ``rfc3339-*`` names are NOT reserved Avro logical types, so strict
+        Avro parsers ignore the annotation and treat the value as a plain string,
+        which keeps the emitted schema valid *standard* Avro (see issue #335) while
+        Avrotize-aware tools still recognize the temporal semantics.
+        See specs/avrotize-schema.md (Logical Types).
         """
         # Simple types without logical type annotation
         simple_type_mapping = {
@@ -802,13 +807,16 @@ class JsonStructureToAvro:
             'jsonpointer': 'string',
         }
         
-        # Temporal types with Avrotize Schema string-based logical types (RFC 3339 format)
+        # Temporal types use the rfc3339-* string-based logical-type family so the
+        # output is valid *standard* Avro (rfc3339-* are not reserved Avro logical
+        # types, so strict parsers fall back to the string base) while preserving the
+        # RFC 3339 textual representation. See issue #335 and specs/avrotize-schema.md.
         temporal_type_mapping = {
-            'date': {'type': 'string', 'logicalType': 'date'},  # RFC 3339 full-date
-            'datetime': {'type': 'string', 'logicalType': 'timestamp-millis'},  # RFC 3339 date-time
-            'time': {'type': 'string', 'logicalType': 'time-millis'},  # RFC 3339 partial-time
-            'duration': {'type': 'string', 'logicalType': 'duration'},  # RFC 3339 duration
-            'timestamp': {'type': 'string', 'logicalType': 'timestamp-millis'},  # RFC 3339 date-time
+            'date': {'type': 'string', 'logicalType': 'rfc3339-date'},  # RFC 3339 full-date
+            'datetime': {'type': 'string', 'logicalType': 'rfc3339-timestamp-millis'},  # RFC 3339 date-time
+            'time': {'type': 'string', 'logicalType': 'rfc3339-time-millis'},  # RFC 3339 partial-time
+            'duration': {'type': 'string', 'logicalType': 'rfc3339-duration'},  # RFC 3339 duration
+            'timestamp': {'type': 'string', 'logicalType': 'rfc3339-timestamp-millis'},  # RFC 3339 date-time
         }
         
         # Special types with logical type annotation
@@ -831,29 +839,31 @@ class JsonStructureToAvro:
     def _map_logical_type(self, logical_type: str, base_type: Optional[str]) -> Dict[str, Any]:
         """Map JSON Structure logical type to Avro/Avrotize logical type.
         
-        Uses Avrotize Schema extensions for string-based temporal types (RFC 3339 format).
+        Temporal logical types map to the rfc3339-* string-based family so the output
+        is valid standard Avro (see issue #335 and specs/avrotize-schema.md).
         """
-        # Avrotize Schema: temporal types on string (RFC 3339 format)
+        # Avrotize Schema: temporal types on string carrying RFC 3339 text, using the
+        # rfc3339-* logical-type family (not reserved Avro names -> valid standard Avro).
         logical_mapping = {
             # Timestamps
-            'timestampMicros': {'type': 'string', 'logicalType': 'timestamp-micros'},
-            'timestampMillis': {'type': 'string', 'logicalType': 'timestamp-millis'},
-            'timestamp-micros': {'type': 'string', 'logicalType': 'timestamp-micros'},
-            'timestamp-millis': {'type': 'string', 'logicalType': 'timestamp-millis'},
+            'timestampMicros': {'type': 'string', 'logicalType': 'rfc3339-timestamp-micros'},
+            'timestampMillis': {'type': 'string', 'logicalType': 'rfc3339-timestamp-millis'},
+            'timestamp-micros': {'type': 'string', 'logicalType': 'rfc3339-timestamp-micros'},
+            'timestamp-millis': {'type': 'string', 'logicalType': 'rfc3339-timestamp-millis'},
             # Local timestamps (no timezone)
-            'localTimestampMicros': {'type': 'string', 'logicalType': 'local-timestamp-micros'},
-            'localTimestampMillis': {'type': 'string', 'logicalType': 'local-timestamp-millis'},
-            'local-timestamp-micros': {'type': 'string', 'logicalType': 'local-timestamp-micros'},
-            'local-timestamp-millis': {'type': 'string', 'logicalType': 'local-timestamp-millis'},
+            'localTimestampMicros': {'type': 'string', 'logicalType': 'rfc3339-local-timestamp-micros'},
+            'localTimestampMillis': {'type': 'string', 'logicalType': 'rfc3339-local-timestamp-millis'},
+            'local-timestamp-micros': {'type': 'string', 'logicalType': 'rfc3339-local-timestamp-micros'},
+            'local-timestamp-millis': {'type': 'string', 'logicalType': 'rfc3339-local-timestamp-millis'},
             # Date and time
-            'date': {'type': 'string', 'logicalType': 'date'},
-            'time-millis': {'type': 'string', 'logicalType': 'time-millis'},
-            'time-micros': {'type': 'string', 'logicalType': 'time-micros'},
-            'timeMillis': {'type': 'string', 'logicalType': 'time-millis'},
-            'timeMicros': {'type': 'string', 'logicalType': 'time-micros'},
+            'date': {'type': 'string', 'logicalType': 'rfc3339-date'},
+            'time-millis': {'type': 'string', 'logicalType': 'rfc3339-time-millis'},
+            'time-micros': {'type': 'string', 'logicalType': 'rfc3339-time-micros'},
+            'timeMillis': {'type': 'string', 'logicalType': 'rfc3339-time-millis'},
+            'timeMicros': {'type': 'string', 'logicalType': 'rfc3339-time-micros'},
             # Duration
-            'duration': {'type': 'string', 'logicalType': 'duration'},
-            # UUID
+            'duration': {'type': 'string', 'logicalType': 'rfc3339-duration'},
+            # UUID (valid standard Avro on a string base)
             'uuid': {'type': 'string', 'logicalType': 'uuid'},
             # Decimal (Avrotize extension: on string)
             'decimal': {'type': 'string', 'logicalType': 'decimal'},

--- a/specs/avrotize-schema.md
+++ b/specs/avrotize-schema.md
@@ -52,6 +52,7 @@ Avro](https://avro.apache.org/docs/1.11.1/specification/) schema model.
       - [3.8.8. local-timestamp-millis](#388-local-timestamp-millis)
       - [3.8.9. local-timestamp-micros](#389-local-timestamp-micros)
       - [3.8.10. duration](#3810-duration)
+      - [3.8.11. RFC 3339 string temporal types](#3811-rfc-3339-string-temporal-types)
     - [3.9. `record` Type](#39-record-type)
       - [3.9.1. `record` field Declarations](#391-record-field-declarations)
       - [3.10. `enum` Type](#310-enum-type)
@@ -535,8 +536,19 @@ Applications that do not recognize the logical type MUST ignore the `logicalType
 attribute and treat the schema as if the logical type were not present.
 
 The following logical types are well-known and defined in this document. Avrotize
-Schema extends the Avro logical type set with RFC 3339 date and time annotations
-for `string` types.
+Schema extends the Avro logical type set with an `rfc3339-*` family of logical
+types that annotate the `string` primitive type with RFC 3339 textual date and
+time values (see [3.8.11](#3811-rfc-3339-string-temporal-types)). Because the
+`rfc3339-*` names are not reserved Avro logical types, schemas that use them
+remain valid *standard* Avro: a strict Avro parser that does not recognize the
+logical type ignores it and treats the value as a plain `string`.
+
+> Note: Earlier versions of Avrotize emitted the reserved Avro logical-type names
+> (`timestamp-millis`, `date`, `time-millis`, `duration`, ...) directly on a
+> `string` base. That pairing is invalid under the Avro logical-type rules and is
+> rejected by strict validators. Avrotize now emits the `rfc3339-*` names instead;
+> the legacy `string` + reserved-name form is still accepted on input for
+> backward compatibility.
 
 #### 3.8.1. decimal
 
@@ -607,10 +619,11 @@ Example:
 }
 ```
 
-In Avrotize Schema, the `date` logical type MAY additionally annotate the
-`string` primitive type. In this case, the string value is an [RFC
+In Avrotize Schema, the `rfc3339-date` logical type annotates the `string`
+primitive type. In this case, the string value is an [RFC
 3339](https://tools.ietf.org/html/rfc3339) "full-date" string, i.e. a date
-without a time component.
+without a time component. See
+[3.8.11](#3811-rfc-3339-string-temporal-types).
 
 #### 3.8.4. time-millis
 
@@ -629,10 +642,11 @@ Example:
 }
 ```
 
-In Avrotize Schema, the `time-millis` logical type can also annotate the
+In Avrotize Schema, the `rfc3339-time-millis` logical type annotates the
 `string` primitive type. In this case, the string value is an [RFC
 3339](https://tools.ietf.org/html/rfc3339) "partial-time" string, i.e. a time
-of day with millisecond precision.
+of day with millisecond precision. See
+[3.8.11](#3811-rfc-3339-string-temporal-types).
 
 #### 3.8.5. time-micros
 
@@ -651,10 +665,11 @@ Example:
 }
 ```
 
-In Avrotize Schema, the `time-micros` logical type MAY also annotate the
+In Avrotize Schema, the `rfc3339-time-micros` logical type annotates the
 `string` primitive type. In this case, the string value is an [RFC
 3339](https://tools.ietf.org/html/rfc3339) "partial-time" string, i.e. a time of
-day with microsecond precision.
+day with microsecond precision. See
+[3.8.11](#3811-rfc-3339-string-temporal-types).
 
 #### 3.8.6. timestamp-millis
 
@@ -674,10 +689,11 @@ Example:
 }
 ```
 
-In Avrotize Schema, the `timestamp-millis` logical type MAY also annotate the
+In Avrotize Schema, the `rfc3339-timestamp-millis` logical type annotates the
 `string` primitive type. In this case, the string value is an [RFC
 3339](https://tools.ietf.org/html/rfc3339) "date-time" string, i.e. a date and
-time with millisecond precision.
+time with millisecond precision. See
+[3.8.11](#3811-rfc-3339-string-temporal-types).
 
 #### 3.8.7. timestamp-micros
 
@@ -697,10 +713,11 @@ Example:
 }
 ```
 
-In Avrotize Schema, the `timestamp-micros` logical type MAY also annotate the
+In Avrotize Schema, the `rfc3339-timestamp-micros` logical type annotates the
 `string` primitive type. In this case, the string value is an [RFC
 3339](https://tools.ietf.org/html/rfc3339) "date-time" string, i.e. a date and
-time with microsecond precision.
+time with microsecond precision. See
+[3.8.11](#3811-rfc-3339-string-temporal-types).
 
 #### 3.8.8. local-timestamp-millis
 
@@ -720,10 +737,11 @@ Example:
 }
 ```
 
-In Avrotize Schema, the `local-timestamp-millis` logical type MAY also annotate
+In Avrotize Schema, the `rfc3339-local-timestamp-millis` logical type annotates
 the `string` primitive type. In this case, the string value is an [RFC
 3339](https://tools.ietf.org/html/rfc3339) "date-time" string, i.e. a date and
-time with millisecond precision, whereby the offset is ignored.
+time with millisecond precision, whereby the offset is ignored. See
+[3.8.11](#3811-rfc-3339-string-temporal-types).
 
 #### 3.8.9. local-timestamp-micros
 
@@ -743,10 +761,11 @@ Example:
 }
 ```
 
-In Avrotize Schema, the `local-timestamp-micros` logical type MAY also annotate
+In Avrotize Schema, the `rfc3339-local-timestamp-micros` logical type annotates
 the `string` primitive type. In this case, the string value is an [RFC
 3339](https://tools.ietf.org/html/rfc3339) "date-time" string, i.e. a date and
-time with microsecond precision, whereby the offset is ignored.
+time with microsecond precision, whereby the offset is ignored. See
+[3.8.11](#3811-rfc-3339-string-temporal-types).
 
 #### 3.8.10. duration
 
@@ -773,9 +792,46 @@ Example:
 }
 ```
 
-In Avrotize Schema, the `duration` logical type MAY also annotate the `string`
+In Avrotize Schema, the `rfc3339-duration` logical type annotates the `string`
 primitive type. In this case, the string value is an [RFC
-3339](https://tools.ietf.org/html/rfc3339) "duration" string (Appendix A).
+3339](https://tools.ietf.org/html/rfc3339) "duration" string (Appendix A). See
+[3.8.11](#3811-rfc-3339-string-temporal-types).
+
+#### 3.8.11. RFC 3339 string temporal types
+
+Avrotize Schema defines an `rfc3339-*` family of logical types that annotate the
+`string` primitive type with [RFC 3339](https://tools.ietf.org/html/rfc3339)
+textual date and time values. These are the canonical string-based temporal
+encodings emitted by Avrotize converters — for example, by `s2a` (JSON Structure
+to Avrotize) when converting the JSON Structure native temporal types `date`,
+`time`, `datetime`, `timestamp`, and `duration`.
+
+Because the `rfc3339-*` names are not reserved Avro logical types, a schema that
+uses them is valid *standard* Avro: an implementation that does not recognize the
+logical type MUST ignore it and treat the value as a plain `string` (see
+[3.8](#38-logical-types)). This avoids the invalid pairing of a reserved numeric
+logical type (such as `timestamp-millis`, which requires a `long` base) with a
+`string` base.
+
+| Logical type                     | String value (RFC 3339)               |
+| -------------------------------- | ------------------------------------- |
+| `rfc3339-date`                   | "full-date" (e.g. `2024-06-03`)       |
+| `rfc3339-time-millis`            | "partial-time", millisecond precision |
+| `rfc3339-time-micros`            | "partial-time", microsecond precision |
+| `rfc3339-timestamp-millis`       | "date-time", millisecond precision    |
+| `rfc3339-timestamp-micros`       | "date-time", microsecond precision    |
+| `rfc3339-local-timestamp-millis` | "date-time" (offset ignored), millis  |
+| `rfc3339-local-timestamp-micros` | "date-time" (offset ignored), micros  |
+| `rfc3339-duration`               | "duration" (Appendix A, e.g. `P1Y2M`) |
+
+Example:
+
+```json
+{
+  "type": "string",
+  "logicalType": "rfc3339-timestamp-millis"
+}
+```
 
 ### 3.9. `record` Type
 

--- a/test/struct/temporal-types.struct-ref.avsc
+++ b/test/struct/temporal-types.struct-ref.avsc
@@ -9,7 +9,7 @@
         "null",
         {
           "type": "string",
-          "logicalType": "date"
+          "logicalType": "rfc3339-date"
         }
       ],
       "doc": "A date field",
@@ -21,7 +21,7 @@
         "null",
         {
           "type": "string",
-          "logicalType": "time-millis"
+          "logicalType": "rfc3339-time-millis"
         }
       ],
       "doc": "A time field",
@@ -31,7 +31,7 @@
       "name": "datetimeField",
       "type": {
         "type": "string",
-        "logicalType": "timestamp-millis"
+        "logicalType": "rfc3339-timestamp-millis"
       },
       "doc": "A datetime field"
     },
@@ -41,7 +41,7 @@
         "null",
         {
           "type": "string",
-          "logicalType": "timestamp-millis"
+          "logicalType": "rfc3339-timestamp-millis"
         }
       ],
       "doc": "A timestamp field",
@@ -53,7 +53,7 @@
         "null",
         {
           "type": "string",
-          "logicalType": "duration"
+          "logicalType": "rfc3339-duration"
         }
       ],
       "doc": "A duration field",

--- a/test/test_jstructtoavro.py
+++ b/test/test_jstructtoavro.py
@@ -607,14 +607,147 @@ class TestJsonStructureToAvro(unittest.TestCase):
 
         result = self.converter.convert(structure)
 
-        # Avrotize Schema: temporal types use string base type with logical type annotation
+        # Avrotize Schema: temporal types use a string base with an rfc3339-* logical
+        # type so the output is valid standard Avro (issue #335).
         timestamp_field = next(f for f in result['fields'] if f['name'] == 'timestamp')
         self.assertEqual(timestamp_field['type']['type'], 'string')
-        self.assertEqual(timestamp_field['type']['logicalType'], 'timestamp-millis')
+        self.assertEqual(timestamp_field['type']['logicalType'], 'rfc3339-timestamp-millis')
 
         uuid_field = next(f for f in result['fields'] if f['name'] == 'uuid')
         self.assertEqual(uuid_field['type']['type'], 'string')
         self.assertEqual(uuid_field['type']['logicalType'], 'uuid')
+
+    # ---- Issue #335: temporal types must emit valid *standard* Avro -----------
+
+    # Reserved Avro logical types that require a non-string base; emitting any of
+    # these on a "string" base is invalid standard Avro (the #335 defect).
+    _RESERVED_NONSTRING_TEMPORAL = {
+        'date', 'time-millis', 'time-micros',
+        'timestamp-millis', 'timestamp-micros',
+        'local-timestamp-millis', 'local-timestamp-micros',
+        'duration',
+    }
+
+    @staticmethod
+    def _iter_logical(node):
+        """Yield (base_type, logicalType) pairs for every annotated node in a schema."""
+        if isinstance(node, dict):
+            lt = node.get('logicalType')
+            if lt is not None:
+                yield (node.get('type'), lt)
+            for v in node.values():
+                yield from TestJsonStructureToAvro._iter_logical(v)
+        elif isinstance(node, list):
+            for v in node:
+                yield from TestJsonStructureToAvro._iter_logical(v)
+
+    def _temporal_avro(self):
+        with open('test/struct/temporal-types.struct.json', 'r', encoding='utf-8') as f:
+            structure = json.load(f)
+        return self.converter.convert(structure)
+
+    def test_temporal_types_emit_rfc3339_logical_types(self):
+        """Each JSON Structure temporal type maps to the rfc3339-* string family."""
+        result = self._temporal_avro()
+        fields = {f['name']: f for f in result['fields']}
+
+        def logical_of(field):
+            t = field['type']
+            if isinstance(t, list):  # nullable union ["null", {...}]
+                t = next(x for x in t if x != 'null')
+            return t['type'], t['logicalType']
+
+        self.assertEqual(logical_of(fields['dateField']), ('string', 'rfc3339-date'))
+        self.assertEqual(logical_of(fields['timeField']), ('string', 'rfc3339-time-millis'))
+        self.assertEqual(logical_of(fields['datetimeField']), ('string', 'rfc3339-timestamp-millis'))
+        self.assertEqual(logical_of(fields['timestampField']), ('string', 'rfc3339-timestamp-millis'))
+        self.assertEqual(logical_of(fields['durationField']), ('string', 'rfc3339-duration'))
+
+    def test_temporal_output_has_no_reserved_logical_on_string(self):
+        """Regression for #335: never emit a reserved Avro logical type on string."""
+        result = self._temporal_avro()
+        offenders = [
+            (base, lt) for base, lt in self._iter_logical(result)
+            if base == 'string' and lt in self._RESERVED_NONSTRING_TEMPORAL
+        ]
+        self.assertEqual(
+            offenders, [],
+            f"Emitted reserved Avro logical type(s) on a string base: {offenders}")
+
+    def test_issue_335_reproducer_datetime(self):
+        """Exact reproducer from issue #335 must not emit string+timestamp-millis."""
+        structure = {
+            "$schema": "https://json-structure.org/meta/core/v0/#",
+            "$id": "https://example.com/repro/dt2",
+            "name": "DtRepro2",
+            "type": "object",
+            "properties": {
+                "Id": {"type": "string"},
+                "sent": {"type": "datetime", "description": "ISO-8601 timestamp"},
+            },
+        }
+        result = self.converter.convert(structure)
+        sent = next(f for f in result['fields'] if f['name'] == 'sent')
+        sent_type = sent['type']
+        if isinstance(sent_type, list):
+            sent_type = next(x for x in sent_type if x != 'null')
+        self.assertEqual(sent_type['type'], 'string')
+        self.assertNotEqual(sent_type['logicalType'], 'timestamp-millis')
+        self.assertEqual(sent_type['logicalType'], 'rfc3339-timestamp-millis')
+
+    def test_temporal_output_is_valid_standard_avro(self):
+        """fastavro must parse the emitted schema as valid standard Avro."""
+        try:
+            import fastavro
+        except ImportError:
+            self.skipTest("fastavro not installed")
+        # Must not raise.
+        fastavro.parse_schema(self._temporal_avro())
+
+    def test_temporal_round_trip_to_json_structure(self):
+        """s2a -> a2s returns the native JSON Structure temporal types."""
+        avro = self._temporal_avro()
+        structure = AvroToJsonStructure().convert(avro)
+        defs = structure['definitions']['TemporalTypes']['properties']
+        self.assertEqual(defs['dateField']['type'], 'date')
+        self.assertEqual(defs['timeField']['type'], 'time')
+        self.assertEqual(defs['datetimeField']['type'], 'datetime')
+        self.assertEqual(defs['timestampField']['type'], 'datetime')
+        self.assertEqual(defs['durationField']['type'], 'duration')
+
+    def test_rfc3339_validator_accepts_and_rejects(self):
+        """avrovalidator validates rfc3339-* values as RFC 3339 strings."""
+        from avrotize.avrovalidator import validate_json_against_avro
+        avro = self._temporal_avro()
+        valid = {
+            "dateField": "2024-06-03",
+            "timeField": "12:00:00",
+            "datetimeField": "2024-06-03T12:00:00Z",
+            "timestampField": "2024-06-03T12:00:00.500Z",
+            "durationField": "P1Y2M3DT4H5M6S",
+        }
+        self.assertEqual(validate_json_against_avro(valid, avro), [])
+        bad = dict(valid, datetimeField="not-a-datetime")
+        self.assertTrue(validate_json_against_avro(bad, avro))
+
+    def test_logical_type_annotation_maps_to_rfc3339(self):
+        """Explicit JSON Structure logicalType annotations also use rfc3339-*."""
+        structure = {
+            "$schema": "https://json-structure.org/meta/core/v0/#",
+            "$id": "t", "name": "E", "type": "object",
+            "properties": {
+                "a": {"type": "int64", "logicalType": "timestampMicros"},
+                "b": {"type": "int32", "logicalType": "date"},
+                "c": {"type": "string", "logicalType": "uuid"},
+            },
+            "required": ["a", "b", "c"],
+        }
+        result = self.converter.convert(structure)
+        fields = {f['name']: f['type'] for f in result['fields']}
+        self.assertEqual(fields['a'], {'type': 'string', 'logicalType': 'rfc3339-timestamp-micros'})
+        self.assertEqual(fields['b'], {'type': 'string', 'logicalType': 'rfc3339-date'})
+        # uuid stays a valid standard-Avro string logical type.
+        self.assertEqual(fields['c'], {'type': 'string', 'logicalType': 'uuid'})
 
     def test_round_trip_conversion(self):
         """Test round-trip conversion: Avro -> Structure -> Avro."""


### PR DESCRIPTION
Closes #335

## Problem

`avrotize s2a` (JSON Structure → Avro) mapped the native temporal types (`date`, `time`, `datetime`, `timestamp`, `duration`) to a `string` base annotated with a **reserved** Avro logical type, e.g.:

```json
{ "type": "string", "logicalType": "timestamp-millis" }
```

This is invalid standard Avro — `timestamp-millis` requires a `long` base — and is rejected by strict validators (Microsoft Fabric EventSchemaSet, etc.).

## Fix

Introduce an `rfc3339-*` logical-type family on the `string` base (e.g. `rfc3339-timestamp-millis`, `rfc3339-date`, `rfc3339-time-millis`, `rfc3339-duration`, plus micros/local variants). Because `rfc3339-*` names are **not** reserved Avro logical types, strict Avro parsers ignore the annotation and treat the value as a plain `string`, so the output is **valid standard Avro** while the **RFC 3339 textual value is preserved** (the deliberate Avrotize Schema design).

- `jstructtoavro.py` — emit the `rfc3339-*` family.
- `avrotojstruct.py` — map `rfc3339-*` back to JSON Structure native temporal types (clean `s2a → a2s` round-trip).
- `avrotojsons.py` — recognize `rfc3339-*` for Avro → JSON Schema (`format: date/date-time/time/duration`).
- `avrovalidator.py` — validate `rfc3339-*` values against the RFC 3339 patterns.
- `specs/avrotize-schema.md` — new §3.8.11 documenting the family.
- Backward compatible: the legacy `string` + reserved-name form is still accepted on input.

## Validation

- New tests in `test/test_jstructtoavro.py`: exact issue reproducer, per-type `rfc3339-*` assertions, a **regression invariant** (no reserved Avro temporal logical type on a `string` base), `fastavro.parse_schema` accepts the output as valid standard Avro, `s2a → a2s` round-trip, and validator accept/reject of RFC 3339 strings.
- `python -m pytest test/test_jstructtoavro.py test/test_avrotojstruct.py test/test_avrotojsons.py test/test_validate.py` → **99 passed**.
- CLI smoke: `s2a` on the issue reproducer now emits `{"type":"string","logicalType":"rfc3339-timestamp-millis"}`.