### PR TITLE
fix(kusto): remove trailing commas in JSON mappings + add --emit-materialized-views flag

### DIFF
--- a/avrotize/avrotokusto.py
+++ b/avrotize/avrotokusto.py
@@ -24,7 +24,7 @@ class AvroToKusto:
         """Initializes a new instance of the AvroToKusto class."""
         pass
 
-    def convert_record_to_kusto(self, type_dict:dict, recordschema: dict, emit_cloudevents_columns: bool, emit_cloudevents_dispatch_table: bool, qualified_table_names: bool = False, namespace_override: str | None = None) -> List[str]:
+    def convert_record_to_kusto(self, type_dict:dict, recordschema: dict, emit_cloudevents_columns: bool, emit_cloudevents_dispatch_table: bool, qualified_table_names: bool = False, namespace_override: str | None = None, emit_materialized_views: bool = True) -> List[str]:
         """Converts an Avro record schema to a Kusto table schema."""
         # Get the name and fields of the top-level record
         simple_name = recordschema["name"]
@@ -120,14 +120,13 @@ class AvroToKusto:
         kusto.append(
             f".create-or-alter table {table_ref} ingestion json mapping \"{mapping_base}_json_flat\"")
         kusto.append("```\n[")
+        flat_mapping_entries = []
         if emit_cloudevents_columns:
-            kusto.append("  {\"column\": \"___type\", \"path\": \"$.type\"},")
-            kusto.append(
-                "  {\"column\": \"___source\", \"path\": \"$.source\"},")
-            kusto.append("  {\"column\": \"___id\", \"path\": \"$.id\"},")
-            kusto.append("  {\"column\": \"___time\", \"path\": \"$.time\"},")
-            kusto.append(
-                "  {\"column\": \"___subject\", \"path\": \"$.subject\"},")
+            flat_mapping_entries.append("  {\"column\": \"___type\", \"path\": \"$.type\"}")
+            flat_mapping_entries.append("  {\"column\": \"___source\", \"path\": \"$.source\"}")
+            flat_mapping_entries.append("  {\"column\": \"___id\", \"path\": \"$.id\"}")
+            flat_mapping_entries.append("  {\"column\": \"___time\", \"path\": \"$.time\"}")
+            flat_mapping_entries.append("  {\"column\": \"___subject\", \"path\": \"$.subject\"}")
         for field in fields:
             json_name = column_name = field["name"]
             if 'altnames' in field:
@@ -135,21 +134,21 @@ class AvroToKusto:
                     column_name = field['altnames']['kql']
                 if 'json' in field['altnames']:
                     json_name = field['altnames']['json']
-            kusto.append(
-                f"  {{\"column\": \"{column_name}\", \"path\": \"$.{json_name}\"}},")
+            flat_mapping_entries.append(
+                f"  {{\"column\": \"{column_name}\", \"path\": \"$.{json_name}\"}}")
+        kusto.append(",\n".join(flat_mapping_entries))
         kusto.append("]\n```\n\n")
 
         if emit_cloudevents_columns:
             kusto.append(
                 f".create-or-alter table {table_ref} ingestion json mapping \"{mapping_base}_json_ce_structured\"")
             kusto.append("```\n[")
-            kusto.append("  {\"column\": \"___type\", \"path\": \"$.type\"},")
-            kusto.append(
-                "  {\"column\": \"___source\", \"path\": \"$.source\"},")
-            kusto.append("  {\"column\": \"___id\", \"path\": \"$.id\"},")
-            kusto.append("  {\"column\": \"___time\", \"path\": \"$.time\"},")
-            kusto.append(
-                "  {\"column\": \"___subject\", \"path\": \"$.subject\"},")
+            ce_mapping_entries = []
+            ce_mapping_entries.append("  {\"column\": \"___type\", \"path\": \"$.type\"}")
+            ce_mapping_entries.append("  {\"column\": \"___source\", \"path\": \"$.source\"}")
+            ce_mapping_entries.append("  {\"column\": \"___id\", \"path\": \"$.id\"}")
+            ce_mapping_entries.append("  {\"column\": \"___time\", \"path\": \"$.time\"}")
+            ce_mapping_entries.append("  {\"column\": \"___subject\", \"path\": \"$.subject\"}")
             for field in fields:
                 json_name = column_name = field["name"]
                 if 'altnames' in field:
@@ -157,11 +156,12 @@ class AvroToKusto:
                         column_name = field['altnames']['kql']
                     if 'json' in field['altnames']:
                         json_name = field['altnames']['json']
