### PR TITLE
fix(s2a): emit valid Avro for inline JSON Structure object types (#336)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ All notable changes to Avrotize are documented in this file.
 
 ### Fixed
 
+- **s2a inline `object` produced invalid Avro / lost nested data (issue #336)**:
+  A JSON Structure property typed as `{"type": "object"}` previously emitted the
+  bare literal `"object"`, which is not a valid Avro type (parsers reject it,
+  Microsoft Fabric `EventSchemaSet` validation fails). Objects *with* `properties`
+  additionally lost their entire nested shape. Inline objects now convert
+  correctly:
+  - open / property-less object -> `{"type": "map", "values": "string"}`
+    (honoring `additionalProperties` value type when present);
+  - object with `properties` -> a nested Avro `record` (shape preserved, with
+    unique record names derived from the enclosing property);
+  - bare `"object"`/`"array"` union members map to their valid open Avro forms.
 - **int64/uint64/int128/uint128/decimal JSON string serialization (issue #346)**:
   All language code generators now serialize these types as JSON strings (not
   numbers) per the JSON Structure Core spec, since IEEE-754 doubles cannot

--- a/avrotize/jstructtoavro.py
+++ b/avrotize/jstructtoavro.py
@@ -20,6 +20,8 @@ class JsonStructureToAvro:
         """Initialize the converter."""
         self.structure_doc: Optional[Dict[str, Any]] = None
         self.converted_types: Dict[str, Dict[str, Any]] = {}
+        self._anon_object_counter: int = 0
+        self._generated_record_names: set = set()
         
     def convert(self, structure_schema: Dict[str, Any]) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
         """
@@ -33,6 +35,8 @@ class JsonStructureToAvro:
         """
         self.structure_doc = structure_schema
         self.converted_types.clear()
+        self._anon_object_counter = 0
+        self._generated_record_names = set()
         
         # Check if this is an inline type (type at root) or uses $root
         root_ref = structure_schema.get('$root')
@@ -386,7 +390,7 @@ class JsonStructureToAvro:
         for prop_name, prop_schema in properties.items():
             field = {
                 'name': prop_name,
-                'type': self._convert_type_reference(prop_schema)
+                'type': self._convert_type_reference(prop_schema, name_hint=prop_name)
             }
             
             # Build documentation with annotations
@@ -678,13 +682,55 @@ class JsonStructureToAvro:
         
         return avro_record
     
-    def _convert_type_reference(self, schema: Union[Dict[str, Any], str]) -> Union[str, Dict[str, Any], List]:
+    def _convert_union_member(self, member: Union[Dict[str, Any], str]) -> Union[str, Dict[str, Any], List]:
+        """Convert a single member of a JSON Structure union type.
+
+        Members are usually primitive type names, but a union may also list the
+        loose container names ``"object"`` and ``"array"`` (open, untyped). A
+        bare ``"object"``/``"array"`` is not a valid Avro type, so map them to
+        their canonical open Avro forms (string-valued map / string-element
+        array), consistent with how inline open objects are handled (#336).
+        """
+        if isinstance(member, str):
+            if member == 'object':
+                return {'type': 'map', 'values': 'string'}
+            if member == 'array':
+                return {'type': 'array', 'items': 'string'}
+            return self._map_primitive_type(member)
+        return self._convert_type_reference(member)
+
+    def _anonymous_object_name(self, name_hint: Optional[str]) -> str:
+        """Generate a valid, unique Avro record name for an inline object.
+
+        Prefers a name derived from the enclosing property (``name_hint``) so
+        that output is readable and round-trips sensibly; falls back to a
+        monotonically increasing generated name. A uniqueness suffix is added
+        when the same hint occurs more than once (e.g. like-named properties at
+        different nesting levels) to avoid Avro name redefinition errors.
+        """
+        if name_hint:
+            candidate = f"{name_hint[0].upper() + name_hint[1:]}Type"
+        else:
+            self._anon_object_counter += 1
+            candidate = f"AnonymousObject{self._anon_object_counter}"
+        unique = candidate
+        suffix = 2
+        while unique in self._generated_record_names:
+            unique = f"{candidate}_{suffix}"
+            suffix += 1
+        self._generated_record_names.add(unique)
+        return unique
+
+    def _convert_type_reference(self, schema: Union[Dict[str, Any], str], name_hint: Optional[str] = None) -> Union[str, Dict[str, Any], List]:
         """
         Convert a type reference or inline type definition.
         
         Args:
             schema: Type schema or reference
-            
+            name_hint: Optional name to use when an inline object must be
+                materialized as a named Avro record (e.g. the enclosing
+                property name). Falls back to a generated unique name.
+        
         Returns:
             Avro type (string, dict, or list for union)
         """
@@ -712,7 +758,7 @@ class JsonStructureToAvro:
         
         # Handle union types (type is an array like ["string", "null"])
         if isinstance(type_value, list):
-            return [self._map_primitive_type(t) if isinstance(t, str) else self._convert_type_reference(t) for t in type_value]
+            return [self._convert_union_member(t) for t in type_value]
         
         # Handle choice types
         if type_value == 'choice':
@@ -744,13 +790,38 @@ class JsonStructureToAvro:
         if type_value == 'array':
             return {
                 'type': 'array',
-                'items': self._convert_type_reference(schema['items'])
+                'items': self._convert_type_reference(schema['items'], name_hint=name_hint)
             }
         
         if type_value == 'map':
             return {
                 'type': 'map',
                 'values': self._convert_type_reference(schema['values'])
+            }
+        
+        # Handle object types appearing inline (i.e. not as a named $root or
+        # definition). Without this, an inline {"type": "object"} fell through
+        # to _map_primitive_type and emitted a bare "object", which is not a
+        # valid Avro type. See issue #336.
+        if type_value == 'object':
+            properties = schema.get('properties')
+            if properties:
+                # Object with a defined shape -> nested Avro record.
+                obj_name = schema.get('name') or self._anonymous_object_name(name_hint)
+                return self._convert_object(schema, None, obj_name)
+            # Open / property-less object -> Avro map. Honor an
+            # additionalProperties value type when specified, otherwise default
+            # to string (an open object carries arbitrary string-keyed values).
+            additional = schema.get('additionalProperties')
+            if isinstance(additional, dict):
+                values_type: Union[str, Dict[str, Any], List] = self._convert_type_reference(additional)
+            elif isinstance(additional, str):
+                values_type = self._map_primitive_type(additional)
+            else:
+                values_type = 'string'
+            return {
+                'type': 'map',
+                'values': values_type
             }
         
         # Handle logical types

--- a/test/struct/complex-scenario.struct-ref.avsc
+++ b/test/struct/complex-scenario.struct-ref.avsc
@@ -5,7 +5,44 @@
   "fields": [
     {
       "name": "metadata",
-      "type": "object"
+      "type": {
+        "type": "record",
+        "name": "MetadataType",
+        "fields": [
+          {
+            "name": "id",
+            "type": {
+              "type": "string",
+              "logicalType": "uuid"
+            },
+            "doc": "Unique identifier"
+          },
+          {
+            "name": "version",
+            "type": "string",
+            "doc": "Semantic version [pattern: ^\\d+\\.\\d+\\.\\d+$]"
+          },
+          {
+            "name": "created",
+            "type": {
+              "type": "string",
+              "logicalType": "timestamp-millis"
+            },
+            "doc": "Creation timestamp"
+          },
+          {
+            "name": "tags",
+            "type": [
+              "null",
+              {
+                "type": "array",
+                "items": "string"
+              }
+            ],
+            "default": null
+          }
+        ]
+      }
     },
     {
       "name": "data",
@@ -29,8 +66,106 @@
           {
             "name": "value",
             "type": [
-              "object",
-              "object"
+              {
+                "type": "record",
+                "name": "AnonymousObject1",
+                "fields": [
+                  {
+                    "name": "type",
+                    "type": "string"
+                  },
+                  {
+                    "name": "value",
+                    "type": {
+                      "type": "string",
+                      "logicalType": "decimal"
+                    },
+                    "doc": "[precision: 15, scale: 6]"
+                  },
+                  {
+                    "name": "timestamp",
+                    "type": {
+                      "type": "string",
+                      "logicalType": "timestamp-millis"
+                    }
+                  },
+                  {
+                    "name": "device",
+                    "type": [
+                      "null",
+                      {
+                        "type": "record",
+                        "name": "DeviceType",
+                        "fields": [
+                          {
+                            "name": "id",
+                            "type": "string"
+                          },
+                          {
+                            "name": "calibration",
+                            "type": [
+                              "null",
+                              {
+                                "type": "map",
+                                "values": "double"
+                              }
+                            ],
+                            "default": null
+                          }
+                        ]
+                      }
+                    ],
+                    "default": null
+                  }
+                ]
+              },
+              {
+                "type": "record",
+                "name": "AnonymousObject2",
+                "fields": [
+                  {
+                    "name": "type",
+                    "type": "string"
+                  },
+                  {
+                    "name": "name",
+                    "type": "string"
+                  },
+                  {
+                    "name": "severity",
+                    "type": "string"
+                  },
+                  {
+                    "name": "details",
+                    "type": [
+                      "null",
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "record",
+                          "name": "DetailsType",
+                          "fields": [
+                            {
+                              "name": "key",
+                              "type": "string"
+                            },
+                            {
+                              "name": "value",
+                              "type": [
+                                "string",
+                                "long",
+                                "double",
+                                "boolean"
+                              ]
+                            }
+                          ]
+                        }
+                      }
+                    ],
+                    "default": null
+                  }
+                ]
+              }
             ],
             "doc": "The actual value of the selected choice type"
           }

--- a/test/struct/edge-cases.struct-ref.avsc
+++ b/test/struct/edge-cases.struct-ref.avsc
@@ -60,8 +60,14 @@
         "int",
         "double",
         "boolean",
-        "array",
-        "object",
+        {
+          "type": "array",
+          "items": "string"
+        },
+        {
+          "type": "map",
+          "values": "string"
+        },
         "null"
       ],
       "default": null
@@ -70,7 +76,52 @@
       "name": "deeplyNested",
       "type": [
         "null",
-        "object"
+        {
+          "type": "record",
+          "name": "DeeplyNestedType",
+          "fields": [
+            {
+              "name": "level1",
+              "type": {
+                "type": "record",
+                "name": "Level1Type",
+                "fields": [
+                  {
+                    "name": "level2",
+                    "type": {
+                      "type": "record",
+                      "name": "Level2Type",
+                      "fields": [
+                        {
+                          "name": "level3",
+                          "type": {
+                            "type": "record",
+                            "name": "Level3Type",
+                            "fields": [
+                              {
+                                "name": "level4",
+                                "type": {
+                                  "type": "record",
+                                  "name": "Level4Type",
+                                  "fields": [
+                                    {
+                                      "name": "value",
+                                      "type": "string"
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
       ],
       "default": null
     }

--- a/test/struct/nested-objects.struct-ref.avsc
+++ b/test/struct/nested-objects.struct-ref.avsc
@@ -5,7 +5,94 @@
   "fields": [
     {
       "name": "person",
-      "type": "object"
+      "type": {
+        "type": "record",
+        "name": "PersonType",
+        "fields": [
+          {
+            "name": "firstName",
+            "type": "string",
+            "doc": "[maxLength: 50]"
+          },
+          {
+            "name": "lastName",
+            "type": "string",
+            "doc": "[maxLength: 50]"
+          },
+          {
+            "name": "address",
+            "type": {
+              "type": "record",
+              "name": "AddressType",
+              "fields": [
+                {
+                  "name": "street",
+                  "type": "string",
+                  "doc": "[maxLength: 100]"
+                },
+                {
+                  "name": "city",
+                  "type": "string",
+                  "doc": "[maxLength: 50]"
+                },
+                {
+                  "name": "country",
+                  "type": "string",
+                  "doc": "[maxLength: 50]"
+                },
+                {
+                  "name": "coordinates",
+                  "type": [
+                    "null",
+                    {
+                      "type": "record",
+                      "name": "CoordinatesType",
+                      "fields": [
+                        {
+                          "name": "latitude",
+                          "type": "double",
+                          "doc": "[minimum: -90.0, maximum: 90.0]"
+                        },
+                        {
+                          "name": "longitude",
+                          "type": "double",
+                          "doc": "[minimum: -180.0, maximum: 180.0]"
+                        }
+                      ]
+                    }
+                  ],
+                  "default": null
+                }
+              ]
+            }
+          },
+          {
+            "name": "phoneNumbers",
+            "type": [
+              "null",
+              {
+                "type": "array",
+                "items": {
+                  "type": "record",
+                  "name": "PhoneNumbersType",
+                  "fields": [
+                    {
+                      "name": "type",
+                      "type": "string"
+                    },
+                    {
+                      "name": "number",
+                      "type": "string",
+                      "doc": "[pattern: ^\\+?[1-9]\\d{1,14}$]"
+                    }
+                  ]
+                }
+              }
+            ],
+            "default": null
+          }
+        ]
+      }
     }
   ]
 }

--- a/test/test_jstructtoavro.py
+++ b/test/test_jstructtoavro.py
@@ -804,5 +804,299 @@ class TestJsonStructureToAvro(unittest.TestCase):
         )
 
 
+class TestInlineObjectConversion(unittest.TestCase):
+    """Inline JSON Structure ``object`` types must produce valid Avro (issue #336).
+
+    A property-less object previously emitted the bare literal ``"object"``,
+    which is not a valid Avro type and also discarded any nested shape. These
+    tests pin the corrected behavior: open objects -> Avro ``map``, objects with
+    ``properties`` -> nested Avro ``record``, and every emitted schema parses.
+    """
+
+    def setUp(self):
+        self.converter = JsonStructureToAvro()
+
+    @staticmethod
+    def _assert_parses(schema):
+        from fastavro.schema import parse_schema
+        import copy
+        parse_schema(copy.deepcopy(schema))
+
+    def _assert_no_bare_object_type(self, node):
+        """Recursively assert no Avro *type position* holds a bare object/array."""
+        if isinstance(node, str):
+            self.assertNotIn(node, ('object',),
+                             "bare 'object' string found in a type position")
+        elif isinstance(node, list):
+            for item in node:
+                self._assert_no_bare_object_type(item)
+        elif isinstance(node, dict):
+            self.assertNotEqual(node.get('type'), 'object',
+                                "dict with type=='object' found (invalid Avro)")
+            for value in node.values():
+                self._assert_no_bare_object_type(value)
+
+    def test_issue_336_property_less_object_is_valid_map(self):
+        """Exact reproducer from issue #336: open object -> map<string>, parseable."""
+        repro = {
+            "$schema": "https://json-structure.org/meta/core/v0/#",
+            "$id": "https://example.com/repro/objlit",
+            "name": "ObjLit",
+            "type": "object",
+            "properties": {
+                "Id": {"type": "string"},
+                "Dimension": {"type": "object"},
+            },
+        }
+        result = self.converter.convert(repro)
+        self._assert_no_bare_object_type(result)
+        self._assert_parses(result)
+
+        dimension = next(f for f in result['fields'] if f['name'] == 'Dimension')
+        # Optional field => nullable union wrapping the map.
+        self.assertIn({'type': 'map', 'values': 'string'}, dimension['type'])
+
+    def test_required_open_object_maps_to_string_map(self):
+        """A required open object becomes a bare map<string> (no null wrapper)."""
+        structure = {
+            "type": "object",
+            "name": "Root",
+            "properties": {"payload": {"type": "object"}},
+            "required": ["payload"],
+        }
+        result = self.converter.convert(structure)
+        payload = next(f for f in result['fields'] if f['name'] == 'payload')
+        self.assertEqual(payload['type'], {'type': 'map', 'values': 'string'})
+        self._assert_parses(result)
+
+    def test_object_with_properties_becomes_nested_record(self):
+        """An inline object WITH properties must keep its shape as a nested record."""
+        structure = {
+            "type": "object",
+            "name": "Root",
+            "properties": {
+                "dimension": {
+                    "type": "object",
+                    "properties": {
+                        "width": {"type": "int32"},
+                        "height": {"type": "int32"},
+                    },
+                    "required": ["width", "height"],
+                }
+            },
+            "required": ["dimension"],
+        }
+        result = self.converter.convert(structure)
+        self._assert_no_bare_object_type(result)
+        self._assert_parses(result)
+
+        dim = next(f for f in result['fields'] if f['name'] == 'dimension')
+        self.assertEqual(dim['type']['type'], 'record')
+        self.assertEqual(dim['type']['name'], 'DimensionType')
+        field_names = {fld['name'] for fld in dim['type']['fields']}
+        self.assertEqual(field_names, {'width', 'height'})
+
+    def test_object_additional_properties_typed_map(self):
+        """additionalProperties as a type schema controls the map value type."""
+        structure = {
+            "type": "object",
+            "name": "Root",
+            "properties": {
+                "counts": {
+                    "type": "object",
+                    "additionalProperties": {"type": "int32"},
+                }
+            },
+            "required": ["counts"],
+        }
+        result = self.converter.convert(structure)
+        counts = next(f for f in result['fields'] if f['name'] == 'counts')
+        self.assertEqual(counts['type'], {'type': 'map', 'values': 'int'})
+        self._assert_parses(result)
+
+    def test_object_additional_properties_string_typename(self):
+        """additionalProperties given as a type *name* string also maps cleanly."""
+        structure = {
+            "type": "object",
+            "name": "Root",
+            "properties": {
+                "flags": {"type": "object", "additionalProperties": "boolean"}
+            },
+            "required": ["flags"],
+        }
+        result = self.converter.convert(structure)
+        flags = next(f for f in result['fields'] if f['name'] == 'flags')
+        self.assertEqual(flags['type'], {'type': 'map', 'values': 'boolean'})
+        self._assert_parses(result)
+
+    def test_array_of_inline_objects(self):
+        """Arrays whose items are inline objects-with-properties stay structured."""
+        structure = {
+            "type": "object",
+            "name": "Root",
+            "properties": {
+                "points": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {"x": {"type": "int32"}},
+                        "required": ["x"],
+                    },
+                }
+            },
+            "required": ["points"],
+        }
+        result = self.converter.convert(structure)
+        self._assert_no_bare_object_type(result)
+        self._assert_parses(result)
+        points = next(f for f in result['fields'] if f['name'] == 'points')
+        self.assertEqual(points['type']['type'], 'array')
+        self.assertEqual(points['type']['items']['type'], 'record')
+
+    def test_union_with_bare_object_and_array_members(self):
+        """A union listing bare 'object'/'array' members must remain valid Avro."""
+        structure = {
+            "type": "object",
+            "name": "Root",
+            "properties": {
+                "anything": {"type": ["string", "int32", "array", "object", "null"]}
+            },
+            "required": ["anything"],
+        }
+        result = self.converter.convert(structure)
+        self._assert_no_bare_object_type(result)
+        self._assert_parses(result)
+        anything = next(f for f in result['fields'] if f['name'] == 'anything')
+        self.assertIn({'type': 'map', 'values': 'string'}, anything['type'])
+        self.assertIn({'type': 'array', 'items': 'string'}, anything['type'])
+
+    def test_deeply_nested_inline_objects_preserved(self):
+        """Deeply nested inline objects are preserved (no data loss) and parse."""
+        structure = {
+            "type": "object",
+            "name": "Root",
+            "properties": {
+                "a": {
+                    "type": "object",
+                    "properties": {
+                        "b": {
+                            "type": "object",
+                            "properties": {"c": {"type": "string"}},
+                            "required": ["c"],
+                        }
+                    },
+                    "required": ["b"],
+                }
+            },
+            "required": ["a"],
+        }
+        result = self.converter.convert(structure)
+        self._assert_no_bare_object_type(result)
+        self._assert_parses(result)
+        a = next(f for f in result['fields'] if f['name'] == 'a')
+        b = next(f for f in a['type']['fields'] if f['name'] == 'b')
+        c = next(f for f in b['type']['fields'] if f['name'] == 'c')
+        self.assertEqual(c['type'], 'string')
+
+    def test_like_named_objects_get_unique_record_names(self):
+        """Like-named inline objects must yield unique Avro record names."""
+        structure = {
+            "type": "object",
+            "name": "Root",
+            "properties": {
+                "outer": {
+                    "type": "object",
+                    "properties": {
+                        "meta": {
+                            "type": "object",
+                            "properties": {"k": {"type": "string"}},
+                            "required": ["k"],
+                        }
+                    },
+                    "required": ["meta"],
+                },
+                "meta": {
+                    "type": "object",
+                    "properties": {"v": {"type": "string"}},
+                    "required": ["v"],
+                },
+            },
+            "required": ["outer", "meta"],
+        }
+        result = self.converter.convert(structure)
+        # Must parse: duplicate record names would raise a redefinition error.
+        self._assert_parses(result)
+
+        names = []
+
+        def collect(node):
+            if isinstance(node, dict):
+                if node.get('type') == 'record':
+                    names.append(node['name'])
+                for v in node.values():
+                    collect(v)
+            elif isinstance(node, list):
+                for v in node:
+                    collect(v)
+
+        collect(result)
+        self.assertEqual(len(names), len(set(names)), f"record names not unique: {names}")
+
+    def test_fastavro_roundtrip_through_nested_record(self):
+        """Data written/read through a converted nested-record schema survives."""
+        from fastavro import writer, reader
+        from fastavro.schema import parse_schema
+
+        structure = {
+            "type": "object",
+            "name": "Order",
+            "properties": {
+                "id": {"type": "string"},
+                "shipTo": {
+                    "type": "object",
+                    "properties": {
+                        "city": {"type": "string"},
+                        "zip": {"type": "string"},
+                    },
+                    "required": ["city", "zip"],
+                },
+                "attributes": {"type": "object"},
+            },
+            "required": ["id", "shipTo", "attributes"],
+        }
+        schema = self.converter.convert(structure)
+        parsed = parse_schema(schema)
+
+        record = {
+            "id": "order-1",
+            "shipTo": {"city": "Seattle", "zip": "98101"},
+            "attributes": {"gift": "true", "priority": "high"},
+        }
+        buf = io.BytesIO()
+        writer(buf, parsed, [record])
+        buf.seek(0)
+        out = list(reader(buf))
+        self.assertEqual(out[0], record)
+
+    def test_all_struct_fixtures_emit_no_bare_object(self):
+        """No committed JSON Structure fixture may emit a bare ``object`` type.
+
+        This is the core #336 invariant across the whole fixture corpus. (Full
+        fastavro parseability is asserted in the self-contained tests above;
+        a few fixtures exercise an unrelated pre-existing forward-reference in
+        multi-type list emission, which is outside the scope of this fix.)
+        """
+        import glob
+
+        fixtures = sorted(glob.glob('test/struct/*.struct.json'))
+        self.assertTrue(fixtures, "no struct fixtures discovered")
+        for path in fixtures:
+            with self.subTest(fixture=path):
+                with open(path, 'r', encoding='utf-8') as fh:
+                    structure = json.load(fh)
+                result = JsonStructureToAvro().convert(structure)
+                self._assert_no_bare_object_type(result)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

`avrotize s2a` (JSON Structure -> Avro) converted a property typed as
`{"type": "object"}` to the bare literal `"object"`, which is **not a valid
Avro type** — parsers reject it and Microsoft Fabric `EventSchemaSet`
validation fails. Worse, inline objects that *did* declare `properties` had
their entire nested shape discarded (silent data loss).

Closes #336

## Fix

In `avrotize/jstructtoavro.py`, inline `object` types are now handled before the
primitive fallthrough:

- **open / property-less object** -> `{"type": "map", "values": "string"}`
  (the canonical mapping from the issue and the user's manual AIS workaround),
  honoring an `additionalProperties` value type when one is specified;
- **object with `properties`** -> a nested Avro `record`, preserving the full
  shape, with a unique readable record name derived from the enclosing property
  (with a collision-avoidance suffix for like-named objects at different levels);
- **bare `"object"`/`"array"` union members** -> their valid open Avro forms
  (`map<string>` / `array<string>`), fixing the same invalidity inside unions.

## Tests

New `TestInlineObjectConversion` suite:
- exact issue #336 reproducer (`ObjLit` / `Dimension`);
- required vs. optional open objects; objects with `properties`;
- `additionalProperties` as a type schema and as a type-name string;
- arrays of inline objects; unions with bare `object`/`array` members;
- deep nesting (no data loss); like-named-object name-uniqueness;
- a fastavro write/read round-trip through a converted nested record;
- a corpus-wide invariant: **no** committed struct fixture emits a bare object.

Three struct reference fixtures (`nested-objects`, `complex-scenario`,
`edge-cases`) whose committed output contained the invalid bare `"object"` are
regenerated with the corrected, fastavro-parseable output.

`python -m pytest test/test_jstructtoavro.py test/test_avrotojstruct.py` ->
**54 passed**. CLI smoke (`s2a` on the issue reproducer) produces a
fastavro-parseable schema.