### PR TITLE
Fix s2a/s2k non-identifier name sanitization (#382, #383, #385)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 All notable changes to Avrotize are documented in this file.
 
+## [3.6.1] - 2026-06-29
+
+### Fixed
+
+- **`s2a` now sanitizes non-identifier property and enum names (issues #382,
+  #383, #385)**: JSON Structure permits property keys and enum values that are
+  not valid Avro names (e.g. `dr-type`, `kar.id`, `1`, `N/A`, `KAR-MQTT`).
+  Previously `s2a` emitted these verbatim, producing schemas that violate the
+  Avro name grammar `[A-Za-z_][A-Za-z0-9_]*` — enum symbols were rejected even by
+  the reference `avro.schema.parse`, and hyphenated field names are rejected by
+  strict consumers (Java, Confluent Schema Registry). Property keys are now
+  sanitized to valid Avro field names with the original key preserved as an Avro
+  `aliases` entry; enum values are sanitized to valid symbols with collisions
+  resolved by numeric suffix and the original wire values preserved in the enum
+  `doc`. Tagged-union discriminator enums are sanitized the same way.
+- **`s2k` now quotes non-identifier column names and JSONPaths (issue #382)**:
+  Kusto column definitions and ingestion-mapping JSONPaths for non-identifier
+  property keys are now bracket/quote-escaped (`['dr-type']`, `$['dr-type']`)
+  instead of the previously invalid bare forms (`[dr-type]`, `$.dr-type`). Plain
+  identifier columns are unchanged.
+
 ## [3.6.0] - 2026-06-29
 
 ### Added

--- a/avrotize/jstructtoavro.py
+++ b/avrotize/jstructtoavro.py
@@ -8,7 +8,7 @@ This is the reverse operation of avrotojstruct.py.
 import json
 from typing import Any, Dict, List, Union, Optional
 
-from avrotize.common import ANY_VALUE_RECORD, any_value_name, deduplicate_any_value_record, generic_type
+from avrotize.common import ANY_VALUE_RECORD, any_value_name, deduplicate_any_value_record, generic_type, avro_name, avro_name_with_altname
 
 
 class JsonStructureToAvro:
@@ -388,10 +388,16 @@ class JsonStructureToAvro:
         
         fields = []
         for prop_name, prop_schema in properties.items():
+            # Property keys may be non-identifiers (e.g. "dr-type", "1"). Avro field
+            # names must match [A-Za-z_][A-Za-z0-9_]*, so sanitize and preserve the
+            # original wire key as an Avro alias for round-trip fidelity (issue #382).
+            avro_field_name, original_name = avro_name_with_altname(prop_name)
             field = {
-                'name': prop_name,
-                'type': self._convert_type_reference(prop_schema, name_hint=prop_name)
+                'name': avro_field_name,
+                'type': self._convert_type_reference(prop_schema, name_hint=avro_field_name)
             }
+            if original_name is not None:
+                field['aliases'] = [original_name]
             
             # Build documentation with annotations
             doc = self._build_doc_with_annotations(
@@ -418,22 +424,61 @@ class JsonStructureToAvro:
         avro_record['fields'] = fields
         return avro_record
     
+    def _sanitize_enum_symbols(self, symbols: List[Any]) -> tuple:
+        """
+        Sanitize JSON Structure enum values into valid Avro enum symbols.
+
+        Avro enum symbols must match [A-Za-z_][A-Za-z0-9_]* and be unique. JSON
+        Structure enum values may be arbitrary (e.g. "N/A", "KAR-MQTT", 1). This
+        sanitizes each value, resolves collisions with a numeric suffix, and returns
+        both the symbol list and a mapping of sanitized-symbol -> original-value for
+        any symbol that was changed (issue #383).
+
+        Returns:
+            tuple: (avro_symbols, symbol_mapping)
+        """
+        avro_symbols: List[str] = []
+        symbol_mapping: Dict[str, Any] = {}
+        seen = set()
+        for value in symbols:
+            base = avro_name(str(value))
+            candidate = base
+            suffix = 1
+            while candidate in seen:
+                candidate = f"{base}_{suffix}"
+                suffix += 1
+            seen.add(candidate)
+            avro_symbols.append(candidate)
+            if candidate != str(value):
+                symbol_mapping[candidate] = value
+        return avro_symbols, symbol_mapping
+
     def _convert_enum(self, schema: Dict[str, Any], namespace: Optional[str], name: str) -> Dict[str, Any]:
         """Convert JSON Structure enum to Avro enum."""
+        avro_symbols, symbol_mapping = self._sanitize_enum_symbols(schema['enum'])
         avro_enum: Dict[str, Any] = {
             'type': 'enum',
             'name': name,
-            'symbols': schema['enum']
+            'symbols': avro_symbols
         }
         
         if namespace:
             avro_enum['namespace'] = namespace
         
+        doc_parts = []
         if 'description' in schema:
-            avro_enum['doc'] = schema['description']
+            doc_parts.append(schema['description'])
+        if symbol_mapping:
+            doc_parts.append(
+                'Original enum values (Avro symbol -> wire value): '
+                + json.dumps(symbol_mapping))
+        if doc_parts:
+            avro_enum['doc'] = ' '.join(doc_parts)
         
         if 'default' in schema:
-            avro_enum['default'] = schema['default']
+            original_values = list(schema['enum'])
+            if schema['default'] in original_values:
+                avro_enum['default'] = avro_symbols[original_values.index(schema['default'])]
         
         return avro_enum
     
@@ -531,11 +576,12 @@ class JsonStructureToAvro:
             # Build enum type for discriminator
             enum_name = f'{name}Type'
             choice_names = list(choices.keys())
+            discriminator_symbols, _ = self._sanitize_enum_symbols(choice_names)
             
             discriminator_enum: Dict[str, Any] = {
                 'type': 'enum',
                 'name': enum_name,
-                'symbols': choice_names
+                'symbols': discriminator_symbols
             }
             
             if namespace:

--- a/avrotize/structuretokusto.py
+++ b/avrotize/structuretokusto.py
@@ -1,10 +1,39 @@
 """Converts a JSON Structure schema to a Kusto table schema."""
 
 import json
+import re
 import sys
 from typing import Any, List, Optional, Dict, Union
 from avrotize.common import build_flat_type_dict, inline_avro_references, strip_first_doc
 from azure.kusto.data import KustoClient, KustoConnectionStringBuilder, ClientRequestProperties
+
+
+_KUSTO_BARE_IDENTIFIER = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
+
+
+def kusto_column_name(name: str) -> str:
+    """Return a Kusto-quoted column identifier.
+
+    Bare identifiers ([A-Za-z_][A-Za-z0-9_]*) are wrapped as [name]; any other
+    name (e.g. "dr-type") is quoted as ['name'] so hyphens and other characters
+    are valid (issue #382).
+    """
+    if _KUSTO_BARE_IDENTIFIER.match(name):
+        return f"[{name}]"
+    escaped = name.replace('\\', '\\\\').replace("'", "\\'")
+    return f"['{escaped}']"
+
+
+def kusto_json_path(name: str, prefix: str = "$") -> str:
+    """Return a JSONPath expression for an ingestion-mapping property name.
+
+    Bare identifiers use dotted notation (``$.name``); any other name uses
+    bracket notation (``$['dr-type']``) so non-identifier keys are valid.
+    """
+    if _KUSTO_BARE_IDENTIFIER.match(name):
+        return f"{prefix}.{name}"
+    escaped = name.replace('\\', '\\\\').replace("'", "\\'")
+    return f"{prefix}['{escaped}']"
 
 
 def kusto_string_literal(value: str) -> str:
@@ -268,7 +297,7 @@ class StructureToKusto:
             if isinstance(prop_schema, dict) and 'const' in prop_schema:
                 continue
             column_type = self.convert_structure_type_to_kusto_type(prop_schema, schema_doc)
-            columns.append(f"   [{column_name}]: {column_type}")
+            columns.append(f"   {kusto_column_name(column_name)}: {column_type}")
         if emit_cloudevents_columns:
             columns.append("   [___type]: string")
             columns.append("   [___source]: string")
@@ -365,7 +394,7 @@ class StructureToKusto:
                 continue
             column_name = prop_name
             mapping_entries.append(
-                f"  {{\"column\": \"{column_name}\", \"path\": \"$.{prop_name}\"}}")
+                f"  {{\"column\": \"{column_name}\", \"path\": \"{kusto_json_path(prop_name)}\"}}")
         kusto.append("```\n[\n" + ",\n".join(mapping_entries) + "\n]\n```\n\n")
 
         if emit_cloudevents_columns:
@@ -383,7 +412,7 @@ class StructureToKusto:
                     continue
                 column_name = prop_name
                 ce_entries.append(
-                    f"  {{\"column\": \"{column_name}\", \"path\": \"$.data.{prop_name}\"}}")
+                    f"  {{\"column\": \"{column_name}\", \"path\": \"{kusto_json_path(prop_name, '$.data')}\"}}")
             kusto.append("```\n[\n" + ",\n".join(ce_entries) + "\n]\n```\n\n")
 
         if emit_cloudevents_columns:

--- a/test/test_jstructtoavro.py
+++ b/test/test_jstructtoavro.py
@@ -1231,5 +1231,141 @@ class TestInlineObjectConversion(unittest.TestCase):
                 self._assert_no_bare_object_type(result)
 
 
+class TestNameSanitization(unittest.TestCase):
+    """Issues #382 / #383: sanitize non-identifier property and enum-symbol names."""
+
+    def setUp(self):
+        self.converter = JsonStructureToAvro()
+
+    @staticmethod
+    def _assert_parses_strict(schema):
+        """Parse with the reference avro lib (strict on enum symbols) and fastavro."""
+        import avro.schema as avro_schema
+        from fastavro.schema import parse_schema
+        import copy
+        avro_schema.parse(json.dumps(schema))
+        parse_schema(copy.deepcopy(schema))
+
+    def test_hyphenated_field_names_get_sanitized_with_aliases(self):
+        """Property keys like 'dr-type' become valid Avro names with the original as alias."""
+        structure = {
+            "$schema": "https://json-structure.org/meta/core/v0/#",
+            "$id": "https://example.com/repro/382",
+            "name": "Ev",
+            "type": "object",
+            "properties": {
+                "dr-type": {"type": "string"},
+                "kar.id": {"type": "string"},
+            },
+            "required": ["dr-type", "kar.id"],
+        }
+        result = self.converter.convert(structure)
+        self._assert_parses_strict(result)
+        fields = {f['name']: f for f in result['fields']}
+        self.assertIn('dr_type', fields)
+        self.assertIn('kar_id', fields)
+        self.assertEqual(fields['dr_type'].get('aliases'), ['dr-type'])
+        self.assertEqual(fields['kar_id'].get('aliases'), ['kar.id'])
+
+    def test_numeric_field_name_prefixed(self):
+        """A numeric property key like '1' becomes '_1' with the original aliased."""
+        structure = {
+            "$schema": "https://json-structure.org/meta/core/v0/#",
+            "$id": "https://example.com/repro/382num",
+            "name": "Ev",
+            "type": "object",
+            "properties": {"1": {"type": "int32"}},
+            "required": ["1"],
+        }
+        result = self.converter.convert(structure)
+        self._assert_parses_strict(result)
+        field = result['fields'][0]
+        self.assertEqual(field['name'], '_1')
+        self.assertEqual(field.get('aliases'), ['1'])
+
+    def test_clean_field_name_has_no_alias(self):
+        """Identifier property keys are emitted verbatim with no spurious alias."""
+        structure = {
+            "$schema": "https://json-structure.org/meta/core/v0/#",
+            "$id": "https://example.com/repro/clean",
+            "name": "Ev",
+            "type": "object",
+            "properties": {"status": {"type": "string"}},
+            "required": ["status"],
+        }
+        result = self.converter.convert(structure)
+        self._assert_parses_strict(result)
+        field = result['fields'][0]
+        self.assertEqual(field['name'], 'status')
+        self.assertNotIn('aliases', field)
+
+    def _root_enum(self, values, default=None):
+        schema = {
+            "$schema": "https://json-structure.org/meta/extended/v0/#",
+            "$id": "urn:repro:bad-enum",
+            "name": "BadEnum",
+            "$root": "#/definitions/BadEnum",
+            "definitions": {
+                "BadEnum": {"name": "BadEnum", "type": "string", "enum": list(values)}
+            },
+        }
+        if default is not None:
+            schema["definitions"]["BadEnum"]["default"] = default
+        return schema
+
+    def test_root_enum_symbols_sanitized_and_parseable(self):
+        """Issue #383: digit/slash/hyphen enum values become valid, parseable symbols."""
+        result = self.converter.convert(self._root_enum(["1", "2", "N/A", "KAR-MQTT"]))
+        self._assert_parses_strict(result)
+        self.assertEqual(result['type'], 'enum')
+        self.assertEqual(result['symbols'], ['_1', '_2', 'N_A', 'KAR_MQTT'])
+
+    def test_enum_original_values_preserved_in_doc(self):
+        """The original wire values are recoverable from the enum doc mapping."""
+        result = self.converter.convert(self._root_enum(["1", "N/A"]))
+        self.assertIn('doc', result)
+        # The doc embeds a JSON object mapping sanitized symbol -> original value.
+        start = result['doc'].index('{')
+        mapping = json.loads(result['doc'][start:])
+        self.assertEqual(mapping, {"_1": "1", "N_A": "N/A"})
+
+    def test_enum_symbol_collision_uniqueness(self):
+        """Distinct values that sanitize to the same base get unique suffixes."""
+        result = self.converter.convert(self._root_enum(["N/A", "N-A", "N.A"]))
+        self._assert_parses_strict(result)
+        self.assertEqual(result['symbols'], ['N_A', 'N_A_1', 'N_A_2'])
+        self.assertEqual(len(set(result['symbols'])), 3)
+
+    def test_enum_default_maps_to_sanitized_symbol(self):
+        """A non-identifier default value is remapped to its sanitized symbol."""
+        result = self.converter.convert(self._root_enum(["1", "2", "N/A"], default="N/A"))
+        self._assert_parses_strict(result)
+        self.assertEqual(result['default'], 'N_A')
+        self.assertIn(result['default'], result['symbols'])
+
+    def test_sanitized_record_roundtrips_with_fastavro(self):
+        """The sanitized schema is usable end-to-end: write then read a record."""
+        from fastavro import writer, reader
+        from fastavro.schema import parse_schema
+        structure = {
+            "$schema": "https://json-structure.org/meta/core/v0/#",
+            "$id": "https://example.com/repro/rt",
+            "name": "Ev",
+            "type": "object",
+            "properties": {
+                "dr-type": {"type": "string"},
+                "1": {"type": "int32"},
+            },
+            "required": ["dr-type", "1"],
+        }
+        result = self.converter.convert(structure)
+        parsed = parse_schema(result)
+        buf = io.BytesIO()
+        writer(buf, parsed, [{"dr_type": "start", "_1": 7}])
+        buf.seek(0)
+        out = list(reader(buf))
+        self.assertEqual(out, [{"dr_type": "start", "_1": 7}])
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_structuretokusto.py
+++ b/test/test_structuretokusto.py
@@ -252,6 +252,48 @@ def test_convert_structure_with_wrapped_nullable_types_to_kusto():
     assert "_cloudevents_dispatch | where (specversion == '1.0' and type == 'WrappedTypes')" in kql
 
 
+def test_convert_structure_with_non_identifier_names_to_kusto():
+    """Issue #382: non-identifier property keys must be bracket/quote-escaped."""
+    schema = {
+        "$schema": "https://json-structure.org/meta/extended/v0/#",
+        "$id": "https://example.com/test/non-identifier-names",
+        "type": "object",
+        "name": "Ev",
+        "properties": {
+            "dr-type": {"type": "string"},
+            "1": {"type": "int32"},
+            "status": {"type": "string"},
+        },
+    }
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        struct_path = os.path.join(temp_dir, "non-identifier.struct.json")
+        kql_path = os.path.join(temp_dir, "non-identifier.kql")
+        with open(struct_path, "w", encoding="utf-8") as struct_file:
+            json.dump(schema, struct_file)
+        convert_structure_to_kusto_file(struct_path, "Ev", kql_path, True, True)
+        with open(kql_path, "r", encoding="utf-8") as kql_file:
+            kql = kql_file.read()
+
+    # Non-identifier columns are quoted; clean identifiers keep the bare form.
+    assert "['dr-type']: string" in kql
+    assert "['1']: int" in kql
+    assert "[status]: string" in kql
+    # Ingestion-mapping JSONPaths use bracket notation for non-identifier keys.
+    assert '"path": "$[\'dr-type\']"' in kql
+    assert '"path": "$[\'1\']"' in kql
+    assert '"path": "$.status"' in kql
+    # The mapping column values stay the plain (unbracketed) column names.
+    assert '"column": "dr-type"' in kql
+    # CloudEvents structured mapping also bracket-escapes under $.data.
+    assert '"path": "$.data[\'dr-type\']"' in kql
+    # All fenced JSON blocks must remain valid JSON.
+    blocks = re.findall(r'```\n(.*?)\n```', kql, re.DOTALL)
+    assert len(blocks) > 0
+    for block in blocks:
+        json.loads(block.strip())
+
+
 def convert_case(file_base_name: str, emit_cloudevents_columns, emit_cloudevents_dispatch_table):
     """Convert a JSON Structure schema to Kusto query language"""
     cwd = os.getcwd()


### PR DESCRIPTION
## Summary

Fixes the s2a/s2k name-sanitization bug cluster: JSON Structure permits property
keys and enum values that are **not** valid Avro names or bare Kusto identifiers
(e.g. `dr-type`, `kar.id`, `1`, `N/A`, `KAR-MQTT`). Both converters previously
emitted these verbatim, producing invalid output.

Closes #382
Closes #383
Closes #385 (duplicate of #383)

## s2a (`jstructtoavro.py`)

- **Property keys** are sanitized to valid Avro field names via the existing
  `avro_name` sanitizer, with the original wire key preserved as an Avro
  `aliases` entry for round-trip fidelity (e.g. `dr-type` → `dr_type`
  `aliases: ["dr-type"]`).
- **Enum values** are sanitized to valid symbols with collisions resolved by a
  numeric suffix (`N/A`, `N-A` → `N_A`, `N_A_1`); the original wire values are
  preserved in the enum `doc`. Enum symbols previously failed even the reference
  `avro.schema.parse`.
- **Tagged-union discriminator** enum symbols are sanitized the same way.
- Enum `default` is remapped to the corresponding sanitized symbol.

## s2k (`structuretokusto.py`)

- Column definitions and ingestion-mapping JSONPaths for non-identifier keys are
  now bracket/quote-escaped (`['dr-type']`, `$['dr-type']`, `$.data['dr-type']`)
  instead of the invalid bare forms. Plain identifiers are unchanged, so existing
  `-ref.kql` fixtures are byte-identical.

## Tests

- `TestNameSanitization` (8 cases): hyphen/dot/numeric field sanitization +
  aliases, clean-name no-alias, enum symbol sanitization + parse (strict `avro`
  **and** `fastavro`), collision uniqueness, default remap, doc mapping, and a
  full fastavro write/read round-trip on the sanitized schema.
- s2k non-identifier quoting test (columns, both JSON mappings, valid-JSON blocks).
- Full s2a + s2k suites: **65 passed**; adjacent round-trip/reference suites:
  **29 passed**. No regressions.