-                kusto.append(
-                    f"  {{\"column\": \"{column_name}\", \"path\": \"$.data.{json_name}\"}},")
+                ce_mapping_entries.append(
+                    f"  {{\"column\": \"{column_name}\", \"path\": \"$.data.{json_name}\"}}")
+            kusto.append(",\n".join(ce_mapping_entries))
             kusto.append("]\n```\n\n")
 
-        if emit_cloudevents_columns:
+        if emit_cloudevents_columns and emit_materialized_views:
             kusto.append(
                 f".drop materialized-view {mv_ref} ifexists;")
             kusto.append("")
@@ -196,13 +196,13 @@ class AvroToKusto:
             kusto.append(
                 f"  \"Query\": \"{query}\",")
             kusto.append("  \"IsTransactional\": false,")
-            kusto.append("  \"PropagateIngestionProperties\": true,")
+            kusto.append("  \"PropagateIngestionProperties\": true")
             kusto.append("}]")
             kusto.append("```\n")
 
         return kusto
 
-    def convert_avro_to_kusto_script(self, avro_schema_path, avro_record_type, emit_cloudevents_columns=False, emit_cloudevents_dispatch_table=False, qualified_table_names: bool = False, namespace_override: str | None = None) -> str:
+    def convert_avro_to_kusto_script(self, avro_schema_path, avro_record_type, emit_cloudevents_columns=False, emit_cloudevents_dispatch_table=False, qualified_table_names: bool = False, namespace_override: str | None = None, emit_materialized_views: bool = True) -> str:
         """Converts an Avro schema to a Kusto table schema."""
         if emit_cloudevents_dispatch_table:
             emit_cloudevents_columns = True
@@ -274,13 +274,13 @@ class AvroToKusto:
             if not isinstance(record, dict) or "type" not in record or record["type"] != "record":
                 continue
             kusto_script.extend(self.convert_record_to_kusto(type_dict,
-                record, emit_cloudevents_columns, emit_cloudevents_dispatch_table, qualified_table_names, namespace_override))
+                record, emit_cloudevents_columns, emit_cloudevents_dispatch_table, qualified_table_names, namespace_override, emit_materialized_views))
         return "\n".join(kusto_script)
 
-    def convert_avro_to_kusto_file(self, avro_schema_path, avro_record_type, kusto_file_path, emit_cloudevents_columns=False, emit_cloudevents_dispatch_table=False, qualified_table_names: bool = False, namespace_override: str | None = None):
+    def convert_avro_to_kusto_file(self, avro_schema_path, avro_record_type, kusto_file_path, emit_cloudevents_columns=False, emit_cloudevents_dispatch_table=False, qualified_table_names: bool = False, namespace_override: str | None = None, emit_materialized_views: bool = True):
         """Converts an Avro schema to a Kusto table schema."""
         script = self.convert_avro_to_kusto_script(
-            avro_schema_path, avro_record_type, emit_cloudevents_columns, emit_cloudevents_dispatch_table, qualified_table_names, namespace_override)
+            avro_schema_path, avro_record_type, emit_cloudevents_columns, emit_cloudevents_dispatch_table, qualified_table_names, namespace_override, emit_materialized_views)
         with open(kusto_file_path, "w", encoding="utf-8") as kusto_file:
             kusto_file.write(script)
 
@@ -357,18 +357,18 @@ class AvroToKusto:
             return "dynamic"
 
 
