### PR TITLE
fix(kusto): remove trailing commas in JSON mapping and update-policy blocks

### DIFF
--- a/avrotize/avrotokusto.py
+++ b/avrotize/avrotokusto.py
@@ -119,15 +119,13 @@ class AvroToKusto:
         # .create-or-alter table dfl_data_events ingestion json mapping
         kusto.append(
             f".create-or-alter table {table_ref} ingestion json mapping \"{mapping_base}_json_flat\"")
-        kusto.append("```\n[")
+        mapping_entries = []
         if emit_cloudevents_columns:
-            kusto.append("  {\"column\": \"___type\", \"path\": \"$.type\"},")
-            kusto.append(
-                "  {\"column\": \"___source\", \"path\": \"$.source\"},")
-            kusto.append("  {\"column\": \"___id\", \"path\": \"$.id\"},")
-            kusto.append("  {\"column\": \"___time\", \"path\": \"$.time\"},")
-            kusto.append(
-                "  {\"column\": \"___subject\", \"path\": \"$.subject\"},")
+            mapping_entries.append("  {\"column\": \"___type\", \"path\": \"$.type\"}")
+            mapping_entries.append("  {\"column\": \"___source\", \"path\": \"$.source\"}")
+            mapping_entries.append("  {\"column\": \"___id\", \"path\": \"$.id\"}")
+            mapping_entries.append("  {\"column\": \"___time\", \"path\": \"$.time\"}")
+            mapping_entries.append("  {\"column\": \"___subject\", \"path\": \"$.subject\"}")
         for field in fields:
             json_name = column_name = field["name"]
             if 'altnames' in field:
@@ -135,21 +133,19 @@ class AvroToKusto:
                     column_name = field['altnames']['kql']
                 if 'json' in field['altnames']:
                     json_name = field['altnames']['json']
-            kusto.append(
-                f"  {{\"column\": \"{column_name}\", \"path\": \"$.{json_name}\"}},")
-        kusto.append("]\n```\n\n")
+            mapping_entries.append(
+                f"  {{\"column\": \"{column_name}\", \"path\": \"$.{json_name}\"}}")
+        kusto.append("```\n[\n" + ",\n".join(mapping_entries) + "\n]\n```\n\n")
 
         if emit_cloudevents_columns:
             kusto.append(
                 f".create-or-alter table {table_ref} ingestion json mapping \"{mapping_base}_json_ce_structured\"")
-            kusto.append("```\n[")
-            kusto.append("  {\"column\": \"___type\", \"path\": \"$.type\"},")
-            kusto.append(
-                "  {\"column\": \"___source\", \"path\": \"$.source\"},")
-            kusto.append("  {\"column\": \"___id\", \"path\": \"$.id\"},")
-            kusto.append("  {\"column\": \"___time\", \"path\": \"$.time\"},")
-            kusto.append(
-                "  {\"column\": \"___subject\", \"path\": \"$.subject\"},")
+            ce_entries = []
+            ce_entries.append("  {\"column\": \"___type\", \"path\": \"$.type\"}")
+            ce_entries.append("  {\"column\": \"___source\", \"path\": \"$.source\"}")
+            ce_entries.append("  {\"column\": \"___id\", \"path\": \"$.id\"}")
+            ce_entries.append("  {\"column\": \"___time\", \"path\": \"$.time\"}")
+            ce_entries.append("  {\"column\": \"___subject\", \"path\": \"$.subject\"}")
             for field in fields:
                 json_name = column_name = field["name"]
                 if 'altnames' in field:
@@ -157,9 +153,9 @@ class AvroToKusto:
                         column_name = field['altnames']['kql']
                     if 'json' in field['altnames']:
                         json_name = field['altnames']['json']
