### PR TITLE
Honor JSON Structure altnames.json for wire serialization (s2py/cs/java/ts/go/rust/cpp)

### DIFF
--- a/avrotize/common.py
+++ b/avrotize/common.py
@@ -830,6 +830,28 @@ def altname(schema_obj: dict, purpose: str):
     return schema_obj["name"]
 
 
+def json_wire_name(prop_name: str, prop_schema: Any) -> str:
+    """
+    Resolve the JSON wire key for a property, honoring JSON Structure ``altnames.json``.
+
+    JSON Structure requires property keys to be identifiers. A non-identifier wire key
+    (e.g. ``dr-type``) is modeled as an identifier property name (``dr_type``) carrying
+    ``altnames: {"json": "dr-type"}``. The ``json`` purpose is the canonical wire name.
+
+    Args:
+        prop_name (str): The property name (identifier) used as the schema key.
+        prop_schema (Any): The property schema; may carry an ``altnames`` map.
+
+    Returns:
+        str: ``altnames.json`` when present, otherwise ``prop_name``.
+    """
+    if isinstance(prop_schema, dict):
+        altnames = prop_schema.get("altnames")
+        if isinstance(altnames, dict) and "json" in altnames:
+            return altnames["json"]
+    return prop_name
+
+
 def process_template(file_path: str, **kvargs) -> str:
     """
     Process a file as a Jinja2 template with the given object as input.

--- a/avrotize/common.py
+++ b/avrotize/common.py
@@ -852,6 +852,30 @@ def json_wire_name(prop_name: str, prop_schema: Any) -> str:
     return prop_name
 
 
+def json_enum_wire_value(value: Any, enum_schema: Any) -> str:
+    """
+    Resolve the JSON wire string for an enum value, honoring JSON Structure ``altenums.json``.
+
+    ``altenums.json`` is a map keyed by the original enum value; the language member name
+    stays derived from the original value, while the wire value uses the mapping when present.
+    Unmapped values serialize verbatim (identity fallback).
+
+    Args:
+        value: The original enum value (schema key).
+        enum_schema (Any): The enum schema; may carry an ``altenums`` map.
+
+    Returns:
+        str: ``altenums.json[value]`` when present, otherwise ``str(value)``.
+    """
+    if isinstance(enum_schema, dict):
+        altenums = enum_schema.get("altenums")
+        if isinstance(altenums, dict):
+            j = altenums.get("json")
+            if isinstance(j, dict) and str(value) in j:
+                return j[str(value)]
+    return str(value)
+
+
 def process_template(file_path: str, **kvargs) -> str:
     """
     Process a file as a Jinja2 template with the given object as input.

--- a/avrotize/structuretocpp.py
+++ b/avrotize/structuretocpp.py
@@ -5,7 +5,7 @@ import json
 import os
 from typing import Dict, List, Union, Set, Optional, Any, cast
 
-from avrotize.common import pascal, process_template, json_wire_name
+from avrotize.common import pascal, process_template, json_wire_name, json_enum_wire_value
 
 INDENT = '    '
 
@@ -397,10 +397,14 @@ class StructureToCpp:
             enum_definition += f"// {doc}\n"
         
         symbols = structure_schema.get('enum', [])
+        members = [(self.safe_identifier(str(s)), json_enum_wire_value(s, structure_schema)) for s in symbols]
         enum_definition += f"enum class {enum_name} {{\n"
-        for symbol in symbols:
-            enum_definition += f"{INDENT}{self.safe_identifier(str(symbol))},\n"
+        for name, _ in members:
+            enum_definition += f"{INDENT}{name},\n"
         enum_definition += "};\n\n"
+        if members:
+            pairs = ", ".join(f'{{{enum_name}::{name}, "{wire}"}}' for name, wire in members)
+            enum_definition += f"NLOHMANN_JSON_SERIALIZE_ENUM({enum_name}, {{ {pairs} }})\n\n"
         
         if write_file:
             self.write_to_file(namespace, enum_name, "", enum_definition)

--- a/avrotize/structuretocpp.py
+++ b/avrotize/structuretocpp.py
@@ -5,7 +5,7 @@ import json
 import os
 from typing import Dict, List, Union, Set, Optional, Any, cast
 
-from avrotize.common import pascal, process_template
+from avrotize.common import pascal, process_template, json_wire_name
 
 INDENT = '    '
 
@@ -307,9 +307,10 @@ class StructureToCpp:
                     source_type = 'object'
             else:
                 source_type = 'object'
-            all_field_info.append((field_name, prop_name, field_type, source_type))
+            wire_name = json_wire_name(prop_name, prop_schema)
+            all_field_info.append((field_name, wire_name, field_type, source_type))
             if source_type in ('int64', 'uint64', 'int128', 'uint128', 'decimal'):
-                string_json_fields.append((field_name, prop_name, field_type, source_type))
+                string_json_fields.append((field_name, wire_name, field_type, source_type))
             
             # Add documentation
             if 'description' in prop_schema or 'doc' in prop_schema:
@@ -330,8 +331,10 @@ class StructureToCpp:
         if self.json_annotation:
             class_definition += self.generate_to_json_method(class_name)
         
-        # Add custom nlohmann to_json/from_json if we have string-serialized numeric fields
-        if self.json_annotation and string_json_fields:
+        # Add custom nlohmann to_json/from_json if we have string-serialized numeric
+        # fields or any field whose JSON wire key differs from the C++ member name
+        has_renamed_fields = any(o != f for f, o, _, _ in all_field_info)
+        if self.json_annotation and (string_json_fields or has_renamed_fields):
             class_definition += f"\n{INDENT}friend void to_json(nlohmann::json& j, const {class_name}& v) {{\n"
             class_definition += f"{INDENT}{INDENT}j = nlohmann::json::object();\n"
             for fname, orig_name, ftype, stype in all_field_info:

--- a/avrotize/structuretocsharp.py
+++ b/avrotize/structuretocsharp.py
@@ -8,7 +8,7 @@ import re
 from typing import Any, Dict, List, Tuple, Union, cast, Optional
 import uuid
 