-def convert_avro_to_kusto_file(avro_schema_path, avro_record_type, kusto_file_path, emit_cloudevents_columns=False, emit_cloudevents_dispatch_table=False, qualified_table_names: bool = False, namespace: str | None = None):
+def convert_avro_to_kusto_file(avro_schema_path, avro_record_type, kusto_file_path, emit_cloudevents_columns=False, emit_cloudevents_dispatch_table=False, qualified_table_names: bool = False, namespace: str | None = None, emit_materialized_views: bool = True):
     """Converts an Avro schema to a Kusto table schema."""
     avro_to_kusto = AvroToKusto()
     avro_to_kusto.convert_avro_to_kusto_file(
-        avro_schema_path, avro_record_type, kusto_file_path, emit_cloudevents_columns, emit_cloudevents_dispatch_table, qualified_table_names, namespace)
+        avro_schema_path, avro_record_type, kusto_file_path, emit_cloudevents_columns, emit_cloudevents_dispatch_table, qualified_table_names, namespace, emit_materialized_views)
 
 
-def convert_avro_to_kusto_db(avro_schema_path, avro_record_type, kusto_uri, kusto_database, emit_cloudevents_columns=False, emit_cloudevents_dispatch_table=False, token_provider=None, qualified_table_names: bool = False, namespace: str | None = None):
+def convert_avro_to_kusto_db(avro_schema_path, avro_record_type, kusto_uri, kusto_database, emit_cloudevents_columns=False, emit_cloudevents_dispatch_table=False, token_provider=None, qualified_table_names: bool = False, namespace: str | None = None, emit_materialized_views: bool = True):
     """Converts an Avro schema to a Kusto table schema."""
     avro_to_kusto = AvroToKusto()
     script = avro_to_kusto.convert_avro_to_kusto_script(
-        avro_schema_path, avro_record_type, emit_cloudevents_columns, emit_cloudevents_dispatch_table, qualified_table_names, namespace)
+        avro_schema_path, avro_record_type, emit_cloudevents_columns, emit_cloudevents_dispatch_table, qualified_table_names, namespace, emit_materialized_views)
     kcsb = KustoConnectionStringBuilder.with_az_cli_authentication(
         kusto_uri) if not token_provider else KustoConnectionStringBuilder.with_token_provider(kusto_uri, token_provider)
     client = KustoClient(kcsb)
@@ -380,11 +380,11 @@ def convert_avro_to_kusto_db(avro_schema_path, avro_record_type, kusto_uri, kust
                 print(e)
                 sys.exit(1)
 
-def convert_avro_to_kusto(avro_schema_path, avro_record_type, kusto_file_path, kusto_uri, kusto_database, emit_cloudevents_columns=False, emit_cloudevents_dispatch_table=False, token_provider=None, qualified_table_names: bool = False, namespace: str | None = None):
+def convert_avro_to_kusto(avro_schema_path, avro_record_type, kusto_file_path, kusto_uri, kusto_database, emit_cloudevents_columns=False, emit_cloudevents_dispatch_table=False, token_provider=None, qualified_table_names: bool = False, namespace: str | None = None, emit_materialized_views: bool = True):
     """Converts an Avro schema to a Kusto table schema."""
     if not kusto_uri and not kusto_database:
         convert_avro_to_kusto_file(
-            avro_schema_path, avro_record_type, kusto_file_path, emit_cloudevents_columns, emit_cloudevents_dispatch_table, qualified_table_names, namespace)
+            avro_schema_path, avro_record_type, kusto_file_path, emit_cloudevents_columns, emit_cloudevents_dispatch_table, qualified_table_names, namespace, emit_materialized_views)
     else:
         convert_avro_to_kusto_db(
-            avro_schema_path, avro_record_type, kusto_uri, kusto_database, emit_cloudevents_columns, emit_cloudevents_dispatch_table, token_provider, qualified_table_names, namespace)
+            avro_schema_path, avro_record_type, kusto_uri, kusto_database, emit_cloudevents_columns, emit_cloudevents_dispatch_table, token_provider, qualified_table_names, namespace, emit_materialized_views)

--- a/avrotize/commands.json
+++ b/avrotize/commands.json
@@ -563,7 +563,8 @@
         "emit_cloudevents_columns": "args.emit_cloudevents_columns",
         "emit_cloudevents_dispatch_table": "args.emit_cloudevents_dispatch",
         "qualified_table_names": "args.qualified_table_names",
-        "namespace": "args.namespace"
+        "namespace": "args.namespace",
+        "emit_materialized_views": "args.emit_materialized_views"
       }
     },
     "extensions": [
@@ -632,6 +633,13 @@
         "type": "str",
         "help": "Set or override the namespace used for qualifying table names and CloudEvents type identifiers",
         "required": false
+      },
+      {
+        "name": "--emit-materialized-views",
+        "type": "bool",
+        "help": "Emit materialized Latest views for each typed table (default: true). Use --no-emit-materialized-views to suppress.",
+        "default": true,
+        "required": false
       }
     ],
     "suggested_output_file_path": "{input_file_name}.kql",
@@ -679,7 +687,8 @@
         "emit_cloudevents_columns": "args.emit_cloudevents_columns",
         "emit_cloudevents_dispatch_table": "args.emit_cloudevents_dispatch",
         "qualified_table_names": "args.qualified_table_names",