-                kusto.append(
-                    f"  {{\"column\": \"{column_name}\", \"path\": \"$.data.{json_name}\"}},")
-            kusto.append("]\n```\n\n")
+                ce_entries.append(
+                    f"  {{\"column\": \"{column_name}\", \"path\": \"$.data.{json_name}\"}}")
+            kusto.append("```\n[\n" + ",\n".join(ce_entries) + "\n]\n```\n\n")
 
         if emit_cloudevents_columns:
             kusto.append(
@@ -196,7 +192,7 @@ class AvroToKusto:
             kusto.append(
                 f"  \"Query\": \"{query}\",")
             kusto.append("  \"IsTransactional\": false,")
-            kusto.append("  \"PropagateIngestionProperties\": true,")
+            kusto.append("  \"PropagateIngestionProperties\": true")
             kusto.append("}]")
             kusto.append("```\n")
 

--- a/avrotize/structuretokusto.py
+++ b/avrotize/structuretokusto.py
@@ -352,43 +352,39 @@ class StructureToKusto:
         # add the JSON mapping for the table
         kusto.append(
             f".create-or-alter table {table_ref} ingestion json mapping \"{mapping_base}_json_flat\"")
-        kusto.append("```\n[")
+        mapping_entries = []
         if emit_cloudevents_columns:
-            kusto.append("  {\"column\": \"___type\", \"path\": \"$.type\"},")
-            kusto.append(
-                "  {\"column\": \"___source\", \"path\": \"$.source\"},")
-            kusto.append("  {\"column\": \"___id\", \"path\": \"$.id\"},")
-            kusto.append("  {\"column\": \"___time\", \"path\": \"$.time\"},")
-            kusto.append(
-                "  {\"column\": \"___subject\", \"path\": \"$.subject\"},")
+            mapping_entries.append("  {\"column\": \"___type\", \"path\": \"$.type\"}")
+            mapping_entries.append("  {\"column\": \"___source\", \"path\": \"$.source\"}")
+            mapping_entries.append("  {\"column\": \"___id\", \"path\": \"$.id\"}")
+            mapping_entries.append("  {\"column\": \"___time\", \"path\": \"$.time\"}")
+            mapping_entries.append("  {\"column\": \"___subject\", \"path\": \"$.subject\"}")
         for prop_name, prop_schema in properties.items():
             # Skip const fields in JSON mapping since they're not stored as columns
             if isinstance(prop_schema, dict) and 'const' in prop_schema:
                 continue
             column_name = prop_name
-            kusto.append(
-                f"  {{\"column\": \"{column_name}\", \"path\": \"$.{prop_name}\"}},")
-        kusto.append("]\n```\n\n")
+            mapping_entries.append(
+                f"  {{\"column\": \"{column_name}\", \"path\": \"$.{prop_name}\"}}")
+        kusto.append("```\n[\n" + ",\n".join(mapping_entries) + "\n]\n```\n\n")
 
         if emit_cloudevents_columns:
             kusto.append(
                 f".create-or-alter table {table_ref} ingestion json mapping \"{mapping_base}_json_ce_structured\"")
-            kusto.append("```\n[")
-            kusto.append("  {\"column\": \"___type\", \"path\": \"$.type\"},")
-            kusto.append(
-                "  {\"column\": \"___source\", \"path\": \"$.source\"},")
-            kusto.append("  {\"column\": \"___id\", \"path\": \"$.id\"},")
-            kusto.append("  {\"column\": \"___time\", \"path\": \"$.time\"},")
-            kusto.append(
-                "  {\"column\": \"___subject\", \"path\": \"$.subject\"},")
+            ce_entries = []
+            ce_entries.append("  {\"column\": \"___type\", \"path\": \"$.type\"}")
+            ce_entries.append("  {\"column\": \"___source\", \"path\": \"$.source\"}")
+            ce_entries.append("  {\"column\": \"___id\", \"path\": \"$.id\"}")
+            ce_entries.append("  {\"column\": \"___time\", \"path\": \"$.time\"}")
+            ce_entries.append("  {\"column\": \"___subject\", \"path\": \"$.subject\"}")
             for prop_name, prop_schema in properties.items():
                 # Skip const fields in JSON mapping since they're not stored as columns
                 if isinstance(prop_schema, dict) and 'const' in prop_schema:
                     continue
                 column_name = prop_name
-                kusto.append(
-                    f"  {{\"column\": \"{column_name}\", \"path\": \"$.data.{prop_name}\"}},")
-            kusto.append("]\n```\n\n")
+                ce_entries.append(
+                    f"  {{\"column\": \"{column_name}\", \"path\": \"$.data.{prop_name}\"}}")
+            kusto.append("```\n[\n" + ",\n".join(ce_entries) + "\n]\n```\n\n")
 
         if emit_cloudevents_columns:
             kusto.append(
@@ -421,7 +417,7 @@ class StructureToKusto:
             kusto.append(
                 f"  \"Query\": \"{query}\",")
             kusto.append("  \"IsTransactional\": false,")
-            kusto.append("  \"PropagateIngestionProperties\": true,")
+            kusto.append("  \"PropagateIngestionProperties\": true")
             kusto.append("}]")
             kusto.append("```\n")
 

--- a/test/avsc/address-ce-dt-ref.kql
+++ b/test/avsc/address-ce-dt-ref.kql
@@ -76,7 +76,7 @@
   {"column": "locality", "path": "$.locality"},
   {"column": "region", "path": "$.region"},
   {"column": "postalCode", "path": "$.postalCode"},
-  {"column": "countryName", "path": "$.countryName"},
+  {"column": "countryName", "path": "$.countryName"}
 ]
 ```
 
@@ -96,7 +96,7 @@
   {"column": "locality", "path": "$.data.locality"},
   {"column": "region", "path": "$.data.region"},
   {"column": "postalCode", "path": "$.data.postalCode"},
-  {"column": "countryName", "path": "$.data.countryName"},
+  {"column": "countryName", "path": "$.data.countryName"}
 ]
 ```
 
@@ -114,6 +114,6 @@
   "Source": "_cloudevents_dispatch",
   "Query": "_cloudevents_dispatch | where (specversion == '1.0' and type == 'example.com.record') | project['type'] = tostring(data.['type']),['postOfficeBox'] = tostring(data.['postOfficeBox']),['extendedAddress'] = tostring(data.['extendedAddress']),['streetAddress'] = tostring(data.['streetAddress']),['locality'] = tostring(data.['locality']),['region'] = tostring(data.['region']),['postalCode'] = tostring(data.['postalCode']),['countryName'] = tostring(data.['countryName']),___type = type,___source = source,___id = ['id'],___time = ['time'],___subject = subject",
   "IsTransactional": false,
-  "PropagateIngestionProperties": true,
+  "PropagateIngestionProperties": true
 }]
 ```

--- a/test/avsc/address-ce-dt-struct-ref.kql
+++ b/test/avsc/address-ce-dt-struct-ref.kql
@@ -76,7 +76,7 @@
   {"column": "locality", "path": "$.locality"},
   {"column": "region", "path": "$.region"},
   {"column": "postalCode", "path": "$.postalCode"},
-  {"column": "countryName", "path": "$.countryName"},
+  {"column": "countryName", "path": "$.countryName"}
 ]
 ```
 
