### PR TITLE
fix(a2p): JSON encode/decode for date dataclass fields (#355)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ All notable changes to Avrotize are documented in this file.
 
 ### Fixed
 
+- **Avro to Python dataclasses JSON date encoding (issue #355)**:
+  `datetime.date` fields generated from Avro `date` logical types now use ISO
+  `dataclasses-json` encoder/decoder wiring and a Marshmallow `fields.Date`,
+  matching existing `datetime.datetime` timestamp handling.
 - **int64/uint64/int128/uint128/decimal JSON string serialization (issue #346)**:
   All language code generators now serialize these types as JSON strings (not
   numbers) per the JSON Structure Core spec, since IEEE-754 doubles cannot

--- a/avrotize/avrotopython/dataclass_core.jinja
+++ b/avrotize/avrotopython/dataclass_core.jinja
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 {%- if dataclasses_json_annotation %}
 import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
-{%- for field in fields if field.type == "datetime" or field.type == "typing.Optional[datetime.datetime]" %}
+{%- for field in fields if field.type == "datetime.datetime" or field.type == "datetime" or field.type == "typing.Optional[datetime.datetime]" or field.type == "datetime.date" or field.type == "typing.Optional[datetime.date]" %}
 {%- if loop.first %}
 from marshmallow import fields
 {%- endif %}
@@ -57,8 +57,9 @@ class {{ class_name }}:
         {%- endfor -%}
     """
     {% for field in fields %}
-    {%- set isdate = field.type == "datetime" or field.type == "typing.Optional[datetime.datetime]" %}
-    {{ field.name }}: {{ field.type }}=dataclasses.field(kw_only=True{% if dataclasses_json_annotation %}, metadata=dataclasses_json.config(field_name="{{ field.original_name }}"{%- if isdate -%}, encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso'){%- endif -%}){%- endif %})
+    {%- set isdatetime = field.type == "datetime.datetime" or field.type == "datetime" or field.type == "typing.Optional[datetime.datetime]" %}
+    {%- set isdate = field.type == "datetime.date" or field.type == "typing.Optional[datetime.date]" %}
+    {{ field.name }}: {{ field.type }}=dataclasses.field(kw_only=True{% if dataclasses_json_annotation %}, metadata=dataclasses_json.config(field_name="{{ field.original_name }}"{%- if isdatetime -%}, encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso'){%- elif isdate -%}, encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d.isoformat() if isinstance(d, datetime.date) else d if d else None, decoder=lambda d: datetime.date.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.Date(format='iso'){%- endif -%}){%- endif %})
     {%- endfor %}
     {% if avro_annotation %}
     AvroType: typing.ClassVar[avro.schema.Schema] = avro.schema.make_avsc_object(

--- a/test/test_avrotopython.py
+++ b/test/test_avrotopython.py
@@ -65,6 +65,50 @@ class TestAvroToPython(unittest.TestCase):
         assert subprocess.check_call(
             ['python', '-m', 'pytest'], cwd=py_path, env=new_env, stdout=sys.stdout, stderr=sys.stderr, shell=True) == 0
 
+    def test_dataclasses_json_logical_date_and_datetime_roundtrip(self):
+        """ Test date and timestamp logical types use JSON ISO encoders/decoders. """
+        import datetime
+        import importlib
+        import json
+
+        schema = {
+            "type": "record",
+            "name": "TemporalRecord",
+            "namespace": "example.logical",
+            "fields": [
+                {"name": "event_date", "type": {"type": "int", "logicalType": "date"}},
+                {"name": "updated_at", "type": {"type": "long", "logicalType": "timestamp-millis"}},
+            ],
+        }
+        py_path = os.path.join(tempfile.gettempdir(), "avrotize", "issue-355-date-py-json")
+        if os.path.exists(py_path):
+            shutil.rmtree(py_path, ignore_errors=True)
+        os.makedirs(py_path, exist_ok=True)
+
+        from avrotize.avrotopython import convert_avro_schema_to_python
+        convert_avro_schema_to_python(
+            schema, py_path, package_name="issue_355_date_json", dataclasses_json_annotation=True)
+
+        generated_src = os.path.join(py_path, "src")
+        sys.path.insert(0, generated_src)
+        try:
+            module = importlib.import_module("issue_355_date_json.example.logical")
+            TemporalRecord = module.TemporalRecord
+            record = TemporalRecord(
+                event_date=datetime.date(2025, 1, 2),
+                updated_at=datetime.datetime(2025, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc),
+            )
+
+            json_text = record.to_json()
+            payload = json.loads(json_text)
+            assert payload["event_date"] == "2025-01-02"
+            assert payload["updated_at"] == "2025-01-02T03:04:05+00:00"
+
+            round_tripped = TemporalRecord.from_json(json_text)
+            assert round_tripped == record
+        finally:
+            sys.path.remove(generated_src)
+
     def test_convert_address_avsc_to_python_avro(self):
         """ Test converting an address.avsc file to Python with avro annotation """
         cwd = os.getcwd()


### PR DESCRIPTION
Closes #355

## Root cause
`avrotize/avrotopython/dataclass_core.jinja` only emitted `dataclasses_json.config(...)` ISO encoder/decoder and Marshmallow `mm_field` wiring for `datetime.datetime` fields. Avro `date` logical types become `datetime.date`, so those fields took the default JSON path and `to_json()` raised `TypeError: Object of type date is not JSON serializable`.

## Fix summary
- Added `datetime.date` and `typing.Optional[datetime.date]` template detection for dataclasses-json support.
- Generated ISO `date.isoformat()` / `datetime.date.fromisoformat(...)` wiring with `fields.Date(format='iso')`.
- Kept datetime handling ahead of date handling, including the generated date encoder's `datetime.datetime` guard before `datetime.date`.
- Added a regression test that generates a dataclass with both Avro `date` and `timestamp-millis` fields and validates `to_json()` / `from_json()` round-trip.
- Updated `CHANGELOG.md`.

## Validation
- Initial regression test before fix failed as expected: `TypeError: Object of type date is not JSON serializable`.
- `python -m pytest test\test_avrotopython.py::TestAvroToPython::test_dataclasses_json_logical_date_and_datetime_roundtrip -q`
  - `1 passed in 0.25s`
- `python -m pytest test\test_avrotopython.py -q -k "not jfrog"`
  - `14 passed, 1 deselected in 47.66s`
- CLI smoke (`python -m avrotize a2py ... --dataclasses-json-annotation`) generated, compiled, and imported `SmokeRecord` successfully.

Requested full-suite checks were also run and exposed existing unrelated failures:
- `python -m pytest test\test_avrotopython.py -q`
  - `1 failed, 14 passed in 119.06s (0:01:59)`
  - Failure: `TestAvroToPython.test_convert_jfrog_pipelines_jsons_to_avro_to_python`, generated test collection reported `1078 errors during collection`.
- `python -m pytest test\ -q -k python`
  - `3 failed, 45 passed, 832 deselected, 3 warnings, 17 subtests passed in 733.80s (0:12:13)`
  - Failures were in `test_structure_codegen_flags.py` generated-test execution paths, unrelated to Avro date JSON encoding.