-        "namespace": "args.namespace"
+        "namespace": "args.namespace",
+        "emit_materialized_views": "args.emit_materialized_views"
       }
     },
     "extensions": [
@@ -748,6 +757,13 @@
         "name": "--namespace",
         "type": "str",
         "help": "Set or override the namespace used for qualifying table names and CloudEvents type identifiers",
+        "required": false
+      },
+      {
+        "name": "--emit-materialized-views",
+        "type": "bool",
+        "help": "Emit materialized Latest views for each typed table (default: true). Use --no-emit-materialized-views to suppress.",
+        "default": true,
         "required": false
       }
     ],

--- a/avrotize/structuretokusto.py
+++ b/avrotize/structuretokusto.py
@@ -221,7 +221,7 @@ class StructureToKusto:
 
         return object_types
 
-    def convert_record_to_kusto(self, recordschema: dict, schema_doc: dict, emit_cloudevents_columns: bool, emit_cloudevents_dispatch_table: bool, qualified_table_names: bool = False, namespace_override: str | None = None) -> List[str]:
+    def convert_record_to_kusto(self, recordschema: dict, schema_doc: dict, emit_cloudevents_columns: bool, emit_cloudevents_dispatch_table: bool, qualified_table_names: bool = False, namespace_override: str | None = None, emit_materialized_views: bool = True) -> List[str]:
         """Converts a JSON Structure object schema to a Kusto table schema."""
         # Get the name and fields of the top-level record
         simple_name = recordschema.get("name", "UnnamedTable")
@@ -353,44 +353,44 @@ class StructureToKusto:
         kusto.append(
             f".create-or-alter table {table_ref} ingestion json mapping \"{mapping_base}_json_flat\"")
         kusto.append("```\n[")
+        flat_mapping_entries = []
         if emit_cloudevents_columns:
-            kusto.append("  {\"column\": \"___type\", \"path\": \"$.type\"},")
-            kusto.append(
-                "  {\"column\": \"___source\", \"path\": \"$.source\"},")
-            kusto.append("  {\"column\": \"___id\", \"path\": \"$.id\"},")
-            kusto.append("  {\"column\": \"___time\", \"path\": \"$.time\"},")
-            kusto.append(
-                "  {\"column\": \"___subject\", \"path\": \"$.subject\"},")
+            flat_mapping_entries.append("  {\"column\": \"___type\", \"path\": \"$.type\"}")
+            flat_mapping_entries.append("  {\"column\": \"___source\", \"path\": \"$.source\"}")
+            flat_mapping_entries.append("  {\"column\": \"___id\", \"path\": \"$.id\"}")
+            flat_mapping_entries.append("  {\"column\": \"___time\", \"path\": \"$.time\"}")
+            flat_mapping_entries.append("  {\"column\": \"___subject\", \"path\": \"$.subject\"}")
         for prop_name, prop_schema in properties.items():
             # Skip const fields in JSON mapping since they're not stored as columns
             if isinstance(prop_schema, dict) and 'const' in prop_schema:
                 continue
             column_name = prop_name
-            kusto.append(
-                f"  {{\"column\": \"{column_name}\", \"path\": \"$.{prop_name}\"}},")
+            flat_mapping_entries.append(
+                f"  {{\"column\": \"{column_name}\", \"path\": \"$.{prop_name}\"}}")
+        kusto.append(",\n".join(flat_mapping_entries))
         kusto.append("]\n```\n\n")
 
         if emit_cloudevents_columns:
             kusto.append(
                 f".create-or-alter table {table_ref} ingestion json mapping \"{mapping_base}_json_ce_structured\"")
             kusto.append("```\n[")
-            kusto.append("  {\"column\": \"___type\", \"path\": \"$.type\"},")
-            kusto.append(
-                "  {\"column\": \"___source\", \"path\": \"$.source\"},")
-            kusto.append("  {\"column\": \"___id\", \"path\": \"$.id\"},")
-            kusto.append("  {\"column\": \"___time\", \"path\": \"$.time\"},")
-            kusto.append(
-                "  {\"column\": \"___subject\", \"path\": \"$.subject\"},")
+            ce_mapping_entries = []
+            ce_mapping_entries.append("  {\"column\": \"___type\", \"path\": \"$.type\"}")
+            ce_mapping_entries.append("  {\"column\": \"___source\", \"path\": \"$.source\"}")
+            ce_mapping_entries.append("  {\"column\": \"___id\", \"path\": \"$.id\"}")
+            ce_mapping_entries.append("  {\"column\": \"___time\", \"path\": \"$.time\"}")
+            ce_mapping_entries.append("  {\"column\": \"___subject\", \"path\": \"$.subject\"}")
             for prop_name, prop_schema in properties.items():
                 # Skip const fields in JSON mapping since they're not stored as columns
                 if isinstance(prop_schema, dict) and 'const' in prop_schema:
                     continue
                 column_name = prop_name