@@ -96,7 +96,7 @@
   {"column": "locality", "path": "$.data.locality"},
   {"column": "region", "path": "$.data.region"},
   {"column": "postalCode", "path": "$.data.postalCode"},
-  {"column": "countryName", "path": "$.data.countryName"},
+  {"column": "countryName", "path": "$.data.countryName"}
 ]
 ```
 
@@ -114,6 +114,6 @@
   "Source": "_cloudevents_dispatch",
   "Query": "_cloudevents_dispatch | where (specversion == '1.0' and type == 'record') | project['type'] = tostring(data.['type']),['postOfficeBox'] = tostring(data.['postOfficeBox']),['extendedAddress'] = tostring(data.['extendedAddress']),['streetAddress'] = tostring(data.['streetAddress']),['locality'] = tostring(data.['locality']),['region'] = tostring(data.['region']),['postalCode'] = tostring(data.['postalCode']),['countryName'] = tostring(data.['countryName']),___type = type,___source = source,___id = ['id'],___time = ['time'],___subject = subject",
   "IsTransactional": false,
-  "PropagateIngestionProperties": true,
+  "PropagateIngestionProperties": true
 }]
 ```

--- a/test/avsc/address-ce-ref.kql
+++ b/test/avsc/address-ce-ref.kql
@@ -47,7 +47,7 @@
   {"column": "locality", "path": "$.locality"},
   {"column": "region", "path": "$.region"},
   {"column": "postalCode", "path": "$.postalCode"},
