### PR TITLE
fix(j2a): preserve JSON Schema format logical types in Avro output (#337)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ All notable changes to Avrotize are documented in this file.
 
 ### Fixed
 
+- **j2a dropped JSON Schema `format` logical types (issue #337)**: Converting a
+  JSON Schema / OpenAPI field with `"format": "date-time"` produced a bare Avro
+  `int` (32-bit — silent millisecond-timestamp overflow) and discarded the
+  logical type. The post-processing step that inlines basic types now preserves
+  logical-type annotations, so:
+  - `date-time` -> `{"type": "long", "logicalType": "timestamp-millis"}`
+  - `date` -> `{"type": "int", "logicalType": "date"}`
+  - `time` -> `{"type": "int", "logicalType": "time-millis"}`
+  - `uuid` -> `{"type": "string", "logicalType": "uuid"}`
+  These are retained for required, optional (nullable), array-item, and nested
+  field positions.
 - **int64/uint64/int128/uint128/decimal JSON string serialization (issue #346)**:
   All language code generators now serialize these types as JSON strings (not
   numbers) per the JSON Structure Core spec, since IEEE-754 doubles cannot

--- a/avrotize/jsonstoavro.py
+++ b/avrotize/jsonstoavro.py
@@ -591,14 +591,16 @@ class JsonToAvroConverter:
 
         # if you've got { 'type': 'string', 'format': ['date-time', 'duration'] }, I'm sorry
         if format and isinstance(format, str):
-            if format in ('date-time', 'date'):
+            if format == 'date-time':
+                avro_primitive = {'type': 'long', 'logicalType': 'timestamp-millis'}
+            elif format == 'date':
                 avro_primitive = {'type': 'int', 'logicalType': 'date'}
-            elif format in ('time'):
+            elif format == 'time':
                 avro_primitive = {'type': 'int', 'logicalType': 'time-millis'}
-            elif format in ('duration'):
+            elif format == 'duration':
                 avro_primitive = {'type': 'fixed',
                                   'size': 12, 'logicalType': 'duration'}
-            elif format in ('uuid'):
+            elif format == 'uuid':
                 avro_primitive = {'type': 'string', 'logicalType': 'uuid'}
 
         return avro_primitive
@@ -1357,7 +1359,14 @@ class JsonToAvroConverter:
         if isinstance(avro_type, dict) and 'type' in avro_type and (isinstance(avro_type, list) or not avro_type['type'] in ['array', 'map', 'record', 'enum', 'fixed']):
             if 'dependencies' in avro_type:
                 dependencies.extend(avro_type['dependencies'])
-            avro_type = avro_type['type']
+            # Preserve logical-type annotations (e.g. timestamp-millis, date,
+            # time-millis, uuid). Collapsing these to the bare base type would
+            # silently discard the logical meaning (and, for date-time, the
+            # required 64-bit width). See issue #337.
+            if 'logicalType' in avro_type:
+                avro_type = {k: v for k, v in avro_type.items() if k != 'dependencies'}
+            else:
+                avro_type = avro_type['type']
         return avro_type
 
     def register_type(self, avro_schema, avro_type) -> bool:
@@ -1733,8 +1742,9 @@ class JsonToAvroConverter:
                             # None type is a problem
                             raise ValueError(
                                 f"avro_field_type is None for field {field_name}")
-                        if isinstance(avro_field_type, dict) and 'type' in avro_field_type and not self.is_avro_complex_type(avro_field_type):
+                        if isinstance(avro_field_type, dict) and 'type' in avro_field_type and 'logicalType' not in avro_field_type and not self.is_avro_complex_type(avro_field_type):
                             # if the field type is a basic type, inline it
+                            # (logical types are kept intact, see issue #337)
                             avro_field_type = avro_field_type['type']
                         field_type_list.append(avro_field_type)
                         field_ref_type_list.append(avro_field_ref_type)

--- a/test/test_jsontoavro.py
+++ b/test/test_jsontoavro.py
@@ -149,3 +149,158 @@ class TestJsonsToAvro(unittest.TestCase):
     def test_convert_conditional_schema_patterns_to_avro(self):
         """Test if/then/else conditional schema patterns conversion."""
         self.create_avro_from_jsons("conditional-schema-patterns.json", "conditional-schema-patterns.avsc")
+
+
+class TestFormatLogicalTypes(unittest.TestCase):
+    """Issue #337: JSON Schema string ``format`` values must convert to the
+    correct Avro logical types instead of being collapsed to a bare base type.
+
+    Notably ``date-time`` must become ``{"type": "long", "logicalType":
+    "timestamp-millis"}`` — a bare ``int``/``long`` loses both the 64-bit width
+    (silent overflow) and the temporal semantics.
+    """
+
+    def _convert(self, json_schema: dict) -> dict:
+        """Convert an in-memory JSON Schema to an Avro schema dict.
+
+        Validates fastavro-parseability as a side effect (raises on invalid).
+        """
+        tmpdir = tempfile.mkdtemp()
+        json_path = os.path.join(tmpdir, "in.json")
+        avro_path = os.path.join(tmpdir, "out.avsc")
+        with open(json_path, "w", encoding="utf-8") as handle:
+            json.dump(json_schema, handle)
+        convert_jsons_to_avro(json_path, avro_path, "com.test.example")
+        load_schema(avro_path)  # fastavro validity gate
+        with open(avro_path, "r", encoding="utf-8") as handle:
+            return json.load(handle)
+
+    @staticmethod
+    def _field(record: dict, name: str) -> dict:
+        return next(f for f in record["fields"] if f["name"] == name)
+
+    @staticmethod
+    def _schema(properties: dict, required=None) -> dict:
+        schema = {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "title": "Event",
+            "properties": properties,
+        }
+        if required is not None:
+            schema["required"] = required
+        return schema
+
+    def test_date_time_maps_to_timestamp_millis(self):
+        """The core issue: required date-time -> long/timestamp-millis."""
+        record = self._convert(self._schema(
+            {"createdTimestamp": {"type": "string", "format": "date-time"}},
+            required=["createdTimestamp"],
+        ))
+        field = self._field(record, "createdTimestamp")
+        self.assertEqual(field["type"], {"type": "long", "logicalType": "timestamp-millis"})
+
+    def test_date_time_is_long_not_int(self):
+        """Regression guard against the 32-bit overflow: base must be long."""
+        record = self._convert(self._schema(
+            {"ts": {"type": "string", "format": "date-time"}},
+            required=["ts"],
+        ))
+        field_type = self._field(record, "ts")["type"]
+        self.assertIsInstance(field_type, dict)
+        self.assertEqual(field_type["type"], "long")
+        self.assertNotEqual(field_type["type"], "int")
+
+    def test_date_maps_to_date_logical_type(self):
+        """date -> int/date (correct: Avro date is days-since-epoch in an int)."""
+        record = self._convert(self._schema(
+            {"birthDate": {"type": "string", "format": "date"}},
+            required=["birthDate"],
+        ))
+        field = self._field(record, "birthDate")
+        self.assertEqual(field["type"], {"type": "int", "logicalType": "date"})
+
+    def test_time_maps_to_time_millis(self):
+        """time -> int/time-millis."""
+        record = self._convert(self._schema(
+            {"alarm": {"type": "string", "format": "time"}},
+            required=["alarm"],
+        ))
+        field = self._field(record, "alarm")
+        self.assertEqual(field["type"], {"type": "int", "logicalType": "time-millis"})
+
+    def test_uuid_maps_to_uuid_logical_type(self):
+        """uuid -> string/uuid (preserved, not flattened to bare string)."""
+        record = self._convert(self._schema(
+            {"id": {"type": "string", "format": "uuid"}},
+            required=["id"],
+        ))
+        field = self._field(record, "id")
+        self.assertEqual(field["type"], {"type": "string", "logicalType": "uuid"})
+
+    def test_optional_date_time_is_nullable_logical_type(self):
+        """An optional date-time becomes ['null', {long, timestamp-millis}]."""
+        record = self._convert(self._schema(
+            {"updatedTimestamp": {"type": "string", "format": "date-time"}},
+        ))
+        field_type = self._field(record, "updatedTimestamp")["type"]
+        self.assertIsInstance(field_type, list)
+        self.assertIn("null", field_type)
+        self.assertIn({"type": "long", "logicalType": "timestamp-millis"}, field_type)
+
+    def test_array_of_date_time(self):
+        """An array of date-time keeps the logical type on its items."""
+        record = self._convert(self._schema(
+            {"timestamps": {
+                "type": "array",
+                "items": {"type": "string", "format": "date-time"},
+            }},
+            required=["timestamps"],
+        ))
+        field_type = self._field(record, "timestamps")["type"]
+        self.assertEqual(field_type["type"], "array")
+        self.assertEqual(field_type["items"], {"type": "long", "logicalType": "timestamp-millis"})
+
+    def test_multiple_temporal_formats_together(self):
+        """A schema mixing several formats converts each one correctly."""
+        record = self._convert(self._schema(
+            {
+                "created": {"type": "string", "format": "date-time"},
+                "day": {"type": "string", "format": "date"},
+                "at": {"type": "string", "format": "time"},
+                "ref": {"type": "string", "format": "uuid"},
+            },
+            required=["created", "day", "at", "ref"],
+        ))
+        self.assertEqual(self._field(record, "created")["type"],
+                         {"type": "long", "logicalType": "timestamp-millis"})
+        self.assertEqual(self._field(record, "day")["type"],
+                         {"type": "int", "logicalType": "date"})
+        self.assertEqual(self._field(record, "at")["type"],
+                         {"type": "int", "logicalType": "time-millis"})
+        self.assertEqual(self._field(record, "ref")["type"],
+                         {"type": "string", "logicalType": "uuid"})
+
+    def test_fastavro_roundtrip_timestamp_millis(self):
+        """Data written/read through the converted schema preserves the instant."""
+        from datetime import datetime, timezone
+        import io
+        from fastavro import writer, reader
+        from fastavro.schema import parse_schema
+
+        record_schema = self._convert(self._schema(
+            {
+                "id": {"type": "string"},
+                "createdTimestamp": {"type": "string", "format": "date-time"},
+            },
+            required=["id", "createdTimestamp"],
+        ))
+        parsed = parse_schema(record_schema)
+
+        moment = datetime(2021, 6, 4, 12, 30, 45, tzinfo=timezone.utc)
+        datum = {"id": "evt-1", "createdTimestamp": moment}
+        buffer = io.BytesIO()
+        writer(buffer, parsed, [datum])
+        buffer.seek(0)
+        out = list(reader(buffer))
+        self.assertEqual(out[0]["createdTimestamp"], moment)


### PR DESCRIPTION
## Summary

`avrotize j2a` converted JSON Schema / OpenAPI fields with `"format": "date-time"`
to a bare Avro `"int"`. This is doubly wrong:

1. **Data loss** — `int` is 32-bit and cannot hold millisecond Unix timestamps
   (tens of trillions), causing silent overflow.
2. **Semantic loss** — the `timestamp-millis` logical type is discarded, so
   consumers cannot tell the field is a point in time.

`date`, `time`, and `uuid` formats were stripped of their logical types too.

Closes #337

## Root cause

Two "inline a basic type" steps collapsed every `{"type": X, ...}` wrapper down
to the bare base type `X`:
- `post_check_avro_type`, and
- the record field builder (`json_type_to_avro_type`).

Because a logical-typed primitive is not an Avro *complex* type, both stripped
the `logicalType`. Additionally, the primitive mapping mapped `date-time` and
`date` to the same `int`/`date` pair.

## Fix

- The primitive mapping now distinguishes `date-time`
  (`{"type":"long","logicalType":"timestamp-millis"}`) from `date`
  (`{"type":"int","logicalType":"date"}`), and uses exact `==` matches.
- Both inlining steps now keep the wrapper intact when a `logicalType` is
  present (dependencies are still lifted as before).

Resulting mappings (required, optional/nullable, array-item, and nested
positions all preserved):

| format | Avro type |
|--------|-----------|
| `date-time` | `{"type":"long","logicalType":"timestamp-millis"}` |
| `date` | `{"type":"int","logicalType":"date"}` |
| `time` | `{"type":"int","logicalType":"time-millis"}` |
| `uuid` | `{"type":"string","logicalType":"uuid"}` |

## Tests

New `TestFormatLogicalTypes`: the exact issue reproducer, each format, the
`int`->`long` overflow regression guard, optional/array/mixed positions, a
fastavro validity gate, and a `timestamp-millis` write/read round-trip.

`python -m pytest test/test_jsontoavro.py test/test_json2a_inference.py` ->
**60 passed** (no fixture regressions).