-                kusto.append(
-                    f"  {{\"column\": \"{column_name}\", \"path\": \"$.data.{prop_name}\"}},")
+                ce_mapping_entries.append(
+                    f"  {{\"column\": \"{column_name}\", \"path\": \"$.data.{prop_name}\"}}")
+            kusto.append(",\n".join(ce_mapping_entries))
             kusto.append("]\n```\n\n")
 
-        if emit_cloudevents_columns:
+        if emit_cloudevents_columns and emit_materialized_views:
             kusto.append(
                 f".drop materialized-view {mv_ref} ifexists;")
             kusto.append("")
@@ -421,13 +421,13 @@ class StructureToKusto:
             kusto.append(
                 f"  \"Query\": \"{query}\",")
             kusto.append("  \"IsTransactional\": false,")
-            kusto.append("  \"PropagateIngestionProperties\": true,")
+            kusto.append("  \"PropagateIngestionProperties\": true")
             kusto.append("}]")
             kusto.append("```\n")
 
         return kusto
 
-    def convert_structure_to_kusto_script(self, structure_schema_path, structure_record_type, emit_cloudevents_columns=False, emit_cloudevents_dispatch_table=False, qualified_table_names: bool = False, namespace_override: str | None = None) -> str:
+    def convert_structure_to_kusto_script(self, structure_schema_path, structure_record_type, emit_cloudevents_columns=False, emit_cloudevents_dispatch_table=False, qualified_table_names: bool = False, namespace_override: str | None = None, emit_materialized_views: bool = True) -> str:
         """Converts a JSON Structure schema to a Kusto table schema."""
         if emit_cloudevents_dispatch_table:
             emit_cloudevents_columns = True
@@ -582,17 +582,17 @@ class StructureToKusto:
                 continue
                 
             kusto_script.extend(self.convert_record_to_kusto(
-                record_schema, schema_doc, emit_cloudevents_columns, emit_cloudevents_dispatch_table, qualified_table_names, namespace_override))
+                record_schema, schema_doc, emit_cloudevents_columns, emit_cloudevents_dispatch_table, qualified_table_names, namespace_override, emit_materialized_views))
         
         # Join and clean up extra blank lines at the end
         result = "\n".join(kusto_script)
         # Remove trailing whitespace while preserving intentional blank lines
         return result.rstrip() + "\n" if result else ""
 
-    def convert_structure_to_kusto_file(self, structure_schema_path, structure_record_type, kusto_file_path, emit_cloudevents_columns=False, emit_cloudevents_dispatch_table=False, qualified_table_names: bool = False, namespace_override: str | None = None):
+    def convert_structure_to_kusto_file(self, structure_schema_path, structure_record_type, kusto_file_path, emit_cloudevents_columns=False, emit_cloudevents_dispatch_table=False, qualified_table_names: bool = False, namespace_override: str | None = None, emit_materialized_views: bool = True):
         """Converts a JSON Structure schema to a Kusto table schema."""
         script = self.convert_structure_to_kusto_script(
-            structure_schema_path, structure_record_type, emit_cloudevents_columns, emit_cloudevents_dispatch_table, qualified_table_names, namespace_override)
+            structure_schema_path, structure_record_type, emit_cloudevents_columns, emit_cloudevents_dispatch_table, qualified_table_names, namespace_override, emit_materialized_views)
         with open(kusto_file_path, "w", encoding="utf-8") as kusto_file:
             kusto_file.write(script)
 
@@ -688,18 +688,18 @@ class StructureToKusto:
         return mapping.get(type_value, 'dynamic')
 
 