-  {"column": "countryName", "path": "$.countryName"},
+  {"column": "countryName", "path": "$.countryName"}
 ]
 ```
 
@@ -67,7 +67,7 @@
   {"column": "locality", "path": "$.data.locality"},
   {"column": "region", "path": "$.data.region"},
   {"column": "postalCode", "path": "$.data.postalCode"},
-  {"column": "countryName", "path": "$.data.countryName"},
+  {"column": "countryName", "path": "$.data.countryName"}
 ]
 ```
 

--- a/test/avsc/address-ce-struct-ref.kql
+++ b/test/avsc/address-ce-struct-ref.kql
@@ -47,7 +47,7 @@
   {"column": "locality", "path": "$.locality"},
   {"column": "region", "path": "$.region"},
   {"column": "postalCode", "path": "$.postalCode"},
-  {"column": "countryName", "path": "$.countryName"},
+  {"column": "countryName", "path": "$.countryName"}
 ]
 ```
 
@@ -67,7 +67,7 @@
   {"column": "locality", "path": "$.data.locality"},
   {"column": "region", "path": "$.data.region"},
   {"column": "postalCode", "path": "$.data.postalCode"},
-  {"column": "countryName", "path": "$.data.countryName"},
+  {"column": "countryName", "path": "$.data.countryName"}
 ]
 ```
 

--- a/test/avsc/address-ref.kql
+++ b/test/avsc/address-ref.kql
@@ -32,7 +32,7 @@
   {"column": "locality", "path": "$.locality"},
   {"column": "region", "path": "$.region"},
   {"column": "postalCode", "path": "$.postalCode"},
-  {"column": "countryName", "path": "$.countryName"},
+  {"column": "countryName", "path": "$.countryName"}
 ]
 ```
 

--- a/test/avsc/address-struct-ref.kql
+++ b/test/avsc/address-struct-ref.kql
@@ -32,6 +32,6 @@
   {"column": "locality", "path": "$.locality"},
   {"column": "region", "path": "$.region"},
   {"column": "postalCode", "path": "$.postalCode"},
-  {"column": "countryName", "path": "$.countryName"},
+  {"column": "countryName", "path": "$.countryName"}
 ]
 ```

--- a/test/avsc/telemetry-ce-dt-ref.kql
+++ b/test/avsc/telemetry-ce-dt-ref.kql
@@ -85,7 +85,7 @@
   {"column": "created", "path": "$.created"},
   {"column": "timespan", "path": "$.timespan"},
   {"column": "data", "path": "$.data"},
-  {"column": "lapId", "path": "$.lapId"},
+  {"column": "lapId", "path": "$.lapId"}
 ]
 ```
 
@@ -108,7 +108,7 @@
   {"column": "created", "path": "$.data.created"},
   {"column": "timespan", "path": "$.data.timespan"},
   {"column": "data", "path": "$.data.data"},
-  {"column": "lapId", "path": "$.data.lapId"},
+  {"column": "lapId", "path": "$.data.lapId"}
 ]
 ```
 
@@ -126,6 +126,6 @@
   "Source": "_cloudevents_dispatch",
   "Query": "_cloudevents_dispatch | where (specversion == '1.0' and type == 'racing.fabrikam.com.TelemetryRecord') | project['id'] = tostring(data.['id']),['version'] = toint(data.['version']),['channel'] = tostring(data.['channel']),['carId'] = tostring(data.['carId']),['intervalId'] = tostring(data.['intervalId']),['sampleCount'] = tolong(data.['sampleCount']),['frequency'] = tolong(data.['frequency']),['created'] = tolong(data.['created']),['timespan'] = todynamic(data.['timespan']),['data'] = todynamic(data.['data']),['lapId'] = tostring(data.['lapId']),___type = type,___source = source,___id = ['id'],___time = ['time'],___subject = subject",
   "IsTransactional": false,
-  "PropagateIngestionProperties": true,
+  "PropagateIngestionProperties": true
 }]
 ```

--- a/test/avsc/telemetry-ce-ref.kql
+++ b/test/avsc/telemetry-ce-ref.kql
@@ -56,7 +56,7 @@
   {"column": "created", "path": "$.created"},
   {"column": "timespan", "path": "$.timespan"},
   {"column": "data", "path": "$.data"},
-  {"column": "lapId", "path": "$.lapId"},
+  {"column": "lapId", "path": "$.lapId"}
 ]
 ```
 
@@ -79,7 +79,7 @@
   {"column": "created", "path": "$.data.created"},
   {"column": "timespan", "path": "$.data.timespan"},
   {"column": "data", "path": "$.data.data"},
-  {"column": "lapId", "path": "$.data.lapId"},
+  {"column": "lapId", "path": "$.data.lapId"}
 ]
 ```
 

--- a/test/avsc/telemetry-ref.kql
+++ b/test/avsc/telemetry-ref.kql
@@ -41,7 +41,7 @@
   {"column": "created", "path": "$.created"},
   {"column": "timespan", "path": "$.timespan"},
   {"column": "data", "path": "$.data"},
-  {"column": "lapId", "path": "$.lapId"},
+  {"column": "lapId", "path": "$.lapId"}
 ]
 ```
 

--- a/test/test_structuretokusto.py
+++ b/test/test_structuretokusto.py
@@ -275,8 +275,36 @@ def convert_case(file_base_name: str, emit_cloudevents_columns, emit_cloudevents
         assert content1 == content2
 
 
+def test_kql_json_blocks_are_valid():
+    """Test that all JSON blocks in generated KQL are valid JSON (no trailing commas)."""
+    cwd = os.getcwd()
+    struct_path = os.path.join(cwd, "test", "avsc", "address-ref.struct.json")
+    kql_path = os.path.join(tempfile.gettempdir(), "avrotize", "address-json-valid.kql")
+    dir_name = os.path.dirname(kql_path)
+    if not os.path.exists(dir_name):
+        os.makedirs(dir_name, exist_ok=True)
+
+    convert_structure_to_kusto_file(struct_path, None, kql_path, True, True)
+
+    with open(kql_path, 'r', encoding="utf-8") as f:
+        content = f.read()
+
+    # Extract all JSON blocks between ``` fences
+    blocks = re.findall(r'```\n(.*?)\n```', content, re.DOTALL)
+    assert len(blocks) > 0, "Expected at least one fenced JSON block"
+    for i, block in enumerate(blocks):
+        block = block.strip()
+        if block.startswith('[') or block.startswith('{'):
+            try:
+                json.loads(block)
+            except json.JSONDecodeError as e:
+                raise AssertionError(
+                    f"Invalid JSON in block {i}: {e}\n---\n{block}\n---")
+
+
 if __name__ == '__main__':
     test_convert_address_struct_to_kusto()
     test_convert_address_struct_to_kusto_ce()
     test_convert_address_struct_to_kusto_ce_dt()
+    test_kql_json_blocks_are_valid()
     print("All tests passed!")


### PR DESCRIPTION
Fixes #378

## Problem

avrotize s2k and a2k emit JSON mapping arrays and update-policy blocks with trailing commas, producing invalid JSON that Kusto rejects on apply.

## Fix

- Collect mapping entries into a list and join with comma-newline — no trailing comma.
- Remove trailing comma after PropagateIngestionProperties in update policy JSON.

## Testing

- All existing golden-file tests pass (reference .kql files updated).
- New test: test_kql_json_blocks_are_valid() extracts every fenced JSON block from generated KQL and asserts json.loads() succeeds. This prevents regression.
