### PR TITLE
fix(a2ts): do not rename TypeScript contextual keywords (#339)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ All notable changes to Avrotize are documented in this file.
 
 ### Fixed
 
+- **Avro to TypeScript contextual field names (issue #339)**: `a2ts` now preserves
+  TypeScript contextual keywords such as `type`, `namespace`, `module`, and
+  `readonly` when they are used as Avro field names instead of renaming them
+  with a trailing underscore.
 - **int64/uint64/int128/uint128/decimal JSON string serialization (issue #346)**:
   All language code generators now serialize these types as JSON strings (not
   numbers) per the JSON Structure Core spec, since IEEE-754 doubles cannot

--- a/README.md
+++ b/README.md
@@ -1030,6 +1030,7 @@ Conversion notes:
 
 - The tool generates TypeScript classes from the Avrotize Schema. Each record type in the Avrotize Schema is converted to a TypeScript class.
 - The fields of the record are mapped to properties in the TypeScript class. Nested records are mapped to nested classes in the TypeScript class.
+- TypeScript contextual keywords such as `type`, `namespace`, `module`, and `readonly` are preserved when used as field names.
 - The tool supports adding annotations to the properties in the TypeScript class. The `--avro-annotation` option adds Avro annotations, and the `--typedjson-annotation` option adds TypedJSON annotations.
 
 ### Convert JSON Structure to TypeScript classes

--- a/avrotize/avrotots.py
+++ b/avrotize/avrotots.py
@@ -16,7 +16,6 @@ def is_typescript_reserved_word(word: str) -> bool:
         'for', 'function', 'if', 'import', 'in', 'instanceof', 'new', 'return',
         'super', 'switch', 'this', 'throw', 'try', 'typeof', 'var', 'void',
         'while', 'with', 'yield', 'enum', 'string', 'number', 'boolean', 'symbol',
-        'type', 'namespace', 'module', 'declare', 'abstract', 'readonly',
     ]
     return word in reserved_words
 

--- a/test/test_avrotots.py
+++ b/test/test_avrotots.py
@@ -42,6 +42,47 @@ class TestAvroToTypeScript(unittest.TestCase):
         self.run_test("telemetry", typedjson_annotation=True)
         self.run_test("telemetry", avro_annotation=True)
 
+    def test_contextual_keywords_are_preserved_as_field_names(self):
+        """TypeScript contextual keywords are valid field/property names."""
+        schema = {
+            "type": "record",
+            "name": "Event",
+            "namespace": "com.example.events.v1",
+            "fields": [
+                {"name": "type", "type": "string"},
+                {"name": "namespace", "type": "string"},
+                {"name": "module", "type": "string"},
+                {"name": "readonly", "type": "boolean"},
+                {"name": "class", "type": "string"},
+            ],
+        }
+        base_path = os.path.join(tempfile.gettempdir(), "avrotize", "typescript-contextual-keywords")
+        avro_path = os.path.join(base_path, "event.avsc")
+        ts_path = os.path.join(base_path, "out")
+        if os.path.exists(base_path):
+            shutil.rmtree(base_path, ignore_errors=True)
+        os.makedirs(base_path, exist_ok=True)
+
+        with open(avro_path, "w", encoding="utf-8") as f:
+            json.dump(schema, f)
+
+        convert_avro_to_typescript(avro_path, ts_path, "eventtypes")
+
+        event_file = None
+        for root, dirs, files in os.walk(os.path.join(ts_path, "src")):
+            if "Event.ts" in files:
+                event_file = os.path.join(root, "Event.ts")
+                break
+
+        self.assertIsNotNone(event_file, "Event.ts should be generated")
+        with open(event_file, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        for field_name in ("type", "namespace", "module", "readonly"):
+            self.assertIn(f"public {field_name}:", content)
+            self.assertNotIn(f"public {field_name}_", content)
+        self.assertIn("public class_:", content)
+
     def test_convert_jfrog_pipelines_jsons_to_avro_to_typescript(self):
         """ Test converting a jfrog-pipelines.json file to C# """
         cwd = getcwd()        


### PR DESCRIPTION
Closes #339

## Root cause
`a2ts` treated TypeScript contextual keywords (`type`, `namespace`, `module`, `declare`, `abstract`, `readonly`) as reserved words, so valid Avro field names were emitted with trailing underscores.

## Fix
Removed those contextual keywords from the Avro-to-TypeScript reserved-word list so generated class properties preserve the Avro field names. Added a regression test that verifies contextual names are preserved while a true reserved word is still escaped.

## Test evidence
- `python -m pytest test\test_avrotots.py -q` -> `16 passed, 11 subtests passed in 258.69s (0:04:18)`
- `python -m pytest test\ -q -k "ts or typescript"` -> `323 passed, 4 skipped, 550 deselected, 3 warnings, 50 subtests passed in 2092.60s (0:34:52)`
- CLI smoke: `python -m avrotize a2ts .\test\avsc\address.avsc --out .\smoke-a2ts-output` succeeded.