-def convert_structure_to_kusto_file(structure_schema_path, structure_record_type, kusto_file_path, emit_cloudevents_columns=False, emit_cloudevents_dispatch_table=False, qualified_table_names: bool = False, namespace: str | None = None):
+def convert_structure_to_kusto_file(structure_schema_path, structure_record_type, kusto_file_path, emit_cloudevents_columns=False, emit_cloudevents_dispatch_table=False, qualified_table_names: bool = False, namespace: str | None = None, emit_materialized_views: bool = True):
     """Converts a JSON Structure schema to a Kusto table schema."""
     structure_to_kusto = StructureToKusto()
     structure_to_kusto.convert_structure_to_kusto_file(
-        structure_schema_path, structure_record_type, kusto_file_path, emit_cloudevents_columns, emit_cloudevents_dispatch_table, qualified_table_names, namespace)
+        structure_schema_path, structure_record_type, kusto_file_path, emit_cloudevents_columns, emit_cloudevents_dispatch_table, qualified_table_names, namespace, emit_materialized_views)
 
 
-def convert_structure_to_kusto_db(structure_schema_path, structure_record_type, kusto_uri, kusto_database, emit_cloudevents_columns=False, emit_cloudevents_dispatch_table=False, token_provider=None, qualified_table_names: bool = False, namespace: str | None = None):
+def convert_structure_to_kusto_db(structure_schema_path, structure_record_type, kusto_uri, kusto_database, emit_cloudevents_columns=False, emit_cloudevents_dispatch_table=False, token_provider=None, qualified_table_names: bool = False, namespace: str | None = None, emit_materialized_views: bool = True):
     """Converts a JSON Structure schema to a Kusto table schema."""
     structure_to_kusto = StructureToKusto()
     script = structure_to_kusto.convert_structure_to_kusto_script(
-        structure_schema_path, structure_record_type, emit_cloudevents_columns, emit_cloudevents_dispatch_table, qualified_table_names, namespace)
+        structure_schema_path, structure_record_type, emit_cloudevents_columns, emit_cloudevents_dispatch_table, qualified_table_names, namespace, emit_materialized_views)
     kcsb = KustoConnectionStringBuilder.with_az_cli_authentication(
         kusto_uri) if not token_provider else KustoConnectionStringBuilder.with_token_provider(kusto_uri, token_provider)
     client = KustoClient(kcsb)
@@ -712,11 +712,11 @@ def convert_structure_to_kusto_db(structure_schema_path, structure_record_type, 
                 sys.exit(1)
 
 
-def convert_structure_to_kusto(structure_schema_path, structure_record_type, kusto_file_path, kusto_uri, kusto_database, emit_cloudevents_columns=False, emit_cloudevents_dispatch_table=False, token_provider=None, qualified_table_names: bool = False, namespace: str | None = None):
+def convert_structure_to_kusto(structure_schema_path, structure_record_type, kusto_file_path, kusto_uri, kusto_database, emit_cloudevents_columns=False, emit_cloudevents_dispatch_table=False, token_provider=None, qualified_table_names: bool = False, namespace: str | None = None, emit_materialized_views: bool = True):
     """Converts a JSON Structure schema to a Kusto table schema."""
     if not kusto_uri and not kusto_database:
         convert_structure_to_kusto_file(
-            structure_schema_path, structure_record_type, kusto_file_path, emit_cloudevents_columns, emit_cloudevents_dispatch_table, qualified_table_names, namespace)
+            structure_schema_path, structure_record_type, kusto_file_path, emit_cloudevents_columns, emit_cloudevents_dispatch_table, qualified_table_names, namespace, emit_materialized_views)
     else:
         convert_structure_to_kusto_db(
-            structure_schema_path, structure_record_type, kusto_uri, kusto_database, emit_cloudevents_columns, emit_cloudevents_dispatch_table, token_provider, qualified_table_names, namespace)
+            structure_schema_path, structure_record_type, kusto_uri, kusto_database, emit_cloudevents_columns, emit_cloudevents_dispatch_table, token_provider, qualified_table_names, namespace, emit_materialized_views)

--- a/test/avsc/address-ce-dt-ref.kql
+++ b/test/avsc/address-ce-dt-ref.kql
@@ -76,7 +76,7 @@
   {"column": "locality", "path": "$.locality"},
   {"column": "region", "path": "$.region"},
   {"column": "postalCode", "path": "$.postalCode"},
-  {"column": "countryName", "path": "$.countryName"},
+  {"column": "countryName", "path": "$.countryName"}
 ]
 ```
 
@@ -96,7 +96,7 @@
   {"column": "locality", "path": "$.data.locality"},
   {"column": "region", "path": "$.data.region"},
   {"column": "postalCode", "path": "$.data.postalCode"},
-  {"column": "countryName", "path": "$.data.countryName"},
+  {"column": "countryName", "path": "$.data.countryName"}
 ]
 ```
 
