### PR TITLE
Fix Go/Python emitters and add C# --target-framework (#401, #402, #403)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,28 @@ All notable changes to Avrotize are documented in this file.
 - Both converters accept an optional `--module` flag to override the ASN.1 module name
   (otherwise derived from the output file name), and both emit `DEFINITIONS AUTOMATIC TAGS`
   modules that are validated by round-tripping through the `asn1tools` compiler.
+- **`a2cs` / `s2cs` — `--target-framework` for generated C# projects** (#403): the C#
+  converters now accept `--target-framework` (Python `target_framework=`) to set the
+  `<TargetFramework>` written into the generated `.csproj`. A `;`-separated value (e.g.
+  `net8.0;net10.0`) emits `<TargetFrameworks>` for multi-targeting. When omitted, the
+  generated projects continue to target `net10.0` as before.
+
+### Fixed
+
+- **Go emitter now produces `gofmt`-clean, idiomatic Go** (#401): `a2go`/`s2go` previously
+  emitted space-indented code, unsorted imports, unaligned struct/`const` blocks, missing
+  blank lines, no trailing newline, and — most notably — struct tags glued together without
+  a separating space (`` `json:"x"avro:"x"` ``), which `gofmt` cannot repair because it lives
+  inside a raw string literal. The tag spacing is now fixed in the templates (`` `json:"x"
+  avro:"x"` ``) and every emitted file is run through `gofmt` as a final step (best-effort;
+  skipped cleanly when the Go toolchain is absent). The Go package name derived from the
+  input file name is also sanitized to a valid identifier, so the canonical `.struct.json`
+  extension no longer yields an un-compilable `package foo.struct` clause.
+- **Python `to_byte_array("application/json")` returns `bytes`** (#402): the dataclasses-json
+  serialization path returned the `str` from `to_json()` for plain `application/json`
+  (encoding to `bytes` only happened on the `+gzip` branch), violating the method's `-> bytes`
+  contract and breaking `from_data` round-tripping and gzip. `a2py` and `s2py` now encode the
+  JSON payload to UTF-8 `bytes` in the `application/json` branch.
 
 ## [3.7.4] - 2026-07-09
 

--- a/README.md
+++ b/README.md
@@ -1480,7 +1480,7 @@ Conversion notes:
 ### Convert Avrotize Schema to C# classes
 
 ```bash
-avrotize a2cs <path_to_avro_schema_file> [--out <path_to_csharp_dir>] [--namespace <csharp_namespace>] [--avro-annotation] [--system_text_json_annotation] [--newtonsoft-json-annotation] [--pascal-properties]
+avrotize a2cs <path_to_avro_schema_file> [--out <path_to_csharp_dir>] [--namespace <csharp_namespace>] [--avro-annotation] [--system_text_json_annotation] [--newtonsoft-json-annotation] [--pascal-properties] [--target-framework <tfm>]
 ```
 
 Parameters:
@@ -1492,6 +1492,7 @@ Parameters:
 - `--system_text_json_annotation`: (optional) Use System.Text.Json annotations.
 - `--newtonsoft-json-annotation`: (optional) Use Newtonsoft.Json annotations.
 - `--pascal-properties`: (optional) Use PascalCase properties.
+- `--target-framework`: (optional) Target framework(s) for the generated `.csproj` (e.g. `net8.0`, or `net8.0;net10.0` for multi-targeting). Defaults to `net10.0`.
 
 Conversion notes:
 

--- a/avrotize/avrotocsharp.py
+++ b/avrotize/avrotocsharp.py
@@ -58,6 +58,7 @@ class AvroToCSharp:
         self.avro_annotation = False
         self.protobuf_net_annotation = False
         self.openapi_generator_compat = False
+        self.target_framework = ''
         self.generated_types: Dict[str,str] = {}
         self.generated_avro_types: Dict[str, Dict[str, Union[str, Dict, List]]] = {}
         self.type_dict: Dict[str, Dict] = {}
@@ -1189,6 +1190,7 @@ class AvroToCSharp:
                     file.write(process_template(
                         "avrotocsharp/project.csproj.jinja",
                         project_name=project_name, 
+                        target_framework=self.target_framework,
                         avro_annotation=self.avro_annotation,
                         system_xml_annotation=self.system_xml_annotation,
                         system_text_json_annotation=self.system_text_json_annotation,
@@ -1216,6 +1218,7 @@ class AvroToCSharp:
                     file.write(process_template(
                         "avrotocsharp/testproject.csproj.jinja", 
                         project_name=project_name,
+                        target_framework=self.target_framework,
                         avro_annotation=self.avro_annotation,
                         system_xml_annotation=self.system_xml_annotation,
                         system_text_json_annotation=self.system_text_json_annotation,
@@ -1279,7 +1282,8 @@ def convert_avro_to_csharp(
     cbor_annotation=False,
     avro_annotation=False,
     protobuf_net_annotation=False,
-    openapi_generator_compat=False
+    openapi_generator_compat=False,
+    target_framework=''
 ):
     """Converts Avro schema to C# classes
 
@@ -1297,6 +1301,7 @@ def convert_avro_to_csharp(
         avro_annotation (bool, optional): Use Avro annotations. Defaults to False.
         protobuf_net_annotation (bool, optional): Use protobuf-net annotations. Defaults to False.
         openapi_generator_compat (bool, optional): Generate OpenAPI Generator-compatible C# models. Defaults to False.
+        target_framework (str, optional): Target framework moniker written into the generated .csproj (e.g. 'net8.0'). A ';'-separated value emits <TargetFrameworks> for multi-targeting. Defaults to '' (net10.0).
     """
 
     if not base_namespace:
@@ -1312,6 +1317,7 @@ def convert_avro_to_csharp(
     avrotocs.avro_annotation = avro_annotation
     avrotocs.protobuf_net_annotation = protobuf_net_annotation
     avrotocs.openapi_generator_compat = openapi_generator_compat
+    avrotocs.target_framework = target_framework
     avrotocs.convert(avro_schema_path, cs_file_path)
 
 
@@ -1328,7 +1334,8 @@ def convert_avro_schema_to_csharp(
     cbor_annotation: bool = False,
     avro_annotation: bool = False,
     protobuf_net_annotation: bool = False,
-    openapi_generator_compat: bool = False
+    openapi_generator_compat: bool = False,
+    target_framework: str = ''
 ):
     """Converts Avro schema to C# classes
 
@@ -1345,6 +1352,7 @@ def convert_avro_schema_to_csharp(
         cbor_annotation (bool, optional): Use Dahomey.Cbor annotations. Defaults to False.
         avro_annotation (bool, optional): Use Avro annotations. Defaults to False.
         protobuf_net_annotation (bool, optional): Use protobuf-net annotations. Defaults to False.
+        target_framework (str, optional): Target framework moniker written into the generated .csproj (e.g. 'net8.0'). A ';'-separated value emits <TargetFrameworks> for multi-targeting. Defaults to '' (net10.0).
     """
     avrotocs = AvroToCSharp(base_namespace)
     avrotocs.project_name = project_name
@@ -1357,4 +1365,5 @@ def convert_avro_schema_to_csharp(
     avrotocs.avro_annotation = avro_annotation
     avrotocs.protobuf_net_annotation = protobuf_net_annotation
     avrotocs.openapi_generator_compat = openapi_generator_compat
+    avrotocs.target_framework = target_framework
     avrotocs.convert_schema(avro_schema, output_dir)

--- a/avrotize/avrotocsharp/project.csproj.jinja
+++ b/avrotize/avrotocsharp/project.csproj.jinja
@@ -1,6 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
+        {%- if target_framework and ';' in target_framework %}
+        <TargetFrameworks>{{ target_framework }}</TargetFrameworks>
+        {%- elif target_framework %}
+        <TargetFramework>{{ target_framework }}</TargetFramework>
+        {%- else %}
         <TargetFramework>net10.0</TargetFramework>
+        {%- endif %}
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>

--- a/avrotize/avrotocsharp/testproject.csproj.jinja
+++ b/avrotize/avrotocsharp/testproject.csproj.jinja
@@ -1,6 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
+        {%- if target_framework and ';' in target_framework %}
+        <TargetFrameworks>{{ target_framework }}</TargetFrameworks>
+        {%- elif target_framework %}
+        <TargetFramework>{{ target_framework }}</TargetFramework>
+        {%- else %}
         <TargetFramework>net10.0</TargetFramework>
+        {%- endif %}
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>

--- a/avrotize/avrotogo.py
+++ b/avrotize/avrotogo.py
@@ -1,7 +1,7 @@
 import json
 import os
 from typing import Dict, List, Union, Set
-from avrotize.common import get_longest_namespace_prefix, is_generic_avro_type, is_any_value_type, pascal, render_template
+from avrotize.common import get_longest_namespace_prefix, is_generic_avro_type, is_any_value_type, pascal, render_template, format_go_files
 
 INDENT = '    '
 
@@ -33,10 +33,19 @@ class AvroToGo:
         self.enums = []
 
     def _safe_package_name(self, name: str) -> str:
-        """Converts a name to a safe Go package name"""
-        if name in self.GO_RESERVED_WORDS:
-            return f"{name}_"
-        return name
+        """Converts a name to a safe Go package name (a valid lowercase identifier).
+
+        Sanitizes any character that is not valid in a Go identifier (dots,
+        hyphens from file names, etc.) to underscores so the emitted ``package``
+        clause is compilable and gofmt-parseable.
+        """
+        import re
+        safe = re.sub(r'[^a-zA-Z0-9_]+', '_', name).strip('_').lower()
+        if not safe or not re.match(r'^[a-z]', safe):
+            safe = f"pkg_{safe}" if safe else "pkg"
+        if safe in self.GO_RESERVED_WORDS:
+            return f"{safe}_"
+        return safe
 
     def safe_identifier(self, name: str) -> str:
         """Converts a name to a safe Go identifier"""
@@ -418,6 +427,7 @@ class AvroToGo:
         self.write_go_mod_file()
         self.write_modname_go_file()
         self.generate_helpers()
+        format_go_files(self.output_dir)
 
     def write_go_mod_file(self):
         """Writes the go.mod file for the Go project"""

--- a/avrotize/avrotogo/go_struct.jinja
+++ b/avrotize/avrotogo/go_struct.jinja
@@ -27,7 +27,7 @@ import (
 {%- endif %}
 type {{ struct_name }} struct {
     {%- for field in fields %}
-    {{ field.name }} {{ field.type }}{% if json_annotation or avro_annotation %} `{%- if json_annotation -%}json:"{{ field.original_name }}"{%- endif %}{%- if avro_annotation -%} avro:"{{ field.original_name }}"{%- endif -%}`{% endif %}
+    {{ field.name }} {{ field.type }}{% if json_annotation or avro_annotation %} `{% if json_annotation %}json:"{{ field.original_name }}"{% endif %}{% if json_annotation and avro_annotation %} {% endif %}{% if avro_annotation %}avro:"{{ field.original_name }}"{% endif %}`{% endif %}
     {%- endfor %}
 }
 

--- a/avrotize/avrotopython/dataclass_core.jinja
+++ b/avrotize/avrotopython/dataclass_core.jinja
@@ -159,6 +159,8 @@ class {{ class_name }}:
             #pylint: disable=no-member
             result = self.to_json()
             #pylint: enable=no-member
+            if isinstance(result, str):
+                result = result.encode('utf-8')
         {%- endif %}
 
         if result is not None and content_type.endswith('+gzip'):

--- a/avrotize/commands.json
+++ b/avrotize/commands.json
@@ -2666,7 +2666,8 @@
         "cbor_annotation": "args.cbor_annotation",
         "pascal_properties": "args.pascal_properties",
         "base_namespace": "args.namespace",
-        "openapi_generator_compat": "args.openapi_generator_compat"
+        "openapi_generator_compat": "args.openapi_generator_compat",
+        "target_framework": "args.target_framework"
       }
     },
     "extensions": [
@@ -2760,6 +2761,12 @@
         "help": "Generate OpenAPI Generator-compatible C# models with Option<T> optional properties and System.Text.Json converters",
         "default": false,
         "required": false
+      },
+      {
+        "name": "--target-framework",
+        "type": "str",
+        "help": "Target framework moniker written into the generated .csproj (e.g. net8.0). A ';'-separated value emits <TargetFrameworks> for multi-targeting. Defaults to net10.0.",
+        "required": false
       }
     ],
     "suggested_output_file_path": "{input_file_name}-cs",
@@ -2810,7 +2817,8 @@
         "pascal_properties": "args.pascal_properties",
         "base_namespace": "args.namespace",
         "project_name": "args.project_name",
-        "openapi_generator_compat": "args.openapi_generator_compat"
+        "openapi_generator_compat": "args.openapi_generator_compat",
+        "target_framework": "args.target_framework"
       }
     },
     "extensions": [
@@ -2889,6 +2897,12 @@
         "type": "bool",
         "help": "Generate OpenAPI Generator-compatible C# models with Option<T> optional properties and System.Text.Json converters",
         "default": false,
+        "required": false
+      },
+      {
+        "name": "--target-framework",
+        "type": "str",
+        "help": "Target framework moniker written into the generated .csproj (e.g. net8.0). A ';'-separated value emits <TargetFrameworks> for multi-targeting. Defaults to net10.0.",
         "required": false
       }
     ],

--- a/avrotize/common.py
+++ b/avrotize/common.py
@@ -940,6 +940,47 @@ def render_template(template: str, output: str, **kvargs):
         f.write(out)
 
 
+def format_go_files(directory: str) -> bool:
+    """Run ``gofmt`` over every ``.go`` file under ``directory`` to produce
+    canonical, gofmt-clean output.
+
+    This normalizes indentation (tabs), sorts imports, aligns struct fields and
+    ``const`` blocks, fixes blank-line placement, and guarantees a trailing
+    newline at EOF -- everything the Go emitters cannot easily express in Jinja
+    templates. Struct-tag spacing is fixed in the templates instead, because
+    ``gofmt`` never rewrites the contents of raw string literals.
+
+    Best-effort: if the Go toolchain is not installed, the generated files are
+    left untouched and ``False`` is returned (the emitter still produced valid,
+    compilable Go).
+
+    Args:
+        directory (str): Directory containing generated ``.go`` files. ``gofmt``
+            processes it recursively.
+
+    Returns:
+        bool: ``True`` if ``gofmt`` (or ``go fmt``) ran, ``False`` otherwise.
+    """
+    import shutil
+    import subprocess
+    gofmt = shutil.which('gofmt')
+    try:
+        if gofmt:
+            subprocess.run(
+                [gofmt, '-w', directory], check=False,
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            return True
+        go = shutil.which('go')
+        if go:
+            subprocess.run(
+                [go, 'fmt', './...'], cwd=directory, check=False,
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            return True
+    except OSError:
+        return False
+    return False
+
+
 def get_longest_namespace_prefix(schema):
     """ Get the longest common prefix for the namespace of all types in the schema. """
     namespaces = set(collect_namespaces(schema))

--- a/avrotize/structuretocsharp.py
+++ b/avrotize/structuretocsharp.py
@@ -50,6 +50,7 @@ class StructureToCSharp:
         self.discriminator_properties: Dict[str, str] = {}  # Maps type ref -> discriminator property name (for inline unions)
         self.openapi_generator_compat = False
         self.emitted_option_namespaces: set[str] = set()
+        self.target_framework = ''
 
     def get_qualified_name(self, namespace: str, name: str) -> str:
         """ Concatenates namespace and name with a dot separator """
@@ -1802,6 +1803,7 @@ class StructureToCSharp:
                     file.write(process_template(
                         "structuretocsharp/project.csproj.jinja",
                         project_name=project_name, 
+                        target_framework=self.target_framework,
                         system_xml_annotation=self.system_xml_annotation,
                         # Avro annotation requires System.Text.Json for intermediate conversions
                         system_text_json_annotation=self.system_text_json_annotation or self.avro_annotation,
@@ -1825,6 +1827,7 @@ class StructureToCSharp:
                     file.write(process_template(
                         "structuretocsharp/testproject.csproj.jinja", 
                         project_name=project_name,
+                        target_framework=self.target_framework,
                         system_xml_annotation=self.system_xml_annotation,
                         system_text_json_annotation=self.system_text_json_annotation,
                         newtonsoft_json_annotation=self.newtonsoft_json_annotation,
@@ -2511,7 +2514,8 @@ def convert_structure_to_csharp(
     newtonsoft_json_annotation: bool = False, 
     system_xml_annotation: bool = False,
     avro_annotation: bool = False,
-    openapi_generator_compat: bool = False
+    openapi_generator_compat: bool = False,
+    target_framework: str = ''
 ):
     """Converts JSON Structure schema to C# classes
 
@@ -2526,6 +2530,7 @@ def convert_structure_to_csharp(
         system_xml_annotation (bool, optional): Use System.Xml.Serialization annotations. Defaults to False.
         avro_annotation (bool, optional): Use Avro annotations. Defaults to False.
         openapi_generator_compat (bool, optional): Generate OpenAPI Generator-compatible C# models. Defaults to False.
+        target_framework (str, optional): Target framework moniker written into the generated .csproj. A ';'-separated value emits <TargetFrameworks>. Defaults to '' (net10.0).
     """
 
     if not base_namespace:
@@ -2539,6 +2544,7 @@ def convert_structure_to_csharp(
     structtocs.system_xml_annotation = system_xml_annotation
     structtocs.avro_annotation = avro_annotation
     structtocs.openapi_generator_compat = openapi_generator_compat
+    structtocs.target_framework = target_framework
     structtocs.convert(structure_schema_path, cs_file_path)
 
 
@@ -2552,7 +2558,8 @@ def convert_structure_schema_to_csharp(
     newtonsoft_json_annotation: bool = False, 
     system_xml_annotation: bool = False,
     avro_annotation: bool = False,
-    openapi_generator_compat: bool = False
+    openapi_generator_compat: bool = False,
+    target_framework: str = ''
 ):
     """Converts JSON Structure schema to C# classes
 
@@ -2566,6 +2573,7 @@ def convert_structure_schema_to_csharp(
         newtonsoft_json_annotation (bool, optional): Use Newtonsoft.Json annotations. Defaults to False.
         system_xml_annotation (bool, optional): Use System.Xml.Serialization annotations. Defaults to False.
         avro_annotation (bool, optional): Use Avro annotations. Defaults to False.
+        target_framework (str, optional): Target framework moniker written into the generated .csproj. A ';'-separated value emits <TargetFrameworks>. Defaults to '' (net10.0).
     """
     structtocs = StructureToCSharp(base_namespace)
     structtocs.project_name = project_name
@@ -2575,4 +2583,5 @@ def convert_structure_schema_to_csharp(
     structtocs.system_xml_annotation = system_xml_annotation
     structtocs.avro_annotation = avro_annotation
     structtocs.openapi_generator_compat = openapi_generator_compat
+    structtocs.target_framework = target_framework
     structtocs.convert_schema(structure_schema, output_dir)

--- a/avrotize/structuretocsharp/project.csproj.jinja
+++ b/avrotize/structuretocsharp/project.csproj.jinja
@@ -1,6 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
+        {%- if target_framework and ';' in target_framework %}
+        <TargetFrameworks>{{ target_framework }}</TargetFrameworks>
+        {%- elif target_framework %}
+        <TargetFramework>{{ target_framework }}</TargetFramework>
+        {%- else %}
         <TargetFramework>net10.0</TargetFramework>
+        {%- endif %}
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>

--- a/avrotize/structuretocsharp/testproject.csproj.jinja
+++ b/avrotize/structuretocsharp/testproject.csproj.jinja
@@ -1,6 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
+        {%- if target_framework and ';' in target_framework %}
+        <TargetFrameworks>{{ target_framework }}</TargetFrameworks>
+        {%- elif target_framework %}
+        <TargetFramework>{{ target_framework }}</TargetFramework>
+        {%- else %}
         <TargetFramework>net10.0</TargetFramework>
+        {%- endif %}
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <OutputType>Exe</OutputType>

--- a/avrotize/structuretogo.py
+++ b/avrotize/structuretogo.py
@@ -6,7 +6,7 @@ import json
 import os
 from typing import Any, Dict, List, Set, Union, Optional, cast
 
-from avrotize.common import pascal, render_template, json_wire_name, json_enum_wire_value
+from avrotize.common import pascal, render_template, json_wire_name, json_enum_wire_value, format_go_files
 
 JsonNode = Dict[str, 'JsonNode'] | List['JsonNode'] | str | None
 
@@ -39,10 +39,19 @@ class StructureToGo:
         self.enums: List[Dict] = []
 
     def _safe_package_name(self, name: str) -> str:
-        """Converts a name to a safe Go package name"""
-        if name in self.GO_RESERVED_WORDS:
-            return f"{name}_"
-        return name
+        """Converts a name to a safe Go package name (a valid lowercase identifier).
+
+        Sanitizes any character that is not valid in a Go identifier (dots from
+        multi-part extensions such as ``.struct``, hyphens, etc.) to underscores
+        so the emitted ``package`` clause is compilable and gofmt-parseable.
+        """
+        import re
+        safe = re.sub(r'[^a-zA-Z0-9_]+', '_', name).strip('_').lower()
+        if not safe or not re.match(r'^[a-z]', safe):
+            safe = f"pkg_{safe}" if safe else "pkg"
+        if safe in self.GO_RESERVED_WORDS:
+            return f"{safe}_"
+        return safe
 
     def safe_identifier(self, name: str, fallback_prefix: str = 'field') -> str:
         """Converts a name to a safe Go identifier.
@@ -709,6 +718,7 @@ class StructureToGo:
         self.write_go_mod_file()
         self.write_modname_go_file()
         self.generate_helpers()
+        format_go_files(self.output_dir)
 
     def convert(self, structure_schema_path: str, output_dir: str):
         """Converts JSON Structure schema to Go"""

--- a/avrotize/structuretogo/go_struct.jinja
+++ b/avrotize/structuretogo/go_struct.jinja
@@ -28,7 +28,7 @@ import (
 type {{ struct_name }} struct {
     {%- for field in fields %}
     {%- set is_json_string = field.source_type in ['int64', 'uint64', 'int128', 'uint128', 'decimal'] %}
-    {{ field.name }} {{ field.type }}{% if json_annotation or avro_annotation %} `{%- if json_annotation -%}json:"{{ field.original_name }}{% if is_json_string %},string{% endif %}"{%- endif -%}{%- if avro_annotation %} avro:"{{ field.original_name }}"{%- endif -%}`{% endif %}
+    {{ field.name }} {{ field.type }}{% if json_annotation or avro_annotation %} `{% if json_annotation %}json:"{{ field.original_name }}{% if is_json_string %},string{% endif %}"{% endif %}{% if json_annotation and avro_annotation %} {% endif %}{% if avro_annotation %}avro:"{{ field.original_name }}"{% endif %}`{% endif %}
     {%- endfor %}
 }
 

--- a/avrotize/structuretopython/dataclass_core.jinja
+++ b/avrotize/structuretopython/dataclass_core.jinja
@@ -276,6 +276,8 @@ class {{ class_name }}{% if base_class or is_abstract %}({% if base_class %}{{ b
             #pylint: disable=no-member
             result = self.to_json()
             #pylint: enable=no-member
+            if isinstance(result, str):
+                result = result.encode('utf-8')
         {%- endif %}
 
         if result is not None and content_type.endswith('+gzip'):

--- a/test/test_avrotocsharp.py
+++ b/test/test_avrotocsharp.py
@@ -51,6 +51,42 @@ class TestAvroToCSharp(unittest.TestCase):
     def test_convert_address_avsc_to_csharp_protobuf_net(self):
         self.run_convert_avsc_to_csharp("address", pascal_properties=True, protobuf_net_annotation=True)
 
+    def test_issue_403_target_framework_written_to_csproj(self):
+        """ Issue #403: --target-framework is written verbatim into the generated
+        .csproj; a ';'-separated value emits <TargetFrameworks> for multi-targeting;
+        the default preserves net10.0. (Fast: inspects .csproj, no dotnet build.) """
+        from avrotize.avrotocsharp import convert_avro_schema_to_csharp
+
+        schema = {
+            "type": "record",
+            "name": "Issue403Record",
+            "namespace": "example.issue403",
+            "fields": [{"name": "id", "type": "string"}],
+        }
+
+        def gen_and_read(tfm, tag):
+            out = os.path.join(tempfile.gettempdir(), "avrotize", "issue-403-cs-" + tag)
+            if os.path.exists(out):
+                shutil.rmtree(out, ignore_errors=True)
+            os.makedirs(out, exist_ok=True)
+            kwargs = {} if tfm is None else {"target_framework": tfm}
+            convert_avro_schema_to_csharp(schema, out, **kwargs)
+            src_dir = os.path.join(out, "src")
+            csprojs = [f for f in os.listdir(src_dir) if f.endswith(".csproj")]
+            assert csprojs, f"no .csproj generated in {src_dir}"
+            with open(os.path.join(src_dir, csprojs[0]), "r", encoding="utf-8") as f:
+                return f.read()
+
+        single = gen_and_read("net8.0", "single")
+        assert "<TargetFramework>net8.0</TargetFramework>" in single
+        assert "net10.0" not in single
+
+        multi = gen_and_read("net8.0;net10.0", "multi")
+        assert "<TargetFrameworks>net8.0;net10.0</TargetFrameworks>" in multi
+
+        default = gen_and_read(None, "default")
+        assert "<TargetFramework>net10.0</TargetFramework>" in default
+
                                         
     def test_convert_enumfield_avsc_to_csharp_annotated(self):
         """ Test converting an enumfield.avsc file to C# """

--- a/test/test_avrotogo.py
+++ b/test/test_avrotogo.py
@@ -84,6 +84,81 @@ class TestAvroToGo(unittest.TestCase):
         
         
 
+    def test_issue_401_gofmt_clean_and_struct_tag_spacing(self):
+        """ Issue #401: the Go emitter must produce gofmt-clean, idiomatic Go.
+
+        Verifies the two things gofmt itself cannot: (a) struct tags are
+        space-separated (`json:"x" avro:"x"`, not `json:"x"avro:"x"`) -- gofmt
+        never rewrites raw string literals -- and (b) the package clause is a
+        valid Go identifier even for dotted/hyphenated inputs. Then, if the Go
+        toolchain is present, asserts `gofmt -l` reports nothing (fully clean:
+        tabs, sorted imports, aligned fields, blank lines, trailing newline). """
+        import re
+        from avrotize.avrotogo import convert_avro_schema_to_go
+
+        schema = [
+            {
+                "type": "record",
+                "name": "BrightnessChangedEventData",
+                "namespace": "example.iss401",
+                "fields": [
+                    {"name": "tenantid", "type": "string"},
+                    {"name": "deviceid", "type": "string"},
+                    {"name": "brightness", "type": "int"},
+                    {"name": "colorTemperature", "type": "int"},
+                ],
+            },
+            {
+                "type": "enum",
+                "name": "SwitchSource",
+                "namespace": "example.iss401",
+                "symbols": ["PhysicalSwitch", "AppSwitch", "VoiceSwitch"],
+            },
+        ]
+        go_path = os.path.join(tempfile.gettempdir(), "avrotize", "issue-401-go")
+        if os.path.exists(go_path):
+            shutil.rmtree(go_path, ignore_errors=True)
+        os.makedirs(go_path, exist_ok=True)
+
+        # Hyphen/dot in package name must be sanitized to a valid Go identifier.
+        convert_avro_schema_to_go(
+            schema, go_path, package_name="brightness-events.data",
+            json_annotation=True, avro_annotation=True)
+
+        go_files = []
+        for root, _dirs, files in os.walk(go_path):
+            for f in files:
+                if f.endswith(".go"):
+                    go_files.append(os.path.join(root, f))
+        assert go_files, "no .go files generated"
+
+        struct_file = None
+        for gf in go_files:
+            with open(gf, "r", encoding="utf-8") as fh:
+                content = fh.read()
+            # (b) package clause is a valid Go identifier (no dot/hyphen).
+            for line in content.splitlines():
+                if line.startswith("package "):
+                    pkg = line[len("package "):].strip()
+                    assert re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", pkg), \
+                        f"invalid Go package name {pkg!r} in {gf}"
+            if 'avro:"' in content:
+                struct_file = content
+
+        # (a) struct tags must be space-separated.
+        assert struct_file is not None, "expected a struct file with avro tags"
+        assert '"avro:' not in struct_file, \
+            'struct tags are glued without a space (json:"x"avro:"x")'
+        assert ' avro:"' in struct_file, "expected space-separated struct tags"
+
+        # If gofmt is available, the whole tree must be gofmt-clean.
+        gofmt = shutil.which("gofmt")
+        if gofmt:
+            result = subprocess.run(
+                [gofmt, "-l", go_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            unformatted = result.stdout.decode().strip()
+            assert unformatted == "", f"gofmt reports unformatted files:\n{unformatted}"
+
     def test_convert_jfrog_pipelines_jsons_to_avro_to_go(self):
         """ Test converting a jfrog-pipelines.json file to go """
         cwd = getcwd()        

--- a/test/test_avrotopython.py
+++ b/test/test_avrotopython.py
@@ -110,6 +110,47 @@ class TestAvroToPython(unittest.TestCase):
         finally:
             sys.path.remove(generated_src)
 
+    def test_issue_402_to_byte_array_application_json_returns_bytes(self):
+        """ Issue #402: to_byte_array('application/json') must return bytes, not str.
+
+        The dataclasses-json branch previously returned the str from to_json()
+        directly for plain 'application/json' (the encode-to-bytes step only ran
+        for the '+gzip' path), violating the '-> bytes' contract and breaking
+        from_data round-tripping and gzip. """
+        import importlib
+        schema = {
+            "type": "record",
+            "name": "Issue402Record",
+            "namespace": "example.issue402",
+            "fields": [
+                {"name": "tenantid", "type": "string"},
+                {"name": "count", "type": "int"},
+            ],
+        }
+        py_path = os.path.join(tempfile.gettempdir(), "avrotize", "issue-402-py-json")
+        if os.path.exists(py_path):
+            shutil.rmtree(py_path, ignore_errors=True)
+        os.makedirs(py_path, exist_ok=True)
+
+        from avrotize.avrotopython import convert_avro_schema_to_python
+        convert_avro_schema_to_python(
+            schema, py_path, package_name="issue_402_json", dataclasses_json_annotation=True)
+
+        generated_src = os.path.join(py_path, "src")
+        sys.path.insert(0, generated_src)
+        try:
+            module = importlib.import_module("issue_402_json.example.issue402")
+            Issue402Record = module.Issue402Record
+            record = Issue402Record(tenantid="acme", count=7)
+
+            payload = record.to_byte_array("application/json")
+            assert isinstance(payload, bytes), f"expected bytes, got {type(payload).__name__}"
+
+            round_tripped = Issue402Record.from_data(payload, "application/json")
+            assert round_tripped == record
+        finally:
+            sys.path.remove(generated_src)
+
     def test_convert_address_avsc_to_python_avro(self):
         """ Test converting an address.avsc file to Python with avro annotation """
         cwd = os.getcwd()

--- a/test/test_structuretocsharp.py
+++ b/test/test_structuretocsharp.py
@@ -25,6 +25,43 @@ sys.path.append(project_root)
 class TestStructureToCSharp(unittest.TestCase):
     """Test cases for JSON Structure to C# conversion"""
 
+    def test_issue_403_target_framework_written_to_csproj(self):
+        """ Issue #403 (parity): s2cs writes --target-framework verbatim into the
+        generated .csproj; a ';'-separated value emits <TargetFrameworks>; the
+        default preserves net10.0. (Fast: inspects .csproj, no dotnet build.) """
+        from avrotize.structuretocsharp import convert_structure_schema_to_csharp
+
+        schema = {
+            "type": "object",
+            "name": "Issue403Struct",
+            "namespace": "example.issue403",
+            "properties": {"id": {"type": "string"}},
+            "required": ["id"],
+        }
+
+        def gen_and_read(tfm, tag):
+            out = os.path.join(tempfile.gettempdir(), "avrotize", "issue-403-s2cs-" + tag)
+            if os.path.exists(out):
+                shutil.rmtree(out, ignore_errors=True)
+            os.makedirs(out, exist_ok=True)
+            kwargs = {} if tfm is None else {"target_framework": tfm}
+            convert_structure_schema_to_csharp(schema, out, **kwargs)
+            src_dir = os.path.join(out, "src")
+            csprojs = [f for f in os.listdir(src_dir) if f.endswith(".csproj")]
+            assert csprojs, f"no .csproj generated in {src_dir}"
+            with open(os.path.join(src_dir, csprojs[0]), "r", encoding="utf-8") as f:
+                return f.read()
+
+        single = gen_and_read("net8.0", "single")
+        assert "<TargetFramework>net8.0</TargetFramework>" in single
+        assert "net10.0" not in single
+
+        multi = gen_and_read("net8.0;net10.0", "multi")
+        assert "<TargetFrameworks>net8.0;net10.0</TargetFrameworks>" in multi
+
+        default = gen_and_read(None, "default")
+        assert "<TargetFramework>net10.0</TargetFramework>" in default
+
     def run_convert_struct_to_csharp(
         self,
         struct_name,

--- a/test/test_structuretogo.py
+++ b/test/test_structuretogo.py
@@ -19,6 +19,67 @@ from avrotize.structuretogo import convert_structure_to_go
 class TestStructureToGo(unittest.TestCase):
     """Test cases for JSON Structure to Go conversion."""
 
+    def test_issue_401_gofmt_clean_and_valid_package(self):
+        """ Issue #401 (parity): s2go must emit gofmt-clean Go with a valid
+        package identifier. The canonical `.struct.json` extension previously
+        produced a package name containing a dot (e.g. `foo.struct`), which is
+        invalid Go and un-parseable by gofmt. Also checks space-separated struct
+        tags. """
+        import re
+        from avrotize.structuretogo import convert_structure_schema_to_go
+
+        schema = {
+            "type": "object",
+            "name": "Issue401Struct",
+            "namespace": "example.iss401",
+            "properties": {
+                "tenantid": {"type": "string"},
+                "deviceid": {"type": "string"},
+                "brightness": {"type": "int32"},
+            },
+            "required": ["tenantid", "deviceid", "brightness"],
+        }
+        go_path = os.path.join(tempfile.gettempdir(), "avrotize", "issue-401-s2go")
+        if os.path.exists(go_path):
+            shutil.rmtree(go_path, ignore_errors=True)
+        os.makedirs(go_path, exist_ok=True)
+
+        # Emulate the canonical dotted extension via a dotted package name.
+        convert_structure_schema_to_go(
+            schema, go_path, package_name="brightness_events.struct",
+            json_annotation=True, avro_annotation=True)
+
+        go_files = []
+        for root, _dirs, files in os.walk(go_path):
+            for f in files:
+                if f.endswith(".go"):
+                    go_files.append(os.path.join(root, f))
+        assert go_files, "no .go files generated"
+
+        struct_file = None
+        for gf in go_files:
+            with open(gf, "r", encoding="utf-8") as fh:
+                content = fh.read()
+            for line in content.splitlines():
+                if line.startswith("package "):
+                    pkg = line[len("package "):].strip()
+                    assert re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", pkg), \
+                        f"invalid Go package name {pkg!r} in {gf}"
+            if 'avro:"' in content:
+                struct_file = content
+
+        assert struct_file is not None, "expected a struct file with avro tags"
+        assert '"avro:' not in struct_file, \
+            'struct tags are glued without a space (json:"x"avro:"x")'
+        assert ' avro:"' in struct_file, "expected space-separated struct tags"
+
+        gofmt = shutil.which("gofmt")
+        if gofmt:
+            result = subprocess.run(
+                [gofmt, "-l", go_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            unformatted = result.stdout.decode().strip()
+            assert unformatted == "", f"gofmt reports unformatted files:\n{unformatted}"
+
     def run_convert_structure_to_go(
         self,
         struct_name,
@@ -127,16 +188,22 @@ class TestStructureToGo(unittest.TestCase):
             print(f"\n{'='*60}")
             print(f"Testing: {struct_name}")
             print('='*60)
-            
+
+            # Mirror the emitter's package-name sanitization (dots from the
+            # .struct.json extension and hyphens become underscores) so the
+            # expected package directory matches the generated one.
+            import re
+            pkg_name = re.sub(r'[^a-zA-Z0-9_]+', '_', struct_name).strip('_').lower()
+
             try:
                 go_path = self.run_convert_structure_to_go(
                     struct_name,
                     json_annotation=True,
-                    package_name=struct_name.lower().replace('-', '_')
+                    package_name=pkg_name
                 )
                 
                 # Verify the generated Go file exists
-                pkg_dir = os.path.join(go_path, "pkg", struct_name.lower().replace('-', '_'))
+                pkg_dir = os.path.join(go_path, "pkg", pkg_name)
                 assert os.path.exists(pkg_dir), f"Package directory not found: {pkg_dir}"
                 
                 # Check that at least one struct or enum file was generated

--- a/test/test_structuretopython.py
+++ b/test/test_structuretopython.py
@@ -477,6 +477,47 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
         
         assert len(py_files) > 0, "No Python files were generated"
 
+    def test_issue_402_to_byte_array_application_json_returns_bytes(self):
+        """ Issue #402 (parity): s2py to_byte_array('application/json') must
+        return bytes, not str. Mirrors the a2py fix for the shared dataclasses
+        core template. """
+        import importlib
+        from avrotize.structuretopython import convert_structure_schema_to_python
+
+        schema = {
+            "type": "object",
+            "name": "Issue402Struct",
+            "namespace": "example.issue402",
+            "properties": {
+                "tenantid": {"type": "string"},
+                "count": {"type": "int32"},
+            },
+            "required": ["tenantid", "count"],
+        }
+        output_dir = os.path.join(tempfile.gettempdir(), "avrotize", "issue-402-s2py-json")
+        if os.path.exists(output_dir):
+            shutil.rmtree(output_dir, ignore_errors=True)
+        os.makedirs(output_dir, exist_ok=True)
+
+        convert_structure_schema_to_python(
+            schema, output_dir, package_name="issue_402s_json", dataclasses_json_annotation=True)
+
+        generated_src = os.path.join(output_dir, "src")
+        sys.path.insert(0, generated_src)
+        try:
+            module = importlib.import_module(
+                "issue_402s_json.example.issue402.issue402struct")
+            Issue402Struct = module.Issue402Struct
+            record = Issue402Struct(tenantid="acme", count=7)
+
+            payload = record.to_byte_array("application/json")
+            assert isinstance(payload, bytes), f"expected bytes, got {type(payload).__name__}"
+
+            round_tripped = Issue402Struct.from_data(payload, "application/json")
+            assert round_tripped == record
+        finally:
+            sys.path.remove(generated_src)
+
     def test_test_file_import_matches_module_structure(self):
         """
         Regression test: Generated test files should import from the correct module path.


### PR DESCRIPTION
Fixes #401, #402, #403.

Each fix is applied to **both** the Avro (`a2*`) and JSON Structure (`s2*`) code paths for parity, and each ships a regression test wired into the existing CI matrix.

## #401 — `a2go`/`s2go` emit gofmt-clean Go
- Struct tags are now separated by a space (`` `json:"x" avro:"x"` ``) in the templates. `gofmt` cannot repair this because the tag lives inside a raw string literal.
- Every generated file is run through `gofmt` as a final step (best-effort; cleanly skipped when the Go toolchain is absent).
- The package name derived from the input file name is sanitized to a valid Go identifier, so the canonical `.struct.json` extension no longer produces an un-compilable `package foo.struct` clause (this affected **all** `s2go` output).

## #402 — Python `to_byte_array("application/json")` returns `bytes`
- The plain `application/json` branch returned the `str` from `to_json()` (only `+gzip` encoded to bytes), violating the method's `-> bytes` contract and breaking `from_data` round-tripping and gzip. `a2py`/`s2py` now UTF-8 encode the JSON payload in that branch.

## #403 — `a2cs`/`s2cs` gain `--target-framework`
- Sets `<TargetFramework>` in the generated `.csproj`. A `;`-separated value (e.g. `net8.0;net10.0`) emits `<TargetFrameworks>` for multi-targeting. Defaults to `net10.0` (unchanged behavior when omitted).

## Tests & docs
- One regression test per emitter (6 total): `test_avrotogo`, `test_structuretogo`, `test_avrotopython`, `test_structuretopython`, `test_avrotocsharp`, `test_structuretocsharp`.
- `test_structuretogo::test_all_struct_files` updated to sanitize expected package/dir names consistently with the new package-name logic.
- README documents `--target-framework`; CHANGELOG updated under `## [3.8.0]`.

Verified locally: all 6 new tests pass, `test_main` (command registry) passes, `test_all_struct_files` passes, generated Go compiles and is `gofmt -l` clean.