### PR TITLE
fix(a2p): valid Python enum members for non-identifier symbols (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ All notable changes to Avrotize are documented in this file.
   environment to handle Unicode characters on Windows cp1252 consoles.
 - **MCP CLI test**: Updated prompt format for `get_conversion` tool to match
   current Copilot CLI conventions.
+- **Avro to Python enum symbols (issue #354)**: `a2p` now sanitizes enum member
+  names that are numeric, digit-prefixed, hyphenated, reserved words, or otherwise
+  invalid Python identifiers while preserving the original Avro symbol strings as
+  enum values.
 
 ## [3.5.7] - 2026-05-23
 

--- a/avrotize/avrotopython.py
+++ b/avrotize/avrotopython.py
@@ -90,6 +90,38 @@ class AvroToPython:
             return name + "_"
         return name
 
+    def safe_enum_symbols(self, symbols: List[str]) -> List[Dict[str, str]]:
+        """Converts Avro enum symbols to collision-safe Python enum members."""
+        enum_symbols = []
+        used_names = set()
+
+        for symbol in symbols:
+            if symbol.isidentifier() and not is_python_reserved_word(symbol):
+                member_name = symbol
+            else:
+                member_name = re.sub(r'[^0-9A-Za-z_]', '_', symbol).strip('_').upper()
+                if not member_name:
+                    member_name = "VALUE"
+                if member_name[0].isdigit():
+                    member_name = f"VALUE_{member_name}"
+                if is_python_reserved_word(symbol) or is_python_reserved_word(member_name.lower()) or is_python_reserved_word(member_name):
+                    member_name = f"{member_name}_"
+
+            base_member_name = member_name
+            suffix = 2
+            while member_name in used_names or not member_name.isidentifier() or is_python_reserved_word(member_name):
+                member_name = f"{base_member_name}_{suffix}"
+                suffix += 1
+
+            used_names.add(member_name)
+            enum_symbols.append({
+                'name': member_name,
+                'value': symbol,
+                'value_literal': repr(symbol)
+            })
+
+        return enum_symbols
+
     def pascal_type_name(self, ref: str) -> str:
         """Converts a reference to a type name"""
         return '_'.join([pascal(part) for part in ref.split('.')[-1].split('_')])
@@ -350,9 +382,12 @@ class AvroToPython:
         if python_qualified_name in self.generated_types:
             return python_qualified_name
 
-        symbols = [symbol if not is_python_reserved_word(
-            symbol) else symbol + "_" for symbol in avro_schema.get('symbols', [])]
-        ordinals =  avro_schema.get('ordinals', {})
+        symbols = self.safe_enum_symbols(avro_schema.get('symbols', []))
+        symbol_names_by_value = {symbol['value']: symbol['name'] for symbol in symbols}
+        ordinals = {
+            symbol_names_by_value[symbol]: ordinal
+            for symbol, ordinal in avro_schema.get('ordinals', {}).items()
+        }
 
         enum_definition = process_template(
             "avrotopython/enum_core.jinja",

--- a/avrotize/avrotopython/enum_core.jinja
+++ b/avrotize/avrotopython/enum_core.jinja
@@ -9,7 +9,7 @@ class {{ class_name }}(Enum):
     {{ docstring }}
     """
     {%- for symbol in symbols %}
-    {{ symbol }} = '{{symbol}}'
+    {{ symbol.name }} = {{ symbol.value_literal }}
     {%- endfor %}
 
     @classmethod

--- a/avrotize/avrotopython/test_enum.jinja
+++ b/avrotize/avrotopython/test_enum.jinja
@@ -19,5 +19,4 @@ class {{ test_class_name }}(unittest.TestCase):
         """
         Create instance of {{ class_name }}
         """
-        return "{{ symbols[0] }}"
-
+        return {{ symbols[0].value_literal }}

--- a/test/test_avrotopython.py
+++ b/test/test_avrotopython.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch
+import importlib
 import unittest
 import os
 import shutil
@@ -124,7 +125,43 @@ class TestAvroToPython(unittest.TestCase):
         new_env['PYTHONPATH'] = py_path
         assert subprocess.check_call(
             ['python', '-m', 'pytest'], cwd=py_path, env=new_env, stdout=sys.stdout, stderr=sys.stderr, shell=True) == 0
-        
+
+    def test_enum_symbols_that_are_not_python_identifiers_are_importable(self):
+        """ Test Avro enum symbols are valid Python member names while preserving values """
+        schema = {
+            "type": "enum",
+            "name": "StatusEnum",
+            "namespace": "example.issue354",
+            "symbols": ["0", "1", "3D", "VALUE_3D", "in-progress", "class"]
+        }
+        py_path = os.path.join(os.getcwd(), "test", "output", "issue354-enum-symbols-py")
+        if os.path.exists(py_path):
+            shutil.rmtree(py_path, ignore_errors=True)
+        os.makedirs(py_path, exist_ok=True)
+
+        try:
+            from avrotize.avrotopython import convert_avro_schema_to_python
+            convert_avro_schema_to_python(schema, py_path, package_name="issue354")
+
+            enum_file = os.path.join(py_path, "src", "issue354", "example", "issue354", "statusenum.py")
+            with open(enum_file, "r", encoding="utf-8") as file:
+                enum_source = file.read()
+            compile(enum_source, enum_file, "exec")
+
+            sys.path.insert(0, os.path.join(py_path, "src"))
+            try:
+                module = importlib.import_module("issue354.example.issue354.statusenum")
+                StatusEnum = module.StatusEnum
+                assert [member.value for member in StatusEnum] == schema["symbols"]
+            finally:
+                sys.path.remove(os.path.join(py_path, "src"))
+                sys.modules.pop("issue354", None)
+                sys.modules.pop("issue354.example", None)
+                sys.modules.pop("issue354.example.issue354", None)
+                sys.modules.pop("issue354.example.issue354.statusenum", None)
+        finally:
+            shutil.rmtree(py_path, ignore_errors=True)
+
     def test_convert_feeditem_avsc_to_python(self):
         """ Test converting a enumfield-ordinal.avsc file to Python """
         cwd = os.getcwd()


### PR DESCRIPTION
Closes #354

## Root cause
`avrotize/avrotopython.py` passed raw Avro enum symbols directly to the Python enum template as member names, so symbols like `"0"`, `"3D"`, `"in-progress"`, or `"class"` generated invalid Python syntax or reserved identifiers.

## Fix summary
- Added deterministic, collision-safe enum member-name sanitization for Avro-to-Python generation.
- Preserved each original Avro symbol string as the Python `Enum` member value.
- Updated enum templates, generated enum tests, changelog, and regression coverage for numeric, digit-prefixed, hyphenated, keyword, and colliding symbols.

## Validation
- Initial TDD test failed before the fix with `SyntaxError: invalid decimal literal`.
- `python -m pytest test\test_avrotopython.py -q` -> `15 passed in 175.41s (0:02:55)`
- `python -m pytest test\ -q -k python` -> `45 passed, 832 deselected, 3 warnings, 20 subtests passed in 697.81s (0:11:37)`
- CLI smoke: `python -m avrotize a2py test\avsc\enumfield.avsc --out test\output\issue354-cli-smoke` and compiled generated files -> `compiled 7 files`