@@ -114,6 +114,6 @@
   "Source": "_cloudevents_dispatch",
   "Query": "_cloudevents_dispatch | where (specversion == '1.0' and type == 'example.com.record') | project['type'] = tostring(data.['type']),['postOfficeBox'] = tostring(data.['postOfficeBox']),['extendedAddress'] = tostring(data.['extendedAddress']),['streetAddress'] = tostring(data.['streetAddress']),['locality'] = tostring(data.['locality']),['region'] = tostring(data.['region']),['postalCode'] = tostring(data.['postalCode']),['countryName'] = tostring(data.['countryName']),___type = type,___source = source,___id = ['id'],___time = ['time'],___subject = subject",
   "IsTransactional": false,
-  "PropagateIngestionProperties": true,
+  "PropagateIngestionProperties": true
 }]
 ```

--- a/test/avsc/address-ce-dt-struct-ref.kql
+++ b/test/avsc/address-ce-dt-struct-ref.kql
@@ -76,7 +76,7 @@
   {"column": "locality", "path": "$.locality"},
   {"column": "region", "path": "$.region"},
   {"column": "postalCode", "path": "$.postalCode"},
-  {"column": "countryName", "path": "$.countryName"},
+  {"column": "countryName", "path": "$.countryName"}
 ]
 ```
 
@@ -96,7 +96,7 @@
   {"column": "locality", "path": "$.data.locality"},
   {"column": "region", "path": "$.data.region"},
   {"column": "postalCode", "path": "$.data.postalCode"},
-  {"column": "countryName", "path": "$.data.countryName"},
+  {"column": "countryName", "path": "$.data.countryName"}
 ]
 ```
 
@@ -114,6 +114,6 @@
   "Source": "_cloudevents_dispatch",
   "Query": "_cloudevents_dispatch | where (specversion == '1.0' and type == 'record') | project['type'] = tostring(data.['type']),['postOfficeBox'] = tostring(data.['postOfficeBox']),['extendedAddress'] = tostring(data.['extendedAddress']),['streetAddress'] = tostring(data.['streetAddress']),['locality'] = tostring(data.['locality']),['region'] = tostring(data.['region']),['postalCode'] = tostring(data.['postalCode']),['countryName'] = tostring(data.['countryName']),___type = type,___source = source,___id = ['id'],___time = ['time'],___subject = subject",
   "IsTransactional": false,
-  "PropagateIngestionProperties": true,
+  "PropagateIngestionProperties": true
 }]
 ```

--- a/test/avsc/address-ce-ref.kql
+++ b/test/avsc/address-ce-ref.kql
@@ -47,7 +47,7 @@
   {"column": "locality", "path": "$.locality"},
   {"column": "region", "path": "$.region"},
   {"column": "postalCode", "path": "$.postalCode"},
-  {"column": "countryName", "path": "$.countryName"},
+  {"column": "countryName", "path": "$.countryName"}
 ]
 ```
 
@@ -67,7 +67,7 @@
   {"column": "locality", "path": "$.data.locality"},
   {"column": "region", "path": "$.data.region"},
   {"column": "postalCode", "path": "$.data.postalCode"},
-  {"column": "countryName", "path": "$.data.countryName"},
+  {"column": "countryName", "path": "$.data.countryName"}
 ]
 ```
 

--- a/test/avsc/address-ce-struct-ref.kql
+++ b/test/avsc/address-ce-struct-ref.kql
@@ -47,7 +47,7 @@
   {"column": "locality", "path": "$.locality"},
   {"column": "region", "path": "$.region"},
   {"column": "postalCode", "path": "$.postalCode"},
-  {"column": "countryName", "path": "$.countryName"},
+  {"column": "countryName", "path": "$.countryName"}
 ]
 ```
 
@@ -67,7 +67,7 @@
   {"column": "locality", "path": "$.data.locality"},
   {"column": "region", "path": "$.data.region"},
   {"column": "postalCode", "path": "$.data.postalCode"},
-  {"column": "countryName", "path": "$.data.countryName"},
+  {"column": "countryName", "path": "$.data.countryName"}
 ]
 ```
 

--- a/test/avsc/address-ref.kql
+++ b/test/avsc/address-ref.kql
@@ -32,7 +32,7 @@
   {"column": "locality", "path": "$.locality"},
   {"column": "region", "path": "$.region"},
   {"column": "postalCode", "path": "$.postalCode"},