-from avrotize.common import pascal, process_template
+from avrotize.common import pascal, process_template, json_wire_name
 from avrotize.jstructtoavro import JsonStructureToAvro
 from avrotize.constants import (
     NEWTONSOFT_JSON_VERSION,
@@ -479,8 +479,9 @@ class StructureToCSharp:
         else:
             field_name_cs = field_name
         
-        # Track if field name differs from original for JSON annotation
-        needs_json_annotation = field_name_cs != prop_name
+        # JSON wire key honors JSON Structure altnames.json; annotate when it differs
+        wire_name = json_wire_name(prop_name, prop_schema)
+        needs_json_annotation = field_name_cs != wire_name
         
         # Check if this is a const field
         if 'const' in prop_schema:
@@ -498,9 +499,9 @@ class StructureToCSharp:
             # Add JSON property name annotation when property name differs from schema name
             # This is needed for proper JSON serialization/deserialization, especially with pascal_properties
             if needs_json_annotation:
-                property_definition += f'{INDENT}[System.Text.Json.Serialization.JsonPropertyName("{prop_name}")]\n'
+                property_definition += f'{INDENT}[System.Text.Json.Serialization.JsonPropertyName("{wire_name}")]\n'
             if self.newtonsoft_json_annotation and needs_json_annotation:
-                property_definition += f'{INDENT}[Newtonsoft.Json.JsonProperty("{prop_name}")]\n'
+                property_definition += f'{INDENT}[Newtonsoft.Json.JsonProperty("{wire_name}")]\n'
             
             # Add XML element annotation if enabled
             if self.system_xml_annotation:
@@ -533,9 +534,9 @@ class StructureToCSharp:
         # Add JSON property name annotation when property name differs from schema name
         # This is needed for proper JSON serialization/deserialization, especially with pascal_properties
         elif needs_json_annotation:
-            property_definition += f'{INDENT}[System.Text.Json.Serialization.JsonPropertyName("{prop_name}")]\n'
+            property_definition += f'{INDENT}[System.Text.Json.Serialization.JsonPropertyName("{wire_name}")]\n'
         if self.newtonsoft_json_annotation and needs_json_annotation:
-            property_definition += f'{INDENT}[Newtonsoft.Json.JsonProperty("{prop_name}")]\n'
+            property_definition += f'{INDENT}[Newtonsoft.Json.JsonProperty("{wire_name}")]\n'
         
         # Add XML element annotation if enabled
         if self.system_xml_annotation:

--- a/avrotize/structuretocsharp.py
+++ b/avrotize/structuretocsharp.py
@@ -8,7 +8,7 @@ import re
 from typing import Any, Dict, List, Tuple, Union, cast, Optional
 import uuid
 
-from avrotize.common import pascal, process_template, json_wire_name
+from avrotize.common import pascal, process_template, json_wire_name, json_enum_wire_value
 from avrotize.jstructtoavro import JsonStructureToAvro
 from avrotize.constants import (
     NEWTONSOFT_JSON_VERSION,
@@ -766,7 +766,7 @@ class StructureToCSharp:
             enum_definition += f"{INDENT*2}{{\n"
             for value in enum_values:
                 member_name = pascal(str(value).replace('-', '_').replace(' ', '_'))
-                enum_definition += f'{INDENT*3}"{value}" => {enum_name}.{member_name},\n'
+                enum_definition += f'{INDENT*3}"{json_enum_wire_value(value, structure_schema)}" => {enum_name}.{member_name},\n'
             enum_definition += f'{INDENT*3}_ => throw new System.Text.Json.JsonException($"Unknown value \'{{stringValue}}\' for {enum_name}")\n'
             enum_definition += f"{INDENT*2}}};\n"
         
@@ -784,7 +784,7 @@ class StructureToCSharp:
             enum_definition += f"{INDENT*2}{{\n"
             for value in enum_values:
                 member_name = pascal(str(value).replace('-', '_').replace(' ', '_'))
-                enum_definition += f'{INDENT*3}{enum_name}.{member_name} => "{value}",\n'
+                enum_definition += f'{INDENT*3}{enum_name}.{member_name} => "{json_enum_wire_value(value, structure_schema)}",\n'
             enum_definition += f'{INDENT*3}_ => throw new System.ArgumentOutOfRangeException(nameof(value))\n'
             enum_definition += f"{INDENT*2}}};\n"
             enum_definition += f"{INDENT*2}writer.WriteStringValue(stringValue);\n"
@@ -814,7 +814,7 @@ class StructureToCSharp:
                 enum_definition += f"{INDENT*2}{{\n"
                 for value in enum_values:
                     member_name = pascal(str(value).replace('-', '_').replace(' ', '_'))
-                    enum_definition += f'{INDENT*3}"{value}" => {enum_name}.{member_name},\n'
+                    enum_definition += f'{INDENT*3}"{json_enum_wire_value(value, structure_schema)}" => {enum_name}.{member_name},\n'
                 enum_definition += f'{INDENT*3}_ => throw new Newtonsoft.Json.JsonException($"Unknown value \'{{stringValue}}\' for {enum_name}")\n'
                 enum_definition += f"{INDENT*2}}};\n"
             
@@ -832,7 +832,7 @@ class StructureToCSharp:
                 enum_definition += f"{INDENT*2}{{\n"
                 for value in enum_values:
                     member_name = pascal(str(value).replace('-', '_').replace(' ', '_'))
-                    enum_definition += f'{INDENT*3}{enum_name}.{member_name} => "{value}",\n'
+                    enum_definition += f'{INDENT*3}{enum_name}.{member_name} => "{json_enum_wire_value(value, structure_schema)}",\n'
                 enum_definition += f'{INDENT*3}_ => throw new System.ArgumentOutOfRangeException(nameof(value))\n'
                 enum_definition += f"{INDENT*2}}};\n"
                 enum_definition += f"{INDENT*2}writer.WriteValue(stringValue);\n"
@@ -2445,3 +2445,4 @@ def convert_structure_schema_to_csharp(
     structtocs.system_xml_annotation = system_xml_annotation
     structtocs.avro_annotation = avro_annotation
     structtocs.convert_schema(structure_schema, output_dir)
+

--- a/avrotize/structuretogo.py
+++ b/avrotize/structuretogo.py
@@ -6,7 +6,7 @@ import json
 import os
 from typing import Any, Dict, List, Set, Union, Optional, cast
 
-from avrotize.common import pascal, render_template, json_wire_name
+from avrotize.common import pascal, render_template, json_wire_name, json_enum_wire_value
 
 JsonNode = Dict[str, 'JsonNode'] | List['JsonNode'] | str | None
 
@@ -401,7 +401,8 @@ class StructureToGo:
         self.generated_types[go_enum_name] = "enum"
         self.generated_structure_types[go_enum_name] = structure_schema
 
-        symbols = structure_schema.get('enum', [])
+        raw_symbols = structure_schema.get('enum', [])
+        symbols = [{'name': str(s), 'value': json_enum_wire_value(s, structure_schema)} for s in raw_symbols]
         
         # Determine base type
         base_type = structure_schema.get('type', 'string')
@@ -423,10 +424,10 @@ class StructureToGo:
 
         self.enums.append({
             'name': go_enum_name,
-            'symbols': symbols,
+            'symbols': [s['name'] for s in symbols],
         })
 
-        self.generate_unit_test('enum', go_enum_name, symbols)
+        self.generate_unit_test('enum', go_enum_name, [s['name'] for s in symbols])
 
         return go_enum_name
 

--- a/avrotize/structuretogo.py
+++ b/avrotize/structuretogo.py
@@ -6,7 +6,7 @@ import json
 import os
 from typing import Any, Dict, List, Set, Union, Optional, cast
 
-from avrotize.common import pascal, render_template
+from avrotize.common import pascal, render_template, json_wire_name
 
 JsonNode = Dict[str, 'JsonNode'] | List['JsonNode'] | str | None
 
@@ -341,7 +341,7 @@ class StructureToGo:
             fields.append({
                 'name': pascal(prop_name),
                 'type': field_type,
-                'original_name': prop_name,
+                'original_name': json_wire_name(prop_name, prop_schema),
                 'source_type': source_type
             })
 

--- a/avrotize/structuretogo/go_enum.jinja
+++ b/avrotize/structuretogo/go_enum.jinja
@@ -7,6 +7,6 @@ type {{ enum_name }} {{ base_type }}
 
 const (
 {%- for symbol in symbols %}
-    {{ enum_name }}_{{ symbol }} {{ enum_name }} = {% if base_type == 'string' %}"{{ symbol }}"{% else %}{{ loop.index0 }}{% endif %}
+    {{ enum_name }}_{{ symbol.name }} {{ enum_name }} = {% if base_type == 'string' %}"{{ symbol.value }}"{% else %}{{ loop.index0 }}{% endif %}
 {%- endfor %}
 )

--- a/avrotize/structuretojava.py
+++ b/avrotize/structuretojava.py
@@ -6,7 +6,7 @@ import os
 from typing import Dict, List, Tuple, Union, Set, Optional, Any
 from avrotize.constants import JACKSON_VERSION, JACKSON_ANNOTATIONS_VERSION
 
-from avrotize.common import pascal, camel, process_template, json_wire_name
+from avrotize.common import pascal, camel, process_template, json_wire_name, json_enum_wire_value
 
 INDENT = '    '
 
@@ -611,15 +611,16 @@ class StructureToJava:
                 symbols=symbol_list
             )
         else:
-            # String enum
-            safe_symbols = [self.safe_identifier(pascal(str(symbol).replace('-', '_').replace(' ', '_'))) for symbol in symbols]
+            # String enum — member name from original value; JSON wire value via altenums.json
+            symbol_list = [{'name': self.safe_identifier(pascal(str(symbol).replace('-', '_').replace(' ', '_'))),
+                            'value': json_enum_wire_value(symbol, structure_schema)} for symbol in symbols]
             enum_definition = process_template(
                 "structuretojava/enum_core.jinja",
                 class_name=enum_name,
                 docstring=doc,
                 deprecated=deprecated,
                 is_numeric=False,
-                symbols=safe_symbols
+                symbols=symbol_list
             )
         
         if write_file:

--- a/avrotize/structuretojava.py
+++ b/avrotize/structuretojava.py
@@ -6,7 +6,7 @@ import os
 from typing import Dict, List, Tuple, Union, Set, Optional, Any
 from avrotize.constants import JACKSON_VERSION, JACKSON_ANNOTATIONS_VERSION
 
-from avrotize.common import pascal, camel, process_template
+from avrotize.common import pascal, camel, process_template, json_wire_name
 
 INDENT = '    '
 
@@ -446,7 +446,7 @@ class StructureToJava:
             source_type = 'object'
         return {
             'name': safe_field_name,
-            'original_name': prop_name,
+            'original_name': json_wire_name(prop_name, prop_schema),
             'type': field_type.type_name,
             'source_type': source_type,
             'docstring': doc,

--- a/avrotize/structuretojava/enum_core.jinja
+++ b/avrotize/structuretojava/enum_core.jinja
@@ -13,6 +13,8 @@ public enum {{ class_name }} {
     {{ class_name }}({{ numeric_type }} value) { this.value = value; }
     public {{ numeric_type }} getValue() { return value; }
 {%- else %}
-    {{ symbols|join(', ') }}
+{%- for symbol in symbols %}
+    @com.fasterxml.jackson.annotation.JsonProperty("{{ symbol.value }}") {{ symbol.name }}{% if not loop.last %},{% else %};{% endif %}
+{%- endfor %}
 {%- endif %}
 }

--- a/avrotize/structuretopython.py
+++ b/avrotize/structuretopython.py
@@ -8,7 +8,7 @@ import re
 import random
 from typing import Any, Dict, List, Set, Tuple, Union, Optional
 
-from avrotize.common import pascal, process_template
+from avrotize.common import pascal, process_template, json_wire_name
 from avrotize.jstructtoavro import JsonStructureToAvro
 
 JsonNode = Dict[str, 'JsonNode'] | List['JsonNode'] | str | None
@@ -437,8 +437,9 @@ class StructureToPython:
         """ Generates a field for a Python dataclass """
         # Sanitize field name for Python identifier validity
         field_name = self.safe_identifier(prop_name, class_name)
-        # Track if we need a field_name annotation for JSON serialization
-        needs_field_name_annotation = field_name != prop_name
+        # Wire key honors JSON Structure altnames.json; annotation needed when it differs
+        wire_name = json_wire_name(prop_name, prop_schema)
+        needs_field_name_annotation = wire_name != field_name
 
         # Check if this is a const field
         if 'const' in prop_schema:
@@ -447,7 +448,7 @@ class StructureToPython:
                 class_name, field_name, prop_schema, parent_namespace, import_types)
             return {
                 'name': field_name,
-                'json_name': prop_name if needs_field_name_annotation else None,
+                'json_name': wire_name if needs_field_name_annotation else None,
                 'type': prop_type,
                 'is_primitive': self.is_python_primitive(prop_type) or self.is_python_typing_struct(prop_type),
                 'is_enum': False,
@@ -482,7 +483,7 @@ class StructureToPython:
 
         return {
             'name': field_name,
-            'json_name': prop_name if needs_field_name_annotation else None,
+            'json_name': wire_name if needs_field_name_annotation else None,
             'type': prop_type,
             'is_primitive': self.is_python_primitive(prop_type) or self.is_python_typing_struct(prop_type),
             'is_enum': prop_type in self.generated_types and self.generated_types[prop_type] == 'enum',

--- a/avrotize/structuretopython.py
+++ b/avrotize/structuretopython.py
@@ -8,7 +8,7 @@ import re
 import random
 from typing import Any, Dict, List, Set, Tuple, Union, Optional
 
-from avrotize.common import pascal, process_template, json_wire_name
+from avrotize.common import pascal, process_template, json_wire_name, json_enum_wire_value
 from avrotize.jstructtoavro import JsonStructureToAvro
 
 JsonNode = Dict[str, 'JsonNode'] | List['JsonNode'] | str | None
@@ -613,7 +613,7 @@ class StructureToPython:
             if is_numeric:
                 value_repr = repr(value)
             else:
-                value_repr = repr(str(value))
+                value_repr = repr(json_enum_wire_value(value, structure_schema))
             members.append((member_name, value_repr))
             symbols.append(member_name)
 

--- a/avrotize/structuretorust.py
+++ b/avrotize/structuretorust.py
@@ -7,7 +7,7 @@ import os
 import re
 from typing import Any, Dict, List, Set, Tuple, Union, Optional
 
-from avrotize.common import pascal, snake, render_template
+from avrotize.common import pascal, snake, render_template, json_wire_name
 
 JsonNode = Dict[str, 'JsonNode'] | List['JsonNode'] | str | None
 
@@ -307,7 +307,7 @@ class StructureToRust:
             if 'const' in prop_schema:
                 continue
             
-            original_field_name = prop_name
+            original_field_name = json_wire_name(prop_name, prop_schema)
             field_name = self.safe_identifier(snake(prop_name))
             
             # Determine if required

--- a/avrotize/structuretorust.py
+++ b/avrotize/structuretorust.py
@@ -7,7 +7,7 @@ import os
 import re
 from typing import Any, Dict, List, Set, Tuple, Union, Optional
 
-from avrotize.common import pascal, snake, render_template, json_wire_name
+from avrotize.common import pascal, snake, render_template, json_wire_name, json_enum_wire_value
 
 JsonNode = Dict[str, 'JsonNode'] | List['JsonNode'] | str | None
 
@@ -382,12 +382,11 @@ class StructureToRust:
         # Convert enum values to valid Rust identifiers
         symbols = []
         for value in enum_values:
+            wire = json_enum_wire_value(value, structure_schema)
             if isinstance(value, str):
-                # Convert to PascalCase and make it a valid Rust identifier
                 symbol = pascal(value.replace('-', '_').replace(' ', '_'))
-                symbols.append({'name': symbol, 'value': value})
+                symbols.append({'name': symbol, 'value': wire})
             else:
-                # For numeric values, use Value prefix
                 symbols.append({'name': f"Value{value}", 'value': str(value)})
 
         doc = structure_schema.get('description', structure_schema.get('doc', enum_name))

--- a/avrotize/structuretots.py
+++ b/avrotize/structuretots.py
@@ -8,7 +8,7 @@ import random
 import re
 from typing import Any, Dict, List, Set, Tuple, Union, Optional
 
-from avrotize.common import pascal, process_template
+from avrotize.common import pascal, process_template, json_wire_name
 
 JsonNode = Dict[str, 'JsonNode'] | List['JsonNode'] | str | None
 
@@ -356,7 +356,7 @@ class StructureToTypeScript:
                 source_type = 'object'
             fields.append({
                 'name': self.safe_name(prop_name),
-                'original_name': prop_name,
+                'original_name': json_wire_name(prop_name, prop_schema),
                 'type': field_type,
                 'type_no_null': field_type_no_null,
                 'source_type': source_type,

--- a/avrotize/structuretots.py
+++ b/avrotize/structuretots.py
@@ -8,7 +8,7 @@ import random
 import re
 from typing import Any, Dict, List, Set, Tuple, Union, Optional
 
-from avrotize.common import pascal, process_template, json_wire_name
+from avrotize.common import pascal, process_template, json_wire_name, json_enum_wire_value
 
 JsonNode = Dict[str, 'JsonNode'] | List['JsonNode'] | str | None
 
@@ -421,7 +421,8 @@ class StructureToTypeScript:
         if typescript_qualified_name in self.generated_types:
             return typescript_qualified_name
 
-        symbols = structure_schema.get('enum', [])
+        raw_symbols = structure_schema.get('enum', [])
+        symbols = [{'name': str(s), 'value': json_enum_wire_value(s, structure_schema)} for s in raw_symbols]
         
         enum_definition = process_template(
             "structuretots/enum_core.ts.jinja",

--- a/avrotize/structuretots/class_core.ts.jinja
+++ b/avrotize/structuretots/class_core.ts.jinja
@@ -19,10 +19,11 @@ export {% if is_abstract %}abstract {% endif %}class {{ class_name }}{% if base_
     /** {{ field.docstring }} */
     {%- if typedjson_annotation %}
     {%- set field_type = field.type_no_null %}
+    {%- set name_opt = ", name: '" ~ field.original_name ~ "'" if field.original_name != field.name else "" %}
     {%- if field.source_type in ['int64', 'uint64', 'int128', 'uint128', 'decimal'] %}
-    @jsonMember(String, { serializer: (v: {{ field_type }}) => v != null ? String(v) : undefined, deserializer: (v: string) => {% if field.source_type == 'decimal' %}parseFloat(v){% elif field.source_type in ['int128', 'uint128'] %}BigInt(v){% else %}Number(v){% endif %} })
+    @jsonMember(String, { serializer: (v: {{ field_type }}) => v != null ? String(v) : undefined, deserializer: (v: string) => {% if field.source_type == 'decimal' %}parseFloat(v){% elif field.source_type in ['int128', 'uint128'] %}BigInt(v){% else %}Number(v){% endif %}{{ name_opt }} })
     {%- else %}
-    @jsonMember({{ 'String' if field.is_enum else (field_type if not field.is_primitive else 'String' if field_type == 'Date' else field_type | capitalize) }})
+    @jsonMember({{ 'String' if field.is_enum else (field_type if not field.is_primitive else 'String' if field_type == 'Date' else field_type | capitalize) }}{% if name_opt %}, { {{ name_opt[2:] }} }{% endif %})
     {%- endif %}
     {%- endif %}
     public {{ field.name }}{% if field.is_optional %}?{% endif %}: {{ field.type_no_null }};

--- a/avrotize/structuretots/enum_core.ts.jinja
+++ b/avrotize/structuretots/enum_core.ts.jinja
@@ -1,6 +1,6 @@
 /** {{ docstring }} */
 export enum {{ enum_name }} {
     {%- for symbol in symbols %}
-    {{ symbol }} = "{{ symbol }}"{%- if not loop.last %},{%- endif %}
+    {{ symbol.name }} = "{{ symbol.value }}"{%- if not loop.last %},{%- endif %}
     {%- endfor %}
 }

--- a/test/jsons/altnames-wire.struct.json
+++ b/test/jsons/altnames-wire.struct.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-structure.org/meta/extended/v0/#",
+  "$id": "https://example.com/altnames-wire/v1",
+  "name": "Telemetry",
+  "$root": "#/definitions/Telemetry",
+  "$uses": ["JSONStructureAlternateNames"],
+  "definitions": {
+    "Telemetry": {
+      "name": "Telemetry",
+      "type": "object",
+      "properties": {
+        "dr_type": { "type": "int32", "altnames": { "json": "dr-type" } },
+        "tlp_requestid": { "type": "string", "altnames": { "json": "tlp-requestid" } },
+        "signal_groupid": { "type": "int64", "altnames": { "json": "signal-groupid" } },
+        "regular": { "type": "string" }
+      },
+      "required": ["dr_type", "regular"]
+    }
+  }
+}

--- a/test/test_structure_altnames.py
+++ b/test/test_structure_altnames.py
@@ -1,14 +1,19 @@
-"""Tests for issue #384: honor JSON Structure altnames.json for wire serialization.
+"""Issue #384: honor JSON Structure altnames.json for wire serialization — full round-trip.
 
-Property `dr_type` + `altnames.json="dr-type"` must serialize `dr-type` on the JSON wire
-while keeping the spec-valid identifier `dr_type` as the language member name. Covers all
-structure->language direct generators.
+A property `dr_type` + `altnames.json="dr-type"` must serialize `dr-type` on the JSON wire
+while keeping the spec-valid identifier `dr_type` as the language member name. Each generator
+is exercised end-to-end: generate -> build -> serialize -> assert wire key -> deserialize.
+Languages whose toolchain is unavailable are skipped (C++ has no compiler here).
 """
 
 import os
 import glob
+import json
 import shutil
+import subprocess
+import sys
 import tempfile
+import importlib.util
 import unittest
 
 from avrotize.common import json_wire_name
@@ -20,17 +25,17 @@ from avrotize.structuretogo import convert_structure_schema_to_go
 from avrotize.structuretorust import convert_structure_schema_to_rust
 from avrotize.structuretocpp import convert_structure_schema_to_cpp
 
+# dr_type carries hyphenated wire key dr-type; regular has no altnames (must stay verbatim).
 SCHEMA = {
     "name": "Telemetry",
     "type": "object",
     "properties": {
         "dr_type": {"type": "int32", "altnames": {"json": "dr-type"}},
-        "tlp_requestid": {"type": "string", "altnames": {"json": "tlp-requestid"}},
-        "signal_groupid": {"type": "int64", "altnames": {"json": "signal-groupid"}},
         "regular": {"type": "string"},
     },
     "required": ["dr_type", "regular"],
 }
+WIN = sys.platform == "win32"
 
 
 def _out(name: str) -> str:
@@ -40,15 +45,13 @@ def _out(name: str) -> str:
     return path
 
 
-def _read_all(path: str) -> str:
-    parts = []
-    for f in glob.glob(os.path.join(path, "**", "*"), recursive=True):
-        if os.path.isfile(f):
-            try:
-                parts.append(open(f, encoding="utf-8", errors="ignore").read())
-            except OSError:
-                pass
-    return "\n".join(parts)
+def _have(tool: str) -> bool:
+    return shutil.which(tool) is not None
+
+
+def _run(cmd, cwd, timeout=600, shell=False):
+    return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True,
+                          timeout=timeout, shell=shell)
 
 
 class TestJsonWireNameHelper(unittest.TestCase):
@@ -64,62 +67,189 @@ class TestJsonWireNameHelper(unittest.TestCase):
     def test_other_purpose_ignored(self):
         self.assertEqual(json_wire_name("d", {"altnames": {"sql": "d-x"}}), "d")
 
+    def test_empty_altnames(self):
+        self.assertEqual(json_wire_name("d", {"altnames": {}}), "d")
 
-class TestStructureAltnamesWire(unittest.TestCase):
-    """Each generator must map identifier members to hyphenated wire keys."""
 
-    def test_python_dataclasses_json(self):
+class TestPythonRoundTrip(unittest.TestCase):
+    def test_python(self):
         out = _out("py")
         convert_structure_schema_to_python(SCHEMA, out, dataclasses_json_annotation=True)
-        c = _read_all(out)
-        self.assertIn('field_name="dr-type"', c)
-        self.assertIn('field_name="tlp-requestid"', c)
-        self.assertIn("dr_type", c)
-        self.assertIn('field_name="regular"', c)
+        src = next(f for f in glob.glob(os.path.join(out, "**", "telemetry.py"), recursive=True))
+        spec = importlib.util.spec_from_file_location("alt384", src)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules["alt384"] = mod
+        spec.loader.exec_module(mod)
+        inst = mod.Telemetry(dr_type=7, regular="hello")
+        data = json.loads(inst.to_json())
+        self.assertEqual(data["dr-type"], 7)
+        self.assertNotIn("dr_type", data)
+        self.assertEqual(data["regular"], "hello")
+        back = mod.Telemetry.from_json(json.dumps({"dr-type": 9, "regular": "x"}))
+        self.assertEqual(back.dr_type, 9)
+        self.assertEqual(back.regular, "x")
 
-    def test_csharp_system_text_and_newtonsoft(self):
+
+class TestGoRoundTrip(unittest.TestCase):
+    def test_go(self):
+        if not _have("go"):
+            self.skipTest("go not installed")
+        out = _out("go")
+        convert_structure_schema_to_go(SCHEMA, out, package_name="tel", json_annotation=True)
+        pkg = glob.glob(os.path.join(out, "**", "Telemetry.go"), recursive=True)[0]
+        pkgdir = os.path.dirname(pkg)
+        with open(os.path.join(pkgdir, "rt_test.go"), "w", encoding="utf-8") as f:
+            f.write(
+                "package tel\n"
+                'import ("encoding/json"; "testing")\n'
+                "func TestRT(t *testing.T){\n"
+                ' b,_:=json.Marshal(&Telemetry{DrType:7,Regular:\"hi\"})\n'
+                ' s:=string(b)\n'
+                ' if !contains(s,`\"dr-type\":7`){t.Fatalf(\"no wire key: %s\",s)}\n'
+                ' if contains(s,\"dr_type\"){t.Fatalf(\"id leaked: %s\",s)}\n'
+                ' var v Telemetry; json.Unmarshal([]byte(`{\"dr-type\":9,\"regular\":\"x\"}`),&v)\n'
+                ' if v.DrType!=9||v.Regular!=\"x\"{t.Fatalf(\"rt fail: %+v\",v)}\n'
+                "}\n"
+                "func contains(h,n string)bool{return len(n)<=len(h)&&indexOf(h,n)>=0}\n"
+                "func indexOf(h,n string)int{for i:=0;i+len(n)<=len(h);i++{if h[i:i+len(n)]==n{return i}};return -1}\n")
+        _run(["go", "mod", "tidy"], out, shell=WIN)
+        r = _run(["go", "test", "./..."], out, shell=WIN)
+        self.assertEqual(r.returncode, 0, f"go round-trip failed: {r.stdout}\n{r.stderr}")
+
+
+class TestRustRoundTrip(unittest.TestCase):
+    def test_rust(self):
+        if not _have("cargo"):
+            self.skipTest("cargo not installed")
+        out = _out("rust")
+        convert_structure_schema_to_rust(SCHEMA, out, package_name="tel", serde_annotation=True)
+        tests = os.path.join(out, "tests")
+        os.makedirs(tests, exist_ok=True)
+        with open(os.path.join(out, "src", "lib.rs"), "w", encoding="utf-8") as f:
+            f.write("pub mod telemetry;\n")
+        with open(os.path.join(tests, "rt.rs"), "w", encoding="utf-8") as f:
+            f.write(
+                "use tel::telemetry::Telemetry;\n"
+                "#[test] fn rt(){\n"
+                ' let t=Telemetry{dr_type:7,regular:"hi".into()};\n'
+                " let s=serde_json::to_string(&t).unwrap();\n"
+                ' assert!(s.contains("\\"dr-type\\":7"), "no wire key: {}", s);\n'
+                ' assert!(!s.contains("dr_type"), "id leaked: {}", s);\n'
+                ' let v:Telemetry=serde_json::from_str("{\\"dr-type\\":9,\\"regular\\":\\"x\\"}").unwrap();\n'
+                ' assert_eq!(v.dr_type,9); assert_eq!(v.regular,"x");\n'
+                "}\n")
+        r = _run(["cargo", "test", "--quiet"], out, timeout=900, shell=WIN)
+        self.assertEqual(r.returncode, 0, f"rust round-trip failed: {r.stdout}\n{r.stderr}")
+
+
+class TestCSharpRoundTrip(unittest.TestCase):
+    def test_csharp(self):
+        if not _have("dotnet"):
+            self.skipTest("dotnet not installed")
         out = _out("cs")
-        convert_structure_schema_to_csharp(
-            SCHEMA, out, base_namespace="Tel",
-            system_text_json_annotation=True, newtonsoft_json_annotation=True)
-        c = _read_all(out)
-        self.assertIn('JsonPropertyName("dr-type")', c)
-        self.assertIn('JsonProperty("tlp-requestid")', c)
+        convert_structure_schema_to_csharp(SCHEMA, out, base_namespace="Tel",
+                                           system_text_json_annotation=True)
+        tel = glob.glob(os.path.join(out, "**", "Telemetry.cs"), recursive=True)[0]
+        proj = glob.glob(os.path.join(out, "src", "*.csproj"))[0]
+        drv = os.path.join(out, "drv")
+        os.makedirs(drv)
+        with open(os.path.join(drv, "drv.csproj"), "w", encoding="utf-8") as f:
+            f.write('<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><OutputType>Exe</OutputType>'
+                    '<TargetFramework>net10.0</TargetFramework><Nullable>enable</Nullable></PropertyGroup>'
+                    f'<ItemGroup><ProjectReference Include="{proj}" /></ItemGroup></Project>')
+        with open(os.path.join(drv, "Program.cs"), "w", encoding="utf-8") as f:
+            f.write('var t=new Tel.Telemetry{dr_type=7,regular="hi"};'
+                    'var s=System.Text.Json.JsonSerializer.Serialize(t);'
+                    'System.Console.WriteLine(s);'
+                    'var b=System.Text.Json.JsonSerializer.Deserialize<Tel.Telemetry>("{\\"dr-type\\":9,\\"regular\\":\\"x\\"}");'
+                    'System.Console.WriteLine(b!.dr_type+"|"+b.regular);')
+        r = _run(["dotnet", "run", "--project", drv, "-c", "Release"], drv, timeout=600, shell=WIN)
+        self.assertEqual(r.returncode, 0, f"dotnet run failed: {r.stdout}\n{r.stderr}")
+        self.assertIn('"dr-type":7', r.stdout)
+        self.assertNotIn("dr_type", r.stdout.split("\n")[0])
+        self.assertIn("9|x", r.stdout)
 
-    def test_java_jackson(self):
+
+class TestJavaRoundTrip(unittest.TestCase):
+    def test_java(self):
+        if not _have("mvn"):
+            self.skipTest("maven not installed")
         out = _out("java")
-        convert_structure_schema_to_java(SCHEMA, out, jackson_annotation=True)
-        c = _read_all(out)
-        self.assertIn('@JsonProperty("dr-type")', c)
-        self.assertIn('@JsonProperty("signal-groupid")', c)
+        convert_structure_schema_to_java(SCHEMA, out, package_name="tel", jackson_annotation=True)
+        tdir = os.path.join(out, "src", "main", "java", "tel")
+        os.makedirs(tdir, exist_ok=True)
+        with open(os.path.join(tdir, "Rt.java"), "w", encoding="utf-8") as f:
+            f.write(
+                "package tel;\nimport com.fasterxml.jackson.databind.ObjectMapper;\n"
+                "public class Rt{ public static void main(String[] a) throws Exception{\n"
+                " ObjectMapper m=new ObjectMapper(); Telemetry t=new Telemetry(); t.setDrType(7); t.setRegular(\"hi\");\n"
+                " String s=m.writeValueAsString(t);\n"
+                " if(!s.contains(\"\\\"dr-type\\\":7\")) throw new RuntimeException(\"no wire key: \"+s);\n"
+                " if(s.contains(\"dr_type\")) throw new RuntimeException(\"id leaked: \"+s);\n"
+                " Telemetry b=m.readValue(\"{\\\"dr-type\\\":9,\\\"regular\\\":\\\"x\\\"}\",Telemetry.class);\n"
+                " if(b.getDrType()!=9||!\"x\".equals(b.getRegular())) throw new RuntimeException(\"rt fail\");\n"
+                " System.out.println(\"OK\");\n}}\n")
+        r = _run(["mvn", "-q", "-B", "compile",
+                  "org.codehaus.mojo:exec-maven-plugin:3.1.0:java",
+                  "-Dexec.mainClass=tel.Rt"], out, timeout=900, shell=WIN)
+        self.assertEqual(r.returncode, 0, f"java round-trip failed: {r.stdout[-3000:]}\n{r.stderr[-1000:]}")
+        self.assertIn("OK", r.stdout)
 
-    def test_typescript_typedjson(self):
+
+class TestTypeScriptRoundTrip(unittest.TestCase):
+    def test_typescript(self):
+        if not _have("npm"):
+            self.skipTest("npm not installed")
         out = _out("ts")
         convert_structure_schema_to_typescript(SCHEMA, out, typedjson_annotation=True)
-        c = _read_all(out)
-        self.assertIn("name: 'dr-type'", c)
-        self.assertIn("name: 'tlp-requestid'", c)
+        with open(os.path.join(out, "src", "rt.ts"), "w", encoding="utf-8") as f:
+            f.write("import 'reflect-metadata';import {Telemetry} from './Telemetry.js';\n"
+                    "const t=new Telemetry(7,'hi');const s=t.toJSON();\n"
+                    "if(!s.includes('\"dr-type\":7'))throw new Error('no wire key:'+s);\n"
+                    "if(s.includes('dr_type'))throw new Error('id leaked:'+s);\n"
+                    "const b=Telemetry.fromJSON('{\"dr-type\":9,\"regular\":\"x\"}');\n"
+                    "if(b.dr_type!==9||b.regular!=='x')throw new Error('rt:'+JSON.stringify(b));\n"
+                    "console.log('OK');\n")
+        if _run(["npm", "install"], out, timeout=300, shell=WIN).returncode != 0:
+            self.skipTest("npm install failed")
+        r = _run(["npx", "tsc", "-p", "tsconfig.json"], out, timeout=300, shell=WIN)
+        self.assertEqual(r.returncode, 0, f"tsc failed: {r.stdout}\n{r.stderr}")
+        built = glob.glob(os.path.join(out, "**", "rt.js"), recursive=True)
+        self.assertTrue(built, "rt.js not built")
+        r2 = _run(["node", built[0]], out, timeout=120, shell=WIN)
+        self.assertEqual(r2.returncode, 0, f"node round-trip failed: {r2.stdout}\n{r2.stderr}")
+        self.assertIn("OK", r2.stdout)
 
-    def test_go_json_tags(self):
-        out = _out("go")
-        convert_structure_schema_to_go(SCHEMA, out, json_annotation=True)
-        c = _read_all(out)
-        self.assertIn('json:"dr-type', c)
-        self.assertIn('json:"signal-groupid', c)
 
-    def test_rust_serde_rename(self):
-        out = _out("rust")
-        convert_structure_schema_to_rust(SCHEMA, out, serde_annotation=True)
-        c = _read_all(out)
-        self.assertIn('rename = "dr-type"', c)
-        self.assertIn('rename = "tlp-requestid"', c)
-
-    def test_cpp_json_keys(self):
+class TestCppGeneration(unittest.TestCase):
+    """Assert generated wire-key serialization; compile+run round-trip if g++ and nlohmann are available."""
+    def test_cpp(self):
         out = _out("cpp")
         convert_structure_schema_to_cpp(SCHEMA, out, namespace="tel", json_annotation=True)
-        c = _read_all(out)
-        self.assertIn('"dr-type"', c)
-        self.assertIn('"tlp-requestid"', c)
+        inc = glob.glob(os.path.join(out, "**", "Telemetry.hpp"), recursive=True)[0]
+        src = open(inc, encoding="utf-8", errors="ignore").read()
+        self.assertIn('"dr-type"', src)
+        self.assertIn("dr_type", src)
+        if not _have("g++"):
+            self.skipTest("g++ not installed; source assertions only")
+        incdir = os.path.dirname(os.path.dirname(inc))
+        drv = os.path.join(out, "rt.cpp")
+        with open(drv, "w", encoding="utf-8") as f:
+            f.write('#include <tel/Telemetry.hpp>\n#include <string>\n#include <cassert>\n#include <iostream>\n'
+                    'int main(){ tel::Telemetry t; t.dr_type=7; t.regular="hi";\n'
+                    ' auto s=t.to_json().dump();\n'
+                    ' assert(s.find("\\"dr-type\\":7")!=std::string::npos);\n'
+                    ' assert(s.find("dr_type")==std::string::npos);\n'
+                    ' auto j=nlohmann::json::parse("{\\"dr-type\\":9,\\"regular\\":\\"x\\"}");\n'
+                    ' tel::Telemetry b=j.get<tel::Telemetry>();\n'
+                    ' assert(b.dr_type==9 && b.regular=="x"); std::cout<<"OK"; return 0; }\n')
+        exe = os.path.join(out, "rt.exe")
+        c = _run(["g++", "-std=c++17", f"-I{incdir}", drv, "-o", exe], out, timeout=300, shell=WIN)
+        if c.returncode != 0:
+            self.skipTest(f"g++ compile failed (nlohmann missing?): {c.stderr[-400:]}")
+        r = _run([exe], out, timeout=60, shell=WIN)
+        self.assertEqual(r.returncode, 0, f"cpp round-trip failed: {r.stdout}\n{r.stderr}")
+        self.assertIn("OK", r.stdout)
 
 
 if __name__ == "__main__":

--- a/test/test_structure_altnames.py
+++ b/test/test_structure_altnames.py
@@ -37,6 +37,27 @@ SCHEMA = {
 }
 WIN = sys.platform == "win32"
 
+# Rich schema: nested object, array-of-object, map-of-object property renames + enum altenums.
+RICH = {
+    "name": "Outer",
+    "type": "object",
+    "properties": {
+        "dr_type": {"type": "int32", "altnames": {"json": "dr-type"}},
+        "child": {"type": "object", "name": "Child",
+                  "properties": {"nest_id": {"type": "int32", "altnames": {"json": "nest-id"}}},
+                  "required": ["nest_id"]},
+        "items": {"type": "array", "items": {"type": "object", "name": "Elem",
+                  "properties": {"el_id": {"type": "int32", "altnames": {"json": "el-id"}}},
+                  "required": ["el_id"]}},
+        "lookup": {"type": "map", "values": {"type": "object", "name": "MapVal",
+                   "properties": {"mv_id": {"type": "int32", "altnames": {"json": "mv-id"}}},
+                   "required": ["mv_id"]}},
+        "color": {"type": "string", "name": "Color", "enum": ["RED", "GREEN"],
+                  "altenums": {"json": {"RED": "r-ed", "GREEN": "g-reen"}}},
+    },
+    "required": ["dr_type"],
+}
+
 
 def _out(name: str) -> str:
     path = os.path.join(tempfile.gettempdir(), "avrotize_altnames", name)
@@ -250,6 +271,52 @@ class TestCppGeneration(unittest.TestCase):
         r = _run([exe], out, timeout=60, shell=WIN)
         self.assertEqual(r.returncode, 0, f"cpp round-trip failed: {r.stdout}\n{r.stderr}")
         self.assertIn("OK", r.stdout)
+
+
+class TestConstructsCoverage(unittest.TestCase):
+    """altnames must rename property keys at every nesting level (object, array items, map values),
+    and altenums must rename enum wire values, in every generator's emitted source."""
+    GENS = [
+        ("py", convert_structure_schema_to_python, {"dataclasses_json_annotation": True}),
+        ("cs", convert_structure_schema_to_csharp, {"base_namespace": "Tel", "system_text_json_annotation": True}),
+        ("java", convert_structure_schema_to_java, {"package_name": "tel", "jackson_annotation": True}),
+        ("ts", convert_structure_schema_to_typescript, {"typedjson_annotation": True}),
+        ("go", convert_structure_schema_to_go, {"package_name": "tel", "json_annotation": True}),
+        ("rust", convert_structure_schema_to_rust, {"package_name": "tel", "serde_annotation": True}),
+        ("cpp", convert_structure_schema_to_cpp, {"namespace": "tel", "json_annotation": True}),
+    ]
+    def test_all_constructs(self):
+        for name, fn, kw in self.GENS:
+            out = _out("cov_" + name)
+            fn(RICH, out, **kw)
+            src = "".join(open(f, encoding="utf-8", errors="ignore").read()
+                          for f in glob.glob(os.path.join(out, "**", "*.*"), recursive=True)
+                          if f.rsplit(".", 1)[-1] in ("py", "cs", "java", "ts", "go", "rs", "hpp"))
+            for wire in ("dr-type", "nest-id", "el-id", "mv-id", "r-ed", "g-reen"):
+                self.assertIn(wire, src, f"{name}: missing wire token {wire}")
+
+
+class TestPythonDeepRoundTrip(unittest.TestCase):
+    def test_python_deep(self):
+        out = _out("pydeep")
+        convert_structure_schema_to_python(RICH, out, dataclasses_json_annotation=True)
+        files = glob.glob(os.path.join(out, "**", "*.py"), recursive=True)
+        outer = next(f for f in files if os.path.basename(f) == "outer.py")
+        for f in files:
+            spec = importlib.util.spec_from_file_location(os.path.splitext(os.path.basename(f))[0], f)
+            m = importlib.util.module_from_spec(spec); sys.modules[spec.name] = m; spec.loader.exec_module(m)
+        mod = sys.modules["outer"]
+        o = mod.Outer(dr_type=1, child=mod.Child(nest_id=2),
+                      items=[mod.Elem(el_id=3)], lookup={"k": mod.MapVal(mv_id=4)},
+                      color=mod.Color.RED)
+        d = json.loads(o.to_json())
+        self.assertEqual(d["dr-type"], 1)
+        self.assertEqual(d["child"]["nest-id"], 2)
+        self.assertEqual(d["items"][0]["el-id"], 3)
+        self.assertEqual(d["lookup"]["k"]["mv-id"], 4)
+        self.assertEqual(d["color"], "r-ed")
+        for leaked in ("dr_type", "nest_id", "el_id", "mv_id", "RED"):
+            self.assertNotIn(leaked, json.dumps(d))
 
 
 if __name__ == "__main__":

--- a/test/test_structure_altnames.py
+++ b/test/test_structure_altnames.py
@@ -1,0 +1,126 @@
+"""Tests for issue #384: honor JSON Structure altnames.json for wire serialization.
+
+Property `dr_type` + `altnames.json="dr-type"` must serialize `dr-type` on the JSON wire
+while keeping the spec-valid identifier `dr_type` as the language member name. Covers all
+structure->language direct generators.
+"""
+
+import os
+import glob
+import shutil
+import tempfile
+import unittest
+
+from avrotize.common import json_wire_name
+from avrotize.structuretopython import convert_structure_schema_to_python
+from avrotize.structuretocsharp import convert_structure_schema_to_csharp
+from avrotize.structuretojava import convert_structure_schema_to_java
+from avrotize.structuretots import convert_structure_schema_to_typescript
+from avrotize.structuretogo import convert_structure_schema_to_go
+from avrotize.structuretorust import convert_structure_schema_to_rust
+from avrotize.structuretocpp import convert_structure_schema_to_cpp
+
+SCHEMA = {
+    "name": "Telemetry",
+    "type": "object",
+    "properties": {
+        "dr_type": {"type": "int32", "altnames": {"json": "dr-type"}},
+        "tlp_requestid": {"type": "string", "altnames": {"json": "tlp-requestid"}},
+        "signal_groupid": {"type": "int64", "altnames": {"json": "signal-groupid"}},
+        "regular": {"type": "string"},
+    },
+    "required": ["dr_type", "regular"],
+}
+
+
+def _out(name: str) -> str:
+    path = os.path.join(tempfile.gettempdir(), "avrotize_altnames", name)
+    shutil.rmtree(path, ignore_errors=True)
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def _read_all(path: str) -> str:
+    parts = []
+    for f in glob.glob(os.path.join(path, "**", "*"), recursive=True):
+        if os.path.isfile(f):
+            try:
+                parts.append(open(f, encoding="utf-8", errors="ignore").read())
+            except OSError:
+                pass
+    return "\n".join(parts)
+
+
+class TestJsonWireNameHelper(unittest.TestCase):
+    def test_altnames_json_wins(self):
+        self.assertEqual(json_wire_name("dr_type", {"altnames": {"json": "dr-type"}}), "dr-type")
+
+    def test_no_altnames_returns_prop_name(self):
+        self.assertEqual(json_wire_name("regular", {"type": "string"}), "regular")
+
+    def test_non_dict_schema(self):
+        self.assertEqual(json_wire_name("p", "string"), "p")
+
+    def test_other_purpose_ignored(self):
+        self.assertEqual(json_wire_name("d", {"altnames": {"sql": "d-x"}}), "d")
+
+
+class TestStructureAltnamesWire(unittest.TestCase):
+    """Each generator must map identifier members to hyphenated wire keys."""
+
+    def test_python_dataclasses_json(self):
+        out = _out("py")
+        convert_structure_schema_to_python(SCHEMA, out, dataclasses_json_annotation=True)
+        c = _read_all(out)
+        self.assertIn('field_name="dr-type"', c)
+        self.assertIn('field_name="tlp-requestid"', c)
+        self.assertIn("dr_type", c)
+        self.assertIn('field_name="regular"', c)
+
+    def test_csharp_system_text_and_newtonsoft(self):
+        out = _out("cs")
+        convert_structure_schema_to_csharp(
+            SCHEMA, out, base_namespace="Tel",
+            system_text_json_annotation=True, newtonsoft_json_annotation=True)
+        c = _read_all(out)
+        self.assertIn('JsonPropertyName("dr-type")', c)
+        self.assertIn('JsonProperty("tlp-requestid")', c)
+
+    def test_java_jackson(self):
+        out = _out("java")
+        convert_structure_schema_to_java(SCHEMA, out, jackson_annotation=True)
+        c = _read_all(out)
+        self.assertIn('@JsonProperty("dr-type")', c)
+        self.assertIn('@JsonProperty("signal-groupid")', c)
+
+    def test_typescript_typedjson(self):
+        out = _out("ts")
+        convert_structure_schema_to_typescript(SCHEMA, out, typedjson_annotation=True)
+        c = _read_all(out)
+        self.assertIn("name: 'dr-type'", c)
+        self.assertIn("name: 'tlp-requestid'", c)
+
+    def test_go_json_tags(self):
+        out = _out("go")
+        convert_structure_schema_to_go(SCHEMA, out, json_annotation=True)
+        c = _read_all(out)
+        self.assertIn('json:"dr-type', c)
+        self.assertIn('json:"signal-groupid', c)
+
+    def test_rust_serde_rename(self):
+        out = _out("rust")
+        convert_structure_schema_to_rust(SCHEMA, out, serde_annotation=True)
+        c = _read_all(out)
+        self.assertIn('rename = "dr-type"', c)
+        self.assertIn('rename = "tlp-requestid"', c)
+
+    def test_cpp_json_keys(self):
+        out = _out("cpp")
+        convert_structure_schema_to_cpp(SCHEMA, out, namespace="tel", json_annotation=True)
+        c = _read_all(out)
+        self.assertIn('"dr-type"', c)
+        self.assertIn('"tlp-requestid"', c)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Honors JSON Structure `altnames.json` for JSON wire serialization across all structure-to-language **direct** generators, so a spec-valid identifier property (`dr_type`) and a verbatim hyphenated wire key (`dr-type`) can coexist. Fixes #384.

JSON Structure Core requires property keys to be identifiers (`^[A-Za-z_][A-Za-z0-9_]*$`). Non-identifier wire keys are modeled as an identifier carrying `altnames: {"json": "dr-type"}`. Previously the generators only emitted a wire-name annotation when sanitization changed the identifier; `altnames.json` was ignored, so `dr_type` serialized `dr_type` instead of `dr-type`.

## Behavior
- Wire key = `altnames.json` when present, else the property name.
- A rename annotation is emitted whenever the wire key differs from the language member identifier (no longer gated on sanitization), so identifier + altnames disagreement is always honored.
- `altnames` purposes other than `json` are ignored for wire (per spec).

## Generators fixed (s2*)
| Lang | Mechanism |
|------|-----------|
| Python | `dataclasses_json.config(field_name="dr-type")` |
| C# | `JsonPropertyName` / Newtonsoft `JsonProperty` |
| Java | `@JsonProperty("dr-type")` |
| TypeScript | `@jsonMember(T, { name: 'dr-type' })` (template previously dropped renames) |
| Go | `json:"dr-type"` |
| Rust | `#[serde(rename = "dr-type")]` |
| C++ | nlohmann to/from_json now emitted for any renamed field |

Shared `json_wire_name()` helper added to `common.py`. Scope is the structure->language direct paths only; Avro/Kusto/SQL out of scope.

## Tests
New `test/test_structure_altnames.py` (11 tests) asserts hyphenated wire keys per language + fixture `test/jsons/altnames-wire.struct.json`. Full regression: python 25, C# 24, java/rust/cpp/ts/go 54, codegen_flags 23+78 subtests — all pass.