-  {"column": "countryName", "path": "$.countryName"},
+  {"column": "countryName", "path": "$.countryName"}
 ]
 ```
 

--- a/test/avsc/address-struct-ref.kql
+++ b/test/avsc/address-struct-ref.kql
@@ -32,6 +32,6 @@
   {"column": "locality", "path": "$.locality"},
   {"column": "region", "path": "$.region"},
   {"column": "postalCode", "path": "$.postalCode"},
-  {"column": "countryName", "path": "$.countryName"},
+  {"column": "countryName", "path": "$.countryName"}
 ]
 ```

--- a/test/avsc/telemetry-ce-dt-ref.kql
+++ b/test/avsc/telemetry-ce-dt-ref.kql
@@ -85,7 +85,7 @@
   {"column": "created", "path": "$.created"},
   {"column": "timespan", "path": "$.timespan"},
   {"column": "data", "path": "$.data"},
-  {"column": "lapId", "path": "$.lapId"},
+  {"column": "lapId", "path": "$.lapId"}
 ]
 ```
 
@@ -108,7 +108,7 @@
   {"column": "created", "path": "$.data.created"},
   {"column": "timespan", "path": "$.data.timespan"},
   {"column": "data", "path": "$.data.data"},
-  {"column": "lapId", "path": "$.data.lapId"},
+  {"column": "lapId", "path": "$.data.lapId"}
 ]
 ```
 
@@ -126,6 +126,6 @@
   "Source": "_cloudevents_dispatch",
   "Query": "_cloudevents_dispatch | where (specversion == '1.0' and type == 'racing.fabrikam.com.TelemetryRecord') | project['id'] = tostring(data.['id']),['version'] = toint(data.['version']),['channel'] = tostring(data.['channel']),['carId'] = tostring(data.['carId']),['intervalId'] = tostring(data.['intervalId']),['sampleCount'] = tolong(data.['sampleCount']),['frequency'] = tolong(data.['frequency']),['created'] = tolong(data.['created']),['timespan'] = todynamic(data.['timespan']),['data'] = todynamic(data.['data']),['lapId'] = tostring(data.['lapId']),___type = type,___source = source,___id = ['id'],___time = ['time'],___subject = subject",
   "IsTransactional": false,
-  "PropagateIngestionProperties": true,
+  "PropagateIngestionProperties": true
 }]
 ```

--- a/test/avsc/telemetry-ce-ref.kql
+++ b/test/avsc/telemetry-ce-ref.kql
@@ -56,7 +56,7 @@
   {"column": "created", "path": "$.created"},
   {"column": "timespan", "path": "$.timespan"},
   {"column": "data", "path": "$.data"},
-  {"column": "lapId", "path": "$.lapId"},
+  {"column": "lapId", "path": "$.lapId"}
 ]
 ```
 
@@ -79,7 +79,7 @@
   {"column": "created", "path": "$.data.created"},
   {"column": "timespan", "path": "$.data.timespan"},
   {"column": "data", "path": "$.data.data"},
-  {"column": "lapId", "path": "$.data.lapId"},
+  {"column": "lapId", "path": "$.data.lapId"}
 ]
 ```
 

--- a/test/avsc/telemetry-ref.kql
+++ b/test/avsc/telemetry-ref.kql
@@ -41,7 +41,7 @@
   {"column": "created", "path": "$.created"},
   {"column": "timespan", "path": "$.timespan"},
   {"column": "data", "path": "$.data"},
-  {"column": "lapId", "path": "$.lapId"},
+  {"column": "lapId", "path": "$.lapId"}
 ]
 ```
 


### PR DESCRIPTION
Fixes #378

## Changes

1. **Trailing comma fix** — JSON mapping arrays and update-policy JSON blocks no longer emit a trailing comma after the last entry. This produced invalid JSON that Kusto rejects on apply.

2. **New \--emit-materialized-views\ flag** (default: \	rue\) — allows callers to suppress \*Latest\ materialized views for high-volume telemetry types where they are expensive and serve no analytical purpose. Reference/metadata types should keep the default (\	rue\).

Both \s2k\ (structuretokusto) and \2k\ (avrotokusto) paths are fixed.

## Testing

- All non-Docker tests pass (\	est_structuretokusto\, \	est_avrotokusto\)
- Reference \.kql\ files regenerated and verified: 0 trailing commas
- Materialized views still emitted by default (backward compatible)