### PR TITLE
Java: add XML serialization support

### DIFF
--- a/avrotize/avrotojava.py
+++ b/avrotize/avrotojava.py
@@ -198,14 +198,8 @@ if (mediaType.equals("application/xml") || mediaType.equals("text/xml")) {
 XML_FROMDATA = \
     """
 if (mediaType.equals("application/xml") || mediaType.equals("text/xml")) {
-    if (data instanceof byte[]) {
-        return {xmlMapper}.readValue((byte[]) data, {typeName}.class);
-    } else if (data instanceof InputStream) {
-        return {xmlMapper}.readValue((InputStream) data, {typeName}.class);
-    } else if (data instanceof String) {
-        return {xmlMapper}.readValue((String) data, {typeName}.class);
-    }
-    throw new UnsupportedOperationException("Data is not of a supported type for XML conversion to {typeName}");
+    return {xmlSupport}.readValue(
+        data, {typeName}.class, {xmlRoot}, {xmlNamespace}, XML_FIELD_RULES);
 }
 """
 
@@ -486,6 +480,70 @@ class AvroToJava:
         method += f"{INDENT}}}\n"
         return method
 
+    def avro_xml_field_kind(self, avro_type) -> str:
+        """Return the generated XML validation kind for an Avro field type."""
+        if isinstance(avro_type, list):
+            non_null = [item for item in avro_type if item != 'null']
+            if len(non_null) > 1:
+                return "UNION_CONTAINER"
+            return self.avro_xml_field_kind(non_null[0]) if non_null else "SINGLE"
+        if isinstance(avro_type, dict):
+            type_name = avro_type.get('type')
+            if type_name in ('array',):
+                return "COLLECTION"
+            if type_name == 'map':
+                return "MAP_SCALAR" if self.is_avro_xml_scalar(
+                    avro_type.get('values')) else "MAP_OBJECT"
+        return "SINGLE"
+
+    def is_avro_xml_scalar(self, avro_type) -> bool:
+        """Return whether an Avro type has a scalar XML representation."""
+        if isinstance(avro_type, str):
+            if avro_type in {
+                    'null', 'boolean', 'int', 'long', 'float', 'double',
+                    'bytes', 'string'}:
+                return True
+            matching_kinds = [
+                kind for name, kind in self.generated_types_avro_namespace.items()
+                if name == avro_type or name.endswith('.' + avro_type)
+            ]
+            return bool(matching_kinds) and all(
+                kind == "enum" for kind in matching_kinds)
+        if isinstance(avro_type, list):
+            non_null = [item for item in avro_type if item != 'null']
+            return len(non_null) == 1 and self.is_avro_xml_scalar(non_null[0])
+        if isinstance(avro_type, dict):
+            return avro_type.get('type') not in ('record', 'array', 'map')
+        return True
+
+    def generate_xml_validation_metadata(
+            self, avro_schema: Dict, xml_namespace: str) -> str:
+        """Generate schema-derived validation rules for XML input."""
+        support = f"{self.xml_support_package()}.AvrotizeXmlSupport"
+        rules = []
+        for field in avro_schema.get('fields', []):
+            xml_name = json.dumps(xml_wire_name(str(field['name']), field))
+            nullable = isinstance(field.get('type'), list) and \
+                'null' in field.get('type', [])
+            required = not nullable and 'default' not in field and 'const' not in field
+            if field.get('xmlkind', 'element') == 'attribute':
+                rules.append(
+                    f"{support}.FieldRule.attribute({xml_name}, "
+                    f"{str(required).lower()})")
+                continue
+            kind = self.avro_xml_field_kind(field.get('type'))
+            if kind == "COLLECTION":
+                required = False
+            rules.append(
+                f"{support}.FieldRule.element({xml_name}, "
+                f"{json.dumps(xml_namespace)}, {str(required).lower()}, "
+                f"{support}.FieldKind.{kind})")
+        joined = f",\n{INDENT*2}".join(rules)
+        return (
+            f"\n{INDENT}private static final {support}.FieldRule[] "
+            f"XML_FIELD_RULES = new {support}.FieldRule[] {{\n"
+            f"{INDENT*2}{joined}\n{INDENT}}};\n")
+
     def generate_class(self, avro_schema: Dict, parent_package: str, write_file: bool) -> JavaType:
         """ Generates a Java class from an Avro record schema """
         class_definition = ''
@@ -549,6 +607,9 @@ class AvroToJava:
 
         # Generate createTestInstance() method for testing
         class_definition += self.generate_create_test_instance_method(class_name, avro_schema.get('fields', []), namespace)
+        if self.xml_annotations:
+            class_definition += self.generate_xml_validation_metadata(
+                avro_schema, xml_namespace)
 
         if self.avro_annotation:
             # Inline all schema references like C# does - each class has self-contained schema
@@ -649,7 +710,11 @@ class AvroToJava:
             class_definition += f'\n{INDENT*2}'+f'\n{INDENT*2}'.join(
                 XML_FROMDATA.strip()
                 .replace("{typeName}", class_name)
-                .replace("{xmlMapper}", self.xml_mapper_reference())
+                .replace(
+                    "{xmlSupport}",
+                    f"{self.xml_support_package()}.AvrotizeXmlSupport")
+                .replace("{xmlRoot}", json.dumps(xml_name))
+                .replace("{xmlNamespace}", json.dumps(xml_namespace))
                 .split("\n"))
         class_definition += f"\n{INDENT*2}throw new UnsupportedOperationException(\"Unsupported media type \"+ contentType);\n{INDENT}}}"
         
@@ -1645,11 +1710,15 @@ class AvroToJava:
 
     def write_xml_support(self) -> None:
         """Generate one cached XML mapper holder for the output project."""
-        definition = process_template("java/xml_support.java.jinja")
-        self.write_to_file(
-            self.xml_support_package().replace('.', '/'),
-            "AvrotizeXmlSupport",
-            definition)
+        package = self.xml_support_package()
+        definition = process_template(
+            "java/xml_support.java.jinja", package=package)
+        directory_path = os.path.join(
+            self.output_dir, package.replace('.', os.sep))
+        os.makedirs(directory_path, exist_ok=True)
+        with open(os.path.join(directory_path, "AvrotizeXmlSupport.java"),
+                  'w', encoding='utf-8') as file:
+            file.write(definition)
 
     def write_to_file(self, package: str, name: str, definition: str):
         """ Writes a Java class or enum to a file """

--- a/avrotize/avrotojava.py
+++ b/avrotize/avrotojava.py
@@ -4,10 +4,12 @@
 import json
 import os
 from typing import Dict, List, Tuple, Union
-from avrotize.constants import (AVRO_VERSION, JACKSON_ANNOTATIONS_VERSION, JACKSON_VERSION,
+from avrotize.constants import (AVRO_VERSION, JAKARTA_XML_BIND_VERSION, JACKSON_ANNOTATIONS_VERSION, JACKSON_VERSION,
                                 JDK_VERSION, JUNIT_VERSION, MAVEN_COMPILER_VERSION, MAVEN_SUREFIRE_VERSION)
 
-from avrotize.common import pascal, camel, is_generic_avro_type, is_any_value_type, inline_avro_references, build_flat_type_dict
+from avrotize.common import (pascal, camel, is_generic_avro_type, is_any_value_type,
+                             inline_avro_references, build_flat_type_dict, xml_wire_name,
+                             xml_enum_wire_value)
 
 INDENT = '    '
 POM_CONTENT = """<?xml version="1.0" encoding="UTF-8"?>
@@ -43,6 +45,21 @@ POM_CONTENT = """<?xml version="1.0" encoding="UTF-8"?>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <version>{JACKSON_ANNOTATIONS_VERSION}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+            <version>{JACKSON_VERSION}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-jakarta-xmlbind-annotations</artifactId>
+            <version>{JACKSON_VERSION}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>{JAKARTA_XML_BIND_VERSION}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -103,14 +120,14 @@ if (result != null && shouldCompress) {
         gzipOutputStream.finish();
         result = byteArrayOutputStream.toByteArray();
     } catch (IOException e) {
-        throw new UnsupportedOperationException("Error compressing data to gzip");
+        throw new UnsupportedOperationException("Error compressing data to gzip", e);
     }
 }
 """
 
 EPILOGUE_TOBYTEARRAY = \
 """
-throw new UnsupportedOperationException("Unsupported media type + mediaType");
+throw new UnsupportedOperationException("Unsupported media type " + contentType);
 """
 
 PREAMBLE_FROMDATA_COMPRESSION = \
@@ -136,7 +153,7 @@ if (mediaType.endsWith("+gzip")) {
         }
         data = outputStream.toByteArray();
     } catch (IOException e) {
-        e.printStackTrace();
+        throw new UnsupportedOperationException("Error decompressing gzip data", e);
     }
 }
 """
@@ -168,6 +185,28 @@ JSON_TOBYTEARRAY = \
     """
 if ( mediaType.equals("application/json")) {    
     result = new ObjectMapper().writeValueAsBytes(this);
+}
+"""
+
+XML_TOBYTEARRAY = \
+    """
+if (mediaType.equals("application/xml") || mediaType.equals("text/xml")) {
+    result = createXmlMapper().writeValueAsBytes(this);
+}
+"""
+
+XML_FROMDATA = \
+    """
+if (mediaType.equals("application/xml") || mediaType.equals("text/xml")) {
+    XmlMapper mapper = createXmlMapper();
+    if (data instanceof byte[]) {
+        return mapper.readValue((byte[]) data, {typeName}.class);
+    } else if (data instanceof InputStream) {
+        return mapper.readValue((InputStream) data, {typeName}.class);
+    } else if (data instanceof String) {
+        return mapper.readValue((String) data, {typeName}.class);
+    }
+    throw new UnsupportedOperationException("Data is not of a supported type for XML conversion to {typeName}");
 }
 """
 
@@ -239,18 +278,20 @@ def is_java_reserved_word(word: str) -> bool:
 
 
 class AvroToJava:
-    """Converts Avro schema to Java classes, including Jackson annotations and Avro SpecificRecord methods"""
+    """Converts Avro schema to Java classes with JSON, Avro, and XML support."""
 
     def __init__(self, base_package: str = '') -> None:
         self.base_package = base_package.replace('.', '/')
         self.output_dir = os.getcwd()
         self.avro_annotation = False
         self.jackson_annotations = False
+        self.xml_annotations = False
         self.pascal_properties = False
         self.generated_types_avro_namespace: Dict[str,str] = {}
         self.generated_types_java_package: Dict[str,str] = {}
         self.generated_avro_schemas: Dict[str, Dict] = {}
         self.discriminated_unions: Dict[str, List[Dict]] = {}  # Maps union name to list of subtype schemas
+        self.xml_package_namespaces: Dict[str, str] = {}
 
     def qualified_name(self, package: str, name: str) -> str:
         """Concatenates package and name using a dot separator"""
@@ -458,6 +499,8 @@ class AvroToJava:
         package = package.replace('.', '/').lower()
         package = self.safe_package(package)
         class_name = self.safe_identifier(avro_schema['name'])
+        xml_namespace = str(avro_schema.get('xmlns', ''))
+        xml_name = xml_wire_name(str(avro_schema['name']), avro_schema)
         namespace_qualified_name = self.qualified_name(namespace,avro_schema['name'])
         qualified_class_name = self.qualified_name(package.replace('/', '.'), class_name)
         if namespace_qualified_name in self.generated_types_avro_namespace:
@@ -478,8 +521,13 @@ class AvroToJava:
                 'qualified_name': qualified_class_name
             })
         
-        fields_str = [self.generate_property(class_name, field, namespace) for field in avro_schema.get('fields', [])]
+        fields_str = [self.generate_property(class_name, field, namespace, xml_namespace) for field in avro_schema.get('fields', [])]
         class_body = "\n".join(fields_str)
+        if self.xml_annotations:
+            namespace_arg = f", namespace = {json.dumps(xml_namespace)}" if xml_namespace else ""
+            class_definition += f"@XmlRootElement(name = {json.dumps(xml_name)}{namespace_arg})\n"
+            class_definition += f"@XmlType(name = {json.dumps(xml_name)}{namespace_arg})\n"
+            class_definition += "@XmlAccessorType(XmlAccessType.FIELD)\n"
         class_definition += f"public class {class_name}"
         
         # Add extends clause if this is a discriminated union subtype
@@ -557,12 +605,19 @@ class AvroToJava:
             class_definition += self.generate_avro_get_method(class_name, avro_schema.get('fields', []), namespace)
             class_definition += self.generate_avro_put_method(class_name, avro_schema.get('fields', []), namespace)
 
+        if self.xml_annotations:
+            class_definition += f"\n\n{INDENT}private static XmlMapper createXmlMapper() {{\n"
+            class_definition += f"{INDENT*2}XmlMapper mapper = new XmlMapper();\n"
+            class_definition += f"{INDENT*2}mapper.setAnnotationIntrospector(new JakartaXmlBindAnnotationIntrospector(mapper.getTypeFactory()));\n"
+            class_definition += f"{INDENT*2}return mapper;\n{INDENT}}}\n"
+
         # emit toByteArray method
         class_definition += f"\n\n{INDENT}/**\n{INDENT} * Converts the object to a byte array\n{INDENT} * @param contentType the content type of the byte array\n{INDENT} * @return the byte array\n{INDENT} */\n"
+        to_byte_array_throws = ",IOException" if self.avro_annotation or self.xml_annotations else (
+            ",JsonProcessingException" if self.jackson_annotations else "")
         class_definition += f"{INDENT}public byte[] toByteArray(String contentType) throws UnsupportedOperationException" + \
-            f"{ JSON_TOBYTEARRAY_THROWS if self.jackson_annotations else '' }" + \
-            f"{ AVRO_TOBYTEARRAY_THROWS if self.avro_annotation else '' }  {{"
-        if self.jackson_annotations or self.avro_annotation:
+            f"{to_byte_array_throws}  {{"
+        if self.jackson_annotations or self.avro_annotation or self.xml_annotations:
             class_definition += f'\n{INDENT*2}'.join((PREAMBLE_TOBYTEARRAY).split("\n"))
         if self.avro_annotation:
             class_definition += f'\n{INDENT*2}'+f'\n{INDENT*2}'.join(
@@ -570,19 +625,22 @@ class AvroToJava:
         if self.jackson_annotations:
             class_definition += f'\n{INDENT*2}'+f'\n{INDENT*2}'.join(
                 JSON_TOBYTEARRAY.strip().replace("{typeName}", class_name).split("\n"))
-        if self.avro_annotation or self.jackson_annotations:
+        if self.xml_annotations:
+            class_definition += f'\n{INDENT*2}'+f'\n{INDENT*2}'.join(
+                XML_TOBYTEARRAY.strip().replace("{typeName}", class_name).split("\n"))
+        if self.avro_annotation or self.jackson_annotations or self.xml_annotations:
             class_definition += f'\n{INDENT*2}'.join(EPILOGUE_TOBYTEARRAY_COMPRESSION.split("\n"))
             class_definition += f'\n{INDENT*2}if ( result != null ) {{ return result; }}'        
         class_definition += (f'\n{INDENT*2}'.join((EPILOGUE_TOBYTEARRAY.strip()).split("\n")))+f"\n{INDENT}}}"
 
         # emit fromData factory method
         class_definition += f"\n\n{INDENT}/**\n{INDENT} * Converts the data to an object\n{INDENT} * @param data the data to convert\n{INDENT} * @param contentType the content type of the data\n{INDENT} * @return the object\n{INDENT} */\n"
+        from_data_throws = ",IOException" if self.avro_annotation or self.jackson_annotations or self.xml_annotations else ""
         class_definition += f"{INDENT}public static {class_name} fromData(Object data, String contentType) throws UnsupportedOperationException" + \
-            f"{ JSON_FROMDATA_THROWS if self.jackson_annotations else '' }" + \
-            f"{ AVRO_FROMDATA_THROWS if self.avro_annotation else '' }  {{"
+            f"{from_data_throws}  {{"
         class_definition += f'\n{INDENT*2}if ( data instanceof {class_name}) return ({class_name})data;'
         
-        if self.avro_annotation or self.jackson_annotations:
+        if self.avro_annotation or self.jackson_annotations or self.xml_annotations:
             class_definition += f'\n{INDENT*2}String mediaType = contentType.split(";")[0].trim().toLowerCase();'
             class_definition += f'\n{INDENT*2}'.join((PREAMBLE_FROMDATA_COMPRESSION).split("\n"))
         if self.avro_annotation:
@@ -591,6 +649,9 @@ class AvroToJava:
         if self.jackson_annotations:
             class_definition += f'\n{INDENT*2}'+f'\n{INDENT*2}'.join(
                 JSON_FROMDATA.strip().replace("{typeName}", class_name).split("\n"))
+        if self.xml_annotations:
+            class_definition += f'\n{INDENT*2}'+f'\n{INDENT*2}'.join(
+                XML_FROMDATA.strip().replace("{typeName}", class_name).split("\n"))
         class_definition += f"\n{INDENT*2}throw new UnsupportedOperationException(\"Unsupported media type \"+ contentType);\n{INDENT}}}"
         
         if self.jackson_annotations:
@@ -603,6 +664,8 @@ class AvroToJava:
         class_definition += "\n}"
 
         if write_file:
+            if self.xml_annotations and xml_namespace:
+                self.write_package_info(package, xml_namespace)
             self.write_to_file(package, class_name, class_definition)
         return AvroToJava.JavaType(qualified_class_name, is_class=True)
     
@@ -1216,6 +1279,8 @@ class AvroToJava:
             
         package = self.join_packages(self.base_package, avro_schema.get('namespace', parent_package)).replace('.', '/').lower()       
         enum_name = self.safe_identifier(avro_schema['name'])
+        xml_namespace = str(avro_schema.get('xmlns', ''))
+        xml_name = xml_wire_name(str(avro_schema['name']), avro_schema)
         type_name = self.qualified_name(package.replace('/', '.'), enum_name)
         self.generated_types_avro_namespace[self.qualified_name(avro_schema.get('namespace', parent_package),avro_schema['name'])] = "enum"
         self.generated_types_java_package[type_name] = "enum"
@@ -1237,11 +1302,18 @@ class AvroToJava:
             symbol_pairs.append((java_symbol, symbol))
         
         # Build enum with avroSymbol field for proper Avro serialization
+        if self.xml_annotations:
+            namespace_arg = f", namespace = {json.dumps(xml_namespace)}" if xml_namespace else ""
+            enum_definition += f"@XmlType(name = {json.dumps(xml_name)}{namespace_arg})\n"
+            enum_definition += "@XmlEnum\n"
         enum_definition += f"public enum {enum_name} {{\n"
         # Each enum constant has its original Avro symbol stored
         enum_constants = []
         for java_symbol, avro_symbol in symbol_pairs:
-            enum_constants.append(f'{java_symbol}("{avro_symbol}")')
+            xml_annotation = ""
+            if self.xml_annotations:
+                xml_annotation = f'@XmlEnumValue({json.dumps(xml_enum_wire_value(avro_symbol, avro_schema))}) '
+            enum_constants.append(f'{xml_annotation}{java_symbol}("{avro_symbol}")')
         enum_definition += f"{INDENT}" + ", ".join(enum_constants)
         
         # Add avroSymbol field and method with Jackson annotations for proper JSON serialization
@@ -1283,6 +1355,8 @@ class AvroToJava:
         
         enum_definition += "}\n"
         if write_file:
+            if self.xml_annotations and xml_namespace:
+                self.write_package_info(package, xml_namespace)
             self.write_to_file(package, enum_name, enum_definition)
         return AvroToJava.JavaType(type_name, is_enum=True)
     
@@ -1405,7 +1479,10 @@ class AvroToJava:
             if gij:
                 list_is_json_match.append(gij)
 
-        class_definition =  f"@JsonSerialize(using = {union_class_name}.Serializer.class)\n"
+        class_definition = ""
+        if self.xml_annotations:
+            class_definition += "@XmlAccessorType(XmlAccessType.FIELD)\n"
+        class_definition += f"@JsonSerialize(using = {union_class_name}.Serializer.class)\n"
         class_definition += f"@JsonDeserialize(using = {union_class_name}.Deserializer.class)\n"
         class_definition += f"public class {union_class_name} {{\n"
         class_definition += class_definition_decls
@@ -1465,7 +1542,7 @@ class AvroToJava:
         return union_class_name
 
 
-    def generate_property(self, class_name: str, field: Dict, parent_package: str) -> str:
+    def generate_property(self, class_name: str, field: Dict, parent_package: str, xml_namespace: str = '') -> str:
         """ Generates a Java property definition """
         field_name = pascal(field['name']) if self.pascal_properties else field['name']
         field_type = self.convert_avro_type_to_java(class_name, field_name, field['type'], parent_package)
@@ -1473,6 +1550,14 @@ class AvroToJava:
         property_def = ''
         if 'doc' in field:
             property_def += f"{INDENT}/** {field['doc']} */\n"
+
+        if self.xml_annotations:
+            xml_name = xml_wire_name(str(field['name']), field)
+            if field.get('xmlkind', 'element') == 'attribute':
+                property_def += f"{INDENT}@XmlAttribute(name = {json.dumps(xml_name)})\n"
+            else:
+                namespace_arg = f", namespace = {json.dumps(xml_namespace)}" if xml_namespace else ""
+                property_def += f"{INDENT}@XmlElement(name = {json.dumps(xml_name)}{namespace_arg})\n"
         
         # For discriminator const fields, don't put @JsonProperty on the field
         # The getter will handle JSON serialization/deserialization
@@ -1528,6 +1613,27 @@ class AvroToJava:
                 property_def += f"{INDENT}public {union_type.type_name} get{pascal(field_name)}As{flatten_type_name(union_type.type_name)}() {{ return ({union_type.type_name}){safe_field_name}; }}\n"
                 property_def += f"{INDENT}public void set{pascal(field_name)}As{flatten_type_name(union_type.type_name)}({union_type.type_name} {safe_field_name}) {{ this.{safe_field_name} = {safe_field_name}; }}\n"
         return property_def
+
+    def write_package_info(self, package: str, xml_namespace: str) -> None:
+        """Write JAXB package metadata for a package's default XML namespace."""
+        package = self.safe_package(package.lower())
+        package_name = package.replace('/', '.')
+        if not package_name:
+            return
+        previous = self.xml_package_namespaces.get(package_name)
+        if previous is not None and previous != xml_namespace:
+            return
+        self.xml_package_namespaces[package_name] = xml_namespace
+        directory_path = os.path.join(
+            self.output_dir, package.replace('.', os.sep).replace('/', os.sep))
+        os.makedirs(directory_path, exist_ok=True)
+        package_info_path = os.path.join(directory_path, "package-info.java")
+        with open(package_info_path, 'w', encoding='utf-8') as file:
+            file.write("@jakarta.xml.bind.annotation.XmlSchema(\n")
+            file.write(f"    namespace = {json.dumps(xml_namespace)},\n")
+            file.write("    elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED\n")
+            file.write(")\n")
+            file.write(f"package {package_name};\n")
 
     def write_to_file(self, package: str, name: str, definition: str):
         """ Writes a Java class or enum to a file """
@@ -1641,7 +1747,27 @@ class AvroToJava:
                     file.write("import com.fasterxml.jackson.core.JsonGenerator;\n")
                 if 'TypeReference' in definition:
                     file.write("import com.fasterxml.jackson.core.type.TypeReference;\n")
-            if self.avro_annotation or self.jackson_annotations:
+            if self.xml_annotations:
+                if 'XmlRootElement' in definition:
+                    file.write("import jakarta.xml.bind.annotation.XmlRootElement;\n")
+                if 'XmlType' in definition:
+                    file.write("import jakarta.xml.bind.annotation.XmlType;\n")
+                if 'XmlAccessorType' in definition:
+                    file.write("import jakarta.xml.bind.annotation.XmlAccessorType;\n")
+                    file.write("import jakarta.xml.bind.annotation.XmlAccessType;\n")
+                if 'XmlElement' in definition:
+                    file.write("import jakarta.xml.bind.annotation.XmlElement;\n")
+                if 'XmlAttribute' in definition:
+                    file.write("import jakarta.xml.bind.annotation.XmlAttribute;\n")
+                if 'XmlEnumValue' in definition:
+                    file.write("import jakarta.xml.bind.annotation.XmlEnumValue;\n")
+                if '@XmlEnum' in definition:
+                    file.write("import jakarta.xml.bind.annotation.XmlEnum;\n")
+                if 'XmlMapper' in definition:
+                    file.write("import com.fasterxml.jackson.dataformat.xml.XmlMapper;\n")
+                if 'JakartaXmlBindAnnotationIntrospector' in definition:
+                    file.write("import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntrospector;\n")
+            if self.avro_annotation or self.jackson_annotations or self.xml_annotations:
                 if 'GZIPOutputStream' in definition:
                     file.write("import java.util.zip.GZIPOutputStream;\n")
                 if 'GZIPInputStream' in definition:
@@ -1691,7 +1817,8 @@ class AvroToJava:
                 fields=fields,
                 imports=imports,
                 avro_annotation=self.avro_annotation,
-                jackson_annotation=self.jackson_annotations
+                jackson_annotation=self.jackson_annotations,
+                xml_annotation=self.xml_annotations
             )
         elif type_kind == "enum":
             # Convert symbols to Java-safe identifiers in SCREAMING_CASE (same logic as generate_enum)
@@ -2165,6 +2292,7 @@ class AvroToJava:
                     AVRO_VERSION=AVRO_VERSION, 
                     JACKSON_VERSION=JACKSON_VERSION, 
                     JACKSON_ANNOTATIONS_VERSION=JACKSON_ANNOTATIONS_VERSION,
+                    JAKARTA_XML_BIND_VERSION=JAKARTA_XML_BIND_VERSION,
                     JDK_VERSION=JDK_VERSION, 
                     JUNIT_VERSION=JUNIT_VERSION,
                     MAVEN_COMPILER_VERSION=MAVEN_COMPILER_VERSION,
@@ -2187,15 +2315,9 @@ class AvroToJava:
         self.convert_schema(schema, output_dir)
 
 
-def convert_avro_to_java(avro_schema_path, java_file_path, package_name='', pascal_properties=False, jackson_annotation=False, avro_annotation=False):
-    """_summary_
-
-    Converts Avro schema to C# classes
-
-    Args:
-        avro_schema_path (_type_): Avro input schema path  
-        cs_file_path (_type_): Output C# file path 
-    """
+def convert_avro_to_java(avro_schema_path, java_file_path, package_name='', pascal_properties=False,
+                         jackson_annotation=False, avro_annotation=False, xml_annotation=False):
+    """Convert an Avro schema file to Java classes."""
     if not package_name:
         package_name = os.path.splitext(os.path.basename(java_file_path))[0].replace('-', '_').lower()
     avrotojava = AvroToJava()
@@ -2203,21 +2325,18 @@ def convert_avro_to_java(avro_schema_path, java_file_path, package_name='', pasc
     avrotojava.pascal_properties = pascal_properties
     avrotojava.avro_annotation = avro_annotation
     avrotojava.jackson_annotations = jackson_annotation
+    avrotojava.xml_annotations = xml_annotation
     avrotojava.convert(avro_schema_path, java_file_path)
 
 
-def convert_avro_schema_to_java(avro_schema: JsonNode, output_dir: str, package_name='', pascal_properties=False, jackson_annotation=False, avro_annotation=False):
-    """_summary_
-
-    Converts Avro schema to C# classes
-
-    Args:
-        avro_schema (_type_): Avro schema as a dictionary or list of dictionaries
-        output_dir (_type_): Output directory path 
-    """
+def convert_avro_schema_to_java(avro_schema: JsonNode, output_dir: str, package_name='',
+                                pascal_properties=False, jackson_annotation=False,
+                                avro_annotation=False, xml_annotation=False):
+    """Convert an Avro schema object to Java classes."""
     avrotojava = AvroToJava()
     avrotojava.base_package = package_name
     avrotojava.pascal_properties = pascal_properties
     avrotojava.avro_annotation = avro_annotation
     avrotojava.jackson_annotations = jackson_annotation
+    avrotojava.xml_annotations = xml_annotation
     avrotojava.convert_schema(avro_schema, output_dir)

--- a/avrotize/avrotojava.py
+++ b/avrotize/avrotojava.py
@@ -8,8 +8,8 @@ from avrotize.constants import (AVRO_VERSION, JAKARTA_XML_BIND_VERSION, JACKSON_
                                 JDK_VERSION, JUNIT_VERSION, MAVEN_COMPILER_VERSION, MAVEN_SUREFIRE_VERSION)
 
 from avrotize.common import (pascal, camel, is_generic_avro_type, is_any_value_type,
-                             inline_avro_references, build_flat_type_dict, xml_wire_name,
-                             xml_enum_wire_value)
+                             inline_avro_references, build_flat_type_dict, process_template,
+                             xml_wire_name, xml_enum_wire_value)
 
 INDENT = '    '
 POM_CONTENT = """<?xml version="1.0" encoding="UTF-8"?>
@@ -191,20 +191,19 @@ if ( mediaType.equals("application/json")) {
 XML_TOBYTEARRAY = \
     """
 if (mediaType.equals("application/xml") || mediaType.equals("text/xml")) {
-    result = createXmlMapper().writeValueAsBytes(this);
+    result = {xmlMapper}.writeValueAsBytes(this);
 }
 """
 
 XML_FROMDATA = \
     """
 if (mediaType.equals("application/xml") || mediaType.equals("text/xml")) {
-    XmlMapper mapper = createXmlMapper();
     if (data instanceof byte[]) {
-        return mapper.readValue((byte[]) data, {typeName}.class);
+        return {xmlMapper}.readValue((byte[]) data, {typeName}.class);
     } else if (data instanceof InputStream) {
-        return mapper.readValue((InputStream) data, {typeName}.class);
+        return {xmlMapper}.readValue((InputStream) data, {typeName}.class);
     } else if (data instanceof String) {
-        return mapper.readValue((String) data, {typeName}.class);
+        return {xmlMapper}.readValue((String) data, {typeName}.class);
     }
     throw new UnsupportedOperationException("Data is not of a supported type for XML conversion to {typeName}");
 }
@@ -605,12 +604,6 @@ class AvroToJava:
             class_definition += self.generate_avro_get_method(class_name, avro_schema.get('fields', []), namespace)
             class_definition += self.generate_avro_put_method(class_name, avro_schema.get('fields', []), namespace)
 
-        if self.xml_annotations:
-            class_definition += f"\n\n{INDENT}private static XmlMapper createXmlMapper() {{\n"
-            class_definition += f"{INDENT*2}XmlMapper mapper = new XmlMapper();\n"
-            class_definition += f"{INDENT*2}mapper.setAnnotationIntrospector(new JakartaXmlBindAnnotationIntrospector(mapper.getTypeFactory()));\n"
-            class_definition += f"{INDENT*2}return mapper;\n{INDENT}}}\n"
-
         # emit toByteArray method
         class_definition += f"\n\n{INDENT}/**\n{INDENT} * Converts the object to a byte array\n{INDENT} * @param contentType the content type of the byte array\n{INDENT} * @return the byte array\n{INDENT} */\n"
         to_byte_array_throws = ",IOException" if self.avro_annotation or self.xml_annotations else (
@@ -627,7 +620,10 @@ class AvroToJava:
                 JSON_TOBYTEARRAY.strip().replace("{typeName}", class_name).split("\n"))
         if self.xml_annotations:
             class_definition += f'\n{INDENT*2}'+f'\n{INDENT*2}'.join(
-                XML_TOBYTEARRAY.strip().replace("{typeName}", class_name).split("\n"))
+                XML_TOBYTEARRAY.strip()
+                .replace("{typeName}", class_name)
+                .replace("{xmlMapper}", self.xml_mapper_reference())
+                .split("\n"))
         if self.avro_annotation or self.jackson_annotations or self.xml_annotations:
             class_definition += f'\n{INDENT*2}'.join(EPILOGUE_TOBYTEARRAY_COMPRESSION.split("\n"))
             class_definition += f'\n{INDENT*2}if ( result != null ) {{ return result; }}'        
@@ -651,7 +647,10 @@ class AvroToJava:
                 JSON_FROMDATA.strip().replace("{typeName}", class_name).split("\n"))
         if self.xml_annotations:
             class_definition += f'\n{INDENT*2}'+f'\n{INDENT*2}'.join(
-                XML_FROMDATA.strip().replace("{typeName}", class_name).split("\n"))
+                XML_FROMDATA.strip()
+                .replace("{typeName}", class_name)
+                .replace("{xmlMapper}", self.xml_mapper_reference())
+                .split("\n"))
         class_definition += f"\n{INDENT*2}throw new UnsupportedOperationException(\"Unsupported media type \"+ contentType);\n{INDENT}}}"
         
         if self.jackson_annotations:
@@ -1635,6 +1634,23 @@ class AvroToJava:
             file.write(")\n")
             file.write(f"package {package_name};\n")
 
+    def xml_support_package(self) -> str:
+        """Return the package containing the project-wide XML runtime holder."""
+        package = self.safe_package(self.base_package.replace('.', '/').lower())
+        return package.replace('/', '.') or 'avrotize.generated.xml'
+
+    def xml_mapper_reference(self) -> str:
+        """Return the shared generated XmlMapper field reference."""
+        return f"{self.xml_support_package()}.AvrotizeXmlSupport.MAPPER"
+
+    def write_xml_support(self) -> None:
+        """Generate one cached XML mapper holder for the output project."""
+        definition = process_template("java/xml_support.java.jinja")
+        self.write_to_file(
+            self.xml_support_package().replace('.', '/'),
+            "AvrotizeXmlSupport",
+            definition)
+
     def write_to_file(self, package: str, name: str, definition: str):
         """ Writes a Java class or enum to a file """
         package = package.lower()
@@ -2303,6 +2319,8 @@ class AvroToJava:
         if not os.path.exists(output_dir):
             os.makedirs(output_dir, exist_ok=True)
         self.output_dir = output_dir
+        if self.xml_annotations:
+            self.write_xml_support()
         for avro_schema in (x for x in schema if isinstance(x, dict)):
             self.generate_class_or_enum(avro_schema, '')
         self.generate_discriminated_union_base_classes()

--- a/avrotize/avrotojava/class_test.java.jinja
+++ b/avrotize/avrotojava/class_test.java.jinja
@@ -207,4 +207,27 @@ public class {{ test_class_name }} {
         assertEquals(instance, newInstance);
     }
     {%- endif %}
+    {%- if xml_annotation %}
+    /**
+     * Testing XML serializer
+     */
+    @Test
+    public void test_ToByteArray_FromData_Xml() throws Exception {
+        String mediaType = "application/xml";
+        byte[] bytes = instance.toByteArray(mediaType);
+        {{ class_name }} newInstance = {{ class_name }}.fromData(bytes, mediaType);
+        assertEquals(instance, newInstance);
+    }
+
+    /**
+     * Testing XML serializer with gzip compression
+     */
+    @Test
+    public void test_ToByteArray_FromData_Xml_Gzip() throws Exception {
+        String mediaType = "text/xml+gzip";
+        byte[] bytes = instance.toByteArray(mediaType);
+        {{ class_name }} newInstance = {{ class_name }}.fromData(bytes, mediaType);
+        assertEquals(instance, newInstance);
+    }
+    {%- endif %}
 }

--- a/avrotize/commands.json
+++ b/avrotize/commands.json
@@ -2957,7 +2957,8 @@
         "package_name": "args.package",
         "avro_annotation": "args.avro_annotation",
         "jackson_annotation": "args.jackson_annotation",
-        "pascal_properties": "args.pascal_properties"
+        "pascal_properties": "args.pascal_properties",
+        "xml_annotation": "args.xml_annotation"
       }
     },
     "extensions": [
@@ -3009,6 +3010,13 @@
         "help": "Use PascalCase properties",
         "default": false,
         "required": false
+      },
+      {
+        "name": "--xml-annotation",
+        "type": "bool",
+        "help": "Use Jakarta JAXB annotations and XML serialization",
+        "default": false,
+        "required": false
       }
     ],
     "suggested_output_file_path": "{input_file_name}-java",
@@ -3028,6 +3036,12 @@
       {
         "name": "--pascal-properties",
         "message": "Use PascalCase properties?",
+        "type": "bool",
+        "default": false
+      },
+      {
+        "name": "--xml-annotation",
+        "message": "Use Jakarta JAXB annotations and XML serialization?",
         "type": "bool",
         "default": false
       }
@@ -3431,7 +3445,8 @@
         "java_file_path": "output_file_path",
         "package_name": "args.package",
         "pascal_properties": "args.pascal_properties",
-        "jackson_annotation": "args.jackson_annotation"
+        "jackson_annotation": "args.jackson_annotation",
+        "xml_annotation": "args.xml_annotation"
       }
     },
     "extensions": [
@@ -3471,6 +3486,13 @@
         "help": "Use PascalCase for property names",
         "default": false,
         "required": false
+      },
+      {
+        "name": "--xml-annotation",
+        "type": "bool",
+        "help": "Use Jakarta JAXB annotations and XML serialization",
+        "default": false,
+        "required": false
       }
     ],
     "suggested_output_file_path": "{input_file_name}-java",
@@ -3487,6 +3509,12 @@
         "message": "Use Jackson annotations?",
         "type": "bool",
         "default": true
+      },
+      {
+        "name": "--xml-annotation",
+        "message": "Use Jakarta JAXB annotations and XML serialization?",
+        "type": "bool",
+        "default": false
       }
     ]
   },

--- a/avrotize/common.py
+++ b/avrotize/common.py
@@ -894,6 +894,26 @@ def json_enum_wire_value(value: Any, enum_schema: Any) -> str:
     return str(value)
 
 
+def xml_wire_name(prop_name: str, schema_obj: Any) -> str:
+    """Resolve an XML local name, honoring ``altnames.xml``."""
+    if isinstance(schema_obj, dict):
+        altnames = schema_obj.get("altnames")
+        if isinstance(altnames, dict) and "xml" in altnames:
+            return str(altnames["xml"])
+    return prop_name
+
+
+def xml_enum_wire_value(value: Any, enum_schema: Any) -> str:
+    """Resolve an XML enum value, honoring ``altenums.xml``."""
+    if isinstance(enum_schema, dict):
+        altenums = enum_schema.get("altenums")
+        if isinstance(altenums, dict):
+            xml_values = altenums.get("xml")
+            if isinstance(xml_values, dict) and str(value) in xml_values:
+                return str(xml_values[str(value)])
+    return str(value)
+
+
 def process_template(file_path: str, **kvargs) -> str:
     """
     Process a file as a Jinja2 template with the given object as input.

--- a/avrotize/constants.py
+++ b/avrotize/constants.py
@@ -22,6 +22,11 @@ try:
 except ValueError:
     JACKSON_ANNOTATIONS_VERSION = '2.18.2'  # Fallback
 
+try:
+    JAKARTA_XML_BIND_VERSION = get_dependency_version('java', 'jdk21', 'jakarta.xml.bind:jakarta.xml.bind-api')
+except ValueError:
+    JAKARTA_XML_BIND_VERSION = '4.0.4'  # Fallback
+
 JDK_VERSION = '21'
 
 # C# dependencies  

--- a/avrotize/dependencies/java/jdk21/pom.xml
+++ b/avrotize/dependencies/java/jdk21/pom.xml
@@ -55,6 +55,21 @@
             <artifactId>jackson-annotations</artifactId>
             <version>2.22</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+            <version>2.22.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-jakarta-xmlbind-annotations</artifactId>
+            <version>2.22.0</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>4.0.4</version>
+        </dependency>
 
         <!-- Testing - JUnit 5 -->
         <dependency>

--- a/avrotize/java/xml_support.java.jinja
+++ b/avrotize/java/xml_support.java.jinja
@@ -1,14 +1,389 @@
+package {{ package }};
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.dataformat.xml.XmlFactory;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntrospector;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.stream.XMLInputFactory;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
 public final class AvrotizeXmlSupport {
+    private static final int MAX_XML_BYTES = 1_048_576;
+    private static final int MAX_XML_DEPTH = 100;
+
     public static final XmlMapper MAPPER = createMapper();
+
+    public enum FieldKind {
+        ATTRIBUTE,
+        SINGLE,
+        COLLECTION,
+        MAP_SCALAR,
+        MAP_OBJECT,
+        UNION_CONTAINER,
+        UNION_SCALAR
+    }
+
+    public record FieldRule(
+            String name,
+            String namespace,
+            boolean required,
+            FieldKind kind) {
+        public static FieldRule attribute(String name, boolean required) {
+            return new FieldRule(name, "", required, FieldKind.ATTRIBUTE);
+        }
+
+        public static FieldRule element(
+                String name,
+                String namespace,
+                boolean required,
+                FieldKind kind) {
+            return new FieldRule(name, namespace, required, kind);
+        }
+    }
 
     private AvrotizeXmlSupport() {
     }
 
     private static XmlMapper createMapper() {
-        XmlMapper mapper = new XmlMapper();
+        XMLInputFactory inputFactory = XMLInputFactory.newFactory();
+        setInputProperty(inputFactory, XMLInputFactory.SUPPORT_DTD, false);
+        setInputProperty(inputFactory, "javax.xml.stream.isSupportingExternalEntities", false);
+        setInputProperty(inputFactory, XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        setInputProperty(inputFactory, XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+
+        XmlFactory xmlFactory = XmlFactory.builder()
+            .xmlInputFactory(inputFactory)
+            .build();
+        xmlFactory.setStreamReadConstraints(StreamReadConstraints.builder()
+            .maxNestingDepth(MAX_XML_DEPTH)
+            .maxStringLength(MAX_XML_BYTES)
+            .maxDocumentLength(MAX_XML_BYTES)
+            .build());
+        XmlMapper mapper = new XmlMapper(xmlFactory);
         mapper.setAnnotationIntrospector(
             new JakartaXmlBindAnnotationIntrospector(mapper.getTypeFactory()));
+        mapper.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        mapper.enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
         mapper.findAndRegisterModules();
         return mapper;
+    }
+
+    private static void setInputProperty(
+            XMLInputFactory factory,
+            String property,
+            Object value) {
+        try {
+            factory.setProperty(property, value);
+        } catch (IllegalArgumentException ignored) {
+            // The secure DOM validation below remains authoritative when a StAX
+            // provider does not expose an optional JAXP property.
+        }
+    }
+
+    public static <T> T readValue(
+            Object data,
+            Class<T> type,
+            String rootName,
+            String rootNamespace,
+            FieldRule[] rules) throws IOException {
+        byte[] bytes = toBytes(data);
+        Document document = parseSecurely(bytes);
+        validate(document, rootName, rootNamespace, rules);
+        try {
+            return MAPPER.readValue(bytes, type);
+        } catch (JsonProcessingException exception) {
+            throw new IOException(
+                "Invalid XML value for " + type.getSimpleName() + ": "
+                    + exception.getOriginalMessage(),
+                exception);
+        }
+    }
+
+    private static byte[] toBytes(Object data) throws IOException {
+        if (data instanceof byte[] bytes) {
+            if (bytes.length > MAX_XML_BYTES) {
+                throw new IOException("XML payload exceeds the configured size limit");
+            }
+            return bytes;
+        }
+        if (data instanceof String text) {
+            byte[] bytes = text.getBytes(StandardCharsets.UTF_8);
+            if (bytes.length > MAX_XML_BYTES) {
+                throw new IOException("XML payload exceeds the configured size limit");
+            }
+            return bytes;
+        }
+        if (data instanceof InputStream input) {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            byte[] buffer = new byte[8192];
+            int total = 0;
+            int read;
+            while ((read = input.read(buffer)) != -1) {
+                total += read;
+                if (total > MAX_XML_BYTES) {
+                    throw new IOException("XML payload exceeds the configured size limit");
+                }
+                output.write(buffer, 0, read);
+            }
+            return output.toByteArray();
+        }
+        throw new IOException("Data is not a supported XML input type");
+    }
+
+    private static Document parseSecurely(byte[] bytes) throws IOException {
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setNamespaceAware(true);
+            factory.setXIncludeAware(false);
+            factory.setExpandEntityReferences(false);
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setFeature(
+                "http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature(
+                "http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature(
+                "http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            var builder = factory.newDocumentBuilder();
+            builder.setEntityResolver((publicId, systemId) -> {
+                throw new SAXException("External entity resolution is disabled");
+            });
+            Document document = builder.parse(new ByteArrayInputStream(bytes));
+            if (document.getDoctype() != null) {
+                throw new IOException("DOCTYPE declarations are not allowed");
+            }
+            enforceDepth(document.getDocumentElement(), 1);
+            return document;
+        } catch (ParserConfigurationException exception) {
+            throw new IOException("Unable to configure secure XML parsing", exception);
+        } catch (SAXException exception) {
+            throw new IOException("Malformed or unsafe XML data", exception);
+        }
+    }
+
+    private static void enforceDepth(Node node, int depth) throws IOException {
+        if (depth > MAX_XML_DEPTH) {
+            throw new IOException("XML nesting exceeds the configured depth limit");
+        }
+        NodeList children = node.getChildNodes();
+        for (int index = 0; index < children.getLength(); index++) {
+            Node child = children.item(index);
+            if (child.getNodeType() == Node.ELEMENT_NODE) {
+                enforceDepth(child, depth + 1);
+            }
+        }
+    }
+
+    private static void validate(
+            Document document,
+            String rootName,
+            String rootNamespace,
+            FieldRule[] rules) throws IOException {
+        Element root = document.getDocumentElement();
+        String actualRootName = localName(root);
+        String actualRootNamespace = namespace(root);
+        if (!rootName.equals(actualRootName)
+                || !normalize(rootNamespace).equals(actualRootNamespace)) {
+            throw new IOException(
+                "Unexpected XML root {" + actualRootNamespace + "}" + actualRootName
+                    + "; expected {" + normalize(rootNamespace) + "}" + rootName);
+        }
+
+        Map<String, FieldRule> attributes = new HashMap<>();
+        Map<String, FieldRule> elements = new HashMap<>();
+        for (FieldRule rule : rules) {
+            if (rule.kind() == FieldKind.ATTRIBUTE) {
+                attributes.put(rule.name(), rule);
+            } else {
+                elements.put(rule.name(), rule);
+            }
+        }
+
+        Set<String> presentAttributes = new HashSet<>();
+        NamedNodeMap rootAttributes = root.getAttributes();
+        for (int index = 0; index < rootAttributes.getLength(); index++) {
+            Attr attribute = (Attr) rootAttributes.item(index);
+            if (XMLConstants.XMLNS_ATTRIBUTE_NS_URI.equals(attribute.getNamespaceURI())) {
+                continue;
+            }
+            FieldRule rule = attributes.get(localName(attribute));
+            if (rule == null || !namespace(attribute).isEmpty()) {
+                throw new IOException(
+                    "Unknown XML attribute {" + namespace(attribute) + "}"
+                        + localName(attribute));
+            }
+            presentAttributes.add(rule.name());
+        }
+
+        Map<String, Integer> counts = new HashMap<>();
+        NodeList children = root.getChildNodes();
+        for (int index = 0; index < children.getLength(); index++) {
+            Node child = children.item(index);
+            if (child.getNodeType() != Node.ELEMENT_NODE) {
+                if (child.getNodeType() == Node.TEXT_NODE
+                        && !child.getTextContent().isBlank()) {
+                    throw new IOException("Unexpected text in XML record");
+                }
+                continue;
+            }
+            Element element = (Element) child;
+            FieldRule rule = elements.get(localName(element));
+            if (rule == null) {
+                throw new IOException(
+                    "Unknown XML element {" + namespace(element) + "}"
+                        + localName(element));
+            }
+            if (!normalize(rule.namespace()).equals(namespace(element))) {
+                throw new IOException(
+                    "Wrong namespace for XML element " + rule.name());
+            }
+            int count = counts.merge(rule.name(), 1, Integer::sum);
+            if (rule.kind() != FieldKind.COLLECTION && count > 1) {
+                throw new IOException("Duplicate XML field " + rule.name());
+            }
+            validateFieldValue(element, rule);
+        }
+
+        for (FieldRule rule : rules) {
+            if (!rule.required()) {
+                continue;
+            }
+            boolean present = rule.kind() == FieldKind.ATTRIBUTE
+                ? presentAttributes.contains(rule.name())
+                : counts.containsKey(rule.name());
+            if (!present) {
+                throw new IOException("Missing required XML field " + rule.name());
+            }
+        }
+    }
+
+    private static void validateFieldValue(
+            Element element,
+            FieldRule rule) throws IOException {
+        if (rule.kind() == FieldKind.MAP_SCALAR
+                || rule.kind() == FieldKind.MAP_OBJECT) {
+            validateMap(element, rule.kind() == FieldKind.MAP_SCALAR);
+        } else if (rule.kind() == FieldKind.UNION_CONTAINER) {
+            int values = populatedElementChildren(element);
+            if (values != 1) {
+                throw new IOException(
+                    "Ambiguous XML union " + rule.name()
+                        + " must contain exactly one value");
+            }
+        } else if (rule.kind() == FieldKind.UNION_SCALAR
+                && elementChildren(element) != 0) {
+            throw new IOException(
+                "Ambiguous XML union " + rule.name() + " must contain a scalar value");
+        }
+    }
+
+    private static void validateMap(
+            Element map,
+            boolean scalarValues) throws IOException {
+        if (hasNonWhitespaceText(map)) {
+            throw new IOException("Malformed XML map value");
+        }
+        Set<String> keys = new HashSet<>();
+        NodeList entries = map.getChildNodes();
+        for (int index = 0; index < entries.getLength(); index++) {
+            Node node = entries.item(index);
+            if (node.getNodeType() != Node.ELEMENT_NODE) {
+                continue;
+            }
+            Element entry = (Element) node;
+            String key = localName(entry);
+            if (!keys.add(key)) {
+                throw new IOException("Duplicate XML map key " + key);
+            }
+            if (scalarValues && elementChildren(entry) != 0) {
+                throw new IOException("Malformed scalar XML map entry " + key);
+            }
+        }
+    }
+
+    private static boolean hasNonWhitespaceText(Element element) {
+        NodeList children = element.getChildNodes();
+        for (int index = 0; index < children.getLength(); index++) {
+            Node child = children.item(index);
+            if (child.getNodeType() == Node.TEXT_NODE
+                    && !child.getTextContent().isBlank()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static int elementChildren(Element element) {
+        int count = 0;
+        NodeList children = element.getChildNodes();
+        for (int index = 0; index < children.getLength(); index++) {
+            if (children.item(index).getNodeType() == Node.ELEMENT_NODE) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static int populatedElementChildren(Element element) {
+        int count = 0;
+        NodeList children = element.getChildNodes();
+        for (int index = 0; index < children.getLength(); index++) {
+            Node child = children.item(index);
+            if (child.getNodeType() != Node.ELEMENT_NODE) {
+                continue;
+            }
+            Element value = (Element) child;
+            if (hasDataAttributes(value)
+                    || elementChildren(value) != 0
+                    || !value.getTextContent().isBlank()) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static boolean hasDataAttributes(Element element) {
+        NamedNodeMap attributes = element.getAttributes();
+        for (int index = 0; index < attributes.getLength(); index++) {
+            Node attribute = attributes.item(index);
+            if (!XMLConstants.XMLNS_ATTRIBUTE_NS_URI.equals(
+                    attribute.getNamespaceURI())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String localName(Node node) {
+        return node.getLocalName() != null ? node.getLocalName() : node.getNodeName();
+    }
+
+    private static String namespace(Node node) {
+        return normalize(node.getNamespaceURI());
+    }
+
+    private static String normalize(String namespace) {
+        return namespace == null ? "" : namespace;
     }
 }

--- a/avrotize/java/xml_support.java.jinja
+++ b/avrotize/java/xml_support.java.jinja
@@ -1,0 +1,14 @@
+public final class AvrotizeXmlSupport {
+    public static final XmlMapper MAPPER = createMapper();
+
+    private AvrotizeXmlSupport() {
+    }
+
+    private static XmlMapper createMapper() {
+        XmlMapper mapper = new XmlMapper();
+        mapper.setAnnotationIntrospector(
+            new JakartaXmlBindAnnotationIntrospector(mapper.getTypeFactory()));
+        mapper.findAndRegisterModules();
+        return mapper;
+    }
+}

--- a/avrotize/structuretojava.py
+++ b/avrotize/structuretojava.py
@@ -595,12 +595,7 @@ class StructureToJava:
             return ''
 
         code = "\n"
-        if self.xml_annotations:
-            code += f"{INDENT}private static XmlMapper createXmlMapper() {{\n"
-            code += f"{INDENT*2}XmlMapper mapper = new XmlMapper();\n"
-            code += f"{INDENT*2}mapper.setAnnotationIntrospector(new JakartaXmlBindAnnotationIntrospector(mapper.getTypeFactory()));\n"
-            code += f"{INDENT*2}mapper.findAndRegisterModules();\n"
-            code += f"{INDENT*2}return mapper;\n{INDENT}}}\n\n"
+        xml_mapper = self.xml_mapper_reference()
 
         code += f"{INDENT}public byte[] toByteArray(String contentType) throws IOException {{\n"
         code += f"{INDENT*2}String mediaType = contentType.split(\";\")[0].trim().toLowerCase();\n"
@@ -619,7 +614,7 @@ class StructureToJava:
             if not self.jackson_annotations:
                 code += f"{INDENT*2}"
             code += "if (mediaType.equals(\"application/xml\") || mediaType.equals(\"text/xml\")) {\n"
-            code += f"{INDENT*3}result = createXmlMapper().writeValueAsBytes(this);\n"
+            code += f"{INDENT*3}result = {xml_mapper}.writeValueAsBytes(this);\n"
             code += f"{INDENT*2}}}\n"
         code += f"{INDENT*2}else {{\n"
         code += f"{INDENT*3}throw new UnsupportedOperationException(\"Unsupported media type \" + contentType);\n"
@@ -655,10 +650,9 @@ class StructureToJava:
             code += f"{INDENT*2}}}\n"
         if self.xml_annotations:
             code += f"{INDENT*2}if (mediaType.equals(\"application/xml\") || mediaType.equals(\"text/xml\")) {{\n"
-            code += f"{INDENT*3}XmlMapper mapper = createXmlMapper();\n"
-            code += f"{INDENT*3}if (data instanceof byte[]) return mapper.readValue((byte[]) data, {class_name}.class);\n"
-            code += f"{INDENT*3}if (data instanceof InputStream) return mapper.readValue((InputStream) data, {class_name}.class);\n"
-            code += f"{INDENT*3}if (data instanceof String) return mapper.readValue((String) data, {class_name}.class);\n"
+            code += f"{INDENT*3}if (data instanceof byte[]) return {xml_mapper}.readValue((byte[]) data, {class_name}.class);\n"
+            code += f"{INDENT*3}if (data instanceof InputStream) return {xml_mapper}.readValue((InputStream) data, {class_name}.class);\n"
+            code += f"{INDENT*3}if (data instanceof String) return {xml_mapper}.readValue((String) data, {class_name}.class);\n"
             code += f"{INDENT*3}throw new UnsupportedOperationException(\"Data is not of a supported type for XML conversion to {class_name}\");\n"
             code += f"{INDENT*2}}}\n"
         code += f"{INDENT*2}throw new UnsupportedOperationException(\"Unsupported media type \" + contentType);\n"
@@ -918,6 +912,23 @@ class StructureToJava:
             file.write(")\n")
             file.write(f"package {package_name};\n")
 
+    def xml_support_package(self) -> str:
+        """Return the package containing the project-wide XML runtime holder."""
+        package = self.safe_package(self.base_package.replace('.', '/').lower())
+        return package.replace('/', '.') or 'avrotize.generated.xml'
+
+    def xml_mapper_reference(self) -> str:
+        """Return the shared generated XmlMapper field reference."""
+        return f"{self.xml_support_package()}.AvrotizeXmlSupport.MAPPER"
+
+    def write_xml_support(self) -> None:
+        """Generate one cached XML mapper holder for the output project."""
+        definition = process_template("java/xml_support.java.jinja")
+        self.write_to_file(
+            self.xml_support_package().replace('.', '/'),
+            "AvrotizeXmlSupport",
+            definition)
+
     def write_to_file(self, package: str, name: str, definition: str):
         """ Writes a Java class or enum to a file """
         package = package.lower()
@@ -1062,6 +1073,8 @@ class StructureToJava:
         if not os.path.exists(output_dir):
             os.makedirs(output_dir, exist_ok=True)
         self.output_dir = output_dir
+        if self.xml_annotations:
+            self.write_xml_support()
         
         # Register all schemas with $id keywords
         for structure_schema in (x for x in schema if isinstance(x, dict)):

--- a/avrotize/structuretojava.py
+++ b/avrotize/structuretojava.py
@@ -4,9 +4,10 @@
 import json
 import os
 from typing import Dict, List, Tuple, Union, Set, Optional, Any
-from avrotize.constants import JACKSON_VERSION, JACKSON_ANNOTATIONS_VERSION
+from avrotize.constants import JACKSON_VERSION, JACKSON_ANNOTATIONS_VERSION, JAKARTA_XML_BIND_VERSION
 
-from avrotize.common import pascal, camel, process_template, json_wire_name, json_enum_wire_value
+from avrotize.common import (pascal, camel, process_template, json_wire_name,
+                             json_enum_wire_value, xml_wire_name, xml_enum_wire_value)
 
 INDENT = '    '
 
@@ -35,17 +36,19 @@ def is_java_reserved_word(word: str) -> bool:
 
 
 class StructureToJava:
-    """Converts JSON Structure schema to Java classes, including Jackson annotations"""
+    """Converts JSON Structure schema to Java classes with JSON and XML support."""
 
     def __init__(self, base_package: str = '') -> None:
         self.base_package = base_package.replace('.', '/')
         self.output_dir = os.getcwd()
         self.jackson_annotations = True  # Always use Jackson annotations for JSON Structure
+        self.xml_annotations = False
         self.pascal_properties = False
         self.generated_types_structure_namespace: Dict[str,str] = {}
         self.generated_types_java_package: Dict[str,str] = {}
         self.schema_doc: JsonNode = None
         self.schema_registry: Dict[str, Dict] = {}
+        self.xml_package_namespaces: Dict[str, str] = {}
 
     def qualified_name(self, package: str, name: str) -> str:
         """Concatenates package and name using a dot separator"""
@@ -345,6 +348,10 @@ class StructureToJava:
         package = package.replace('.', '/').lower()
         package = self.safe_package(package)
         class_name = self.safe_identifier(class_name)
+        xml_namespace = str(structure_schema.get('xmlns', ''))
+        xml_name = xml_wire_name(
+            str(explicit_name if explicit_name else structure_schema.get('name', 'UnnamedClass')),
+            structure_schema)
         namespace_qualified_name = self.qualified_name(schema_namespace, explicit_name or structure_schema.get('name', 'UnnamedClass'))
         qualified_class_name = self.qualified_name(package.replace('/', '.'), class_name)
         if namespace_qualified_name in self.generated_types_structure_namespace:
@@ -374,7 +381,7 @@ class StructureToJava:
         # Generate field information for template
         fields = []
         for prop_name, prop_schema in structure_schema.get('properties', {}).items():
-            field_info = self.generate_field_info(class_name, prop_name, prop_schema, schema_namespace)
+            field_info = self.generate_field_info(class_name, prop_name, prop_schema, schema_namespace, xml_namespace)
             fields.append(field_info)
         
         # Use template for class generation
@@ -386,7 +393,10 @@ class StructureToJava:
             deprecated=deprecated,
             base_class=base_class,
             fields=fields,
-            jackson_annotation=self.jackson_annotations
+            jackson_annotation=self.jackson_annotations,
+            xml_annotation=self.xml_annotations,
+            xml_name=json.dumps(xml_name),
+            xml_namespace=json.dumps(xml_namespace)
         )
         
         # Generate Equals and GetHashCode using template
@@ -409,14 +419,19 @@ class StructureToJava:
         create_test_instance = ''
         if not is_abstract:
             create_test_instance = self.generate_create_test_instance_method(class_name, fields, schema_namespace)
+
+        serialization_methods = self.generate_serialization_methods(class_name)
         
-        class_definition = class_definition.rstrip() + create_test_instance + equals_hashcode + "\n}\n"
+        class_definition = class_definition.rstrip() + create_test_instance + serialization_methods + equals_hashcode + "\n}\n"
 
         if write_file:
+            if self.xml_annotations and xml_namespace:
+                self.write_package_info(package, xml_namespace)
             self.write_to_file(package, class_name, class_definition)
         return StructureToJava.JavaType(qualified_class_name, is_class=True)
 
-    def generate_field_info(self, class_name: str, prop_name: str, prop_schema: Dict, parent_package: str) -> Dict:
+    def generate_field_info(self, class_name: str, prop_name: str, prop_schema: Dict,
+                            parent_package: str, xml_namespace: str = '') -> Dict:
         """ Generates field information for template """
         field_name_java = pascal(prop_name) if self.pascal_properties else prop_name
         field_type = self.convert_structure_type_to_java(class_name, prop_name, prop_schema, parent_package)
@@ -451,7 +466,10 @@ class StructureToJava:
             'source_type': source_type,
             'docstring': doc,
             'is_const': is_const,
-            'const_value': const_value
+            'const_value': const_value,
+            'xml_name': json.dumps(xml_wire_name(prop_name, prop_schema)),
+            'xml_namespace': json.dumps(xml_namespace),
+            'xmlkind': prop_schema.get('xmlkind', 'element')
         }
     
     def generate_property(self, class_name: str, field: Tuple[str, Dict], parent_package: str) -> str:
@@ -571,6 +589,82 @@ class StructureToJava:
         method += f"{INDENT}}}\n"
         return method
 
+    def generate_serialization_methods(self, class_name: str) -> str:
+        """Generate JSON/XML content-type serialization helpers."""
+        if not self.jackson_annotations and not self.xml_annotations:
+            return ''
+
+        code = "\n"
+        if self.xml_annotations:
+            code += f"{INDENT}private static XmlMapper createXmlMapper() {{\n"
+            code += f"{INDENT*2}XmlMapper mapper = new XmlMapper();\n"
+            code += f"{INDENT*2}mapper.setAnnotationIntrospector(new JakartaXmlBindAnnotationIntrospector(mapper.getTypeFactory()));\n"
+            code += f"{INDENT*2}mapper.findAndRegisterModules();\n"
+            code += f"{INDENT*2}return mapper;\n{INDENT}}}\n\n"
+
+        code += f"{INDENT}public byte[] toByteArray(String contentType) throws IOException {{\n"
+        code += f"{INDENT*2}String mediaType = contentType.split(\";\")[0].trim().toLowerCase();\n"
+        code += f"{INDENT*2}boolean shouldCompress = mediaType.endsWith(\"+gzip\");\n"
+        code += f"{INDENT*2}if (shouldCompress) mediaType = mediaType.substring(0, mediaType.length() - 5);\n"
+        code += f"{INDENT*2}byte[] result;\n"
+        if self.jackson_annotations:
+            code += f"{INDENT*2}if (mediaType.equals(\"application/json\")) {{\n"
+            code += f"{INDENT*3}result = new ObjectMapper().findAndRegisterModules().writeValueAsBytes(this);\n"
+            code += f"{INDENT*2}}}"
+            if self.xml_annotations:
+                code += " else "
+            else:
+                code += "\n"
+        if self.xml_annotations:
+            if not self.jackson_annotations:
+                code += f"{INDENT*2}"
+            code += "if (mediaType.equals(\"application/xml\") || mediaType.equals(\"text/xml\")) {\n"
+            code += f"{INDENT*3}result = createXmlMapper().writeValueAsBytes(this);\n"
+            code += f"{INDENT*2}}}\n"
+        code += f"{INDENT*2}else {{\n"
+        code += f"{INDENT*3}throw new UnsupportedOperationException(\"Unsupported media type \" + contentType);\n"
+        code += f"{INDENT*2}}}\n"
+        code += f"{INDENT*2}if (!shouldCompress) return result;\n"
+        code += f"{INDENT*2}try (ByteArrayOutputStream output = new ByteArrayOutputStream();\n"
+        code += f"{INDENT*3}GZIPOutputStream gzip = new GZIPOutputStream(output)) {{\n"
+        code += f"{INDENT*3}gzip.write(result);\n{INDENT*3}gzip.finish();\n"
+        code += f"{INDENT*3}return output.toByteArray();\n{INDENT*2}}}\n"
+        code += f"{INDENT}}}\n\n"
+
+        code += f"{INDENT}public static {class_name} fromData(Object data, String contentType) throws IOException {{\n"
+        code += f"{INDENT*2}if (data instanceof {class_name}) return ({class_name}) data;\n"
+        code += f"{INDENT*2}String mediaType = contentType.split(\";\")[0].trim().toLowerCase();\n"
+        code += f"{INDENT*2}if (mediaType.endsWith(\"+gzip\")) {{\n"
+        code += f"{INDENT*3}mediaType = mediaType.substring(0, mediaType.length() - 5);\n"
+        code += f"{INDENT*3}InputStream input;\n"
+        code += f"{INDENT*3}if (data instanceof byte[]) input = new ByteArrayInputStream((byte[]) data);\n"
+        code += f"{INDENT*3}else if (data instanceof InputStream) input = (InputStream) data;\n"
+        code += f"{INDENT*3}else throw new UnsupportedOperationException(\"Data is not of a supported type for gzip decompression\");\n"
+        code += f"{INDENT*3}try (GZIPInputStream gzip = new GZIPInputStream(input);\n"
+        code += f"{INDENT*4}ByteArrayOutputStream output = new ByteArrayOutputStream()) {{\n"
+        code += f"{INDENT*4}gzip.transferTo(output);\n{INDENT*4}data = output.toByteArray();\n{INDENT*3}}}\n"
+        code += f"{INDENT*2}}}\n"
+        if self.jackson_annotations:
+            code += f"{INDENT*2}if (mediaType.equals(\"application/json\")) {{\n"
+            code += f"{INDENT*3}ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();\n"
+            code += f"{INDENT*3}if (data instanceof byte[]) return mapper.readValue((byte[]) data, {class_name}.class);\n"
+            code += f"{INDENT*3}if (data instanceof InputStream) return mapper.readValue((InputStream) data, {class_name}.class);\n"
+            code += f"{INDENT*3}if (data instanceof JsonNode) return mapper.treeToValue((JsonNode) data, {class_name}.class);\n"
+            code += f"{INDENT*3}if (data instanceof String) return mapper.readValue((String) data, {class_name}.class);\n"
+            code += f"{INDENT*3}throw new UnsupportedOperationException(\"Data is not of a supported type for JSON conversion to {class_name}\");\n"
+            code += f"{INDENT*2}}}\n"
+        if self.xml_annotations:
+            code += f"{INDENT*2}if (mediaType.equals(\"application/xml\") || mediaType.equals(\"text/xml\")) {{\n"
+            code += f"{INDENT*3}XmlMapper mapper = createXmlMapper();\n"
+            code += f"{INDENT*3}if (data instanceof byte[]) return mapper.readValue((byte[]) data, {class_name}.class);\n"
+            code += f"{INDENT*3}if (data instanceof InputStream) return mapper.readValue((InputStream) data, {class_name}.class);\n"
+            code += f"{INDENT*3}if (data instanceof String) return mapper.readValue((String) data, {class_name}.class);\n"
+            code += f"{INDENT*3}throw new UnsupportedOperationException(\"Data is not of a supported type for XML conversion to {class_name}\");\n"
+            code += f"{INDENT*2}}}\n"
+        code += f"{INDENT*2}throw new UnsupportedOperationException(\"Unsupported media type \" + contentType);\n"
+        code += f"{INDENT}}}\n"
+        return code
+
     def generate_enum(self, structure_schema: Dict, field_name: str, parent_package: str, write_file: bool) -> JavaType:
         """ Generates a Java enum from JSON Structure enum schema """
         
@@ -579,6 +673,8 @@ class StructureToJava:
         schema_namespace = structure_schema.get('namespace', parent_package)
         package = self.join_packages(self.base_package, schema_namespace).replace('.', '/').lower()       
         enum_name = self.safe_identifier(enum_name)
+        xml_namespace = str(structure_schema.get('xmlns', ''))
+        xml_name = xml_wire_name(str(structure_schema.get('name', field_name + 'Enum')), structure_schema)
         type_name = self.qualified_name(package.replace('/', '.'), enum_name)
         namespace_qualified_name = self.qualified_name(schema_namespace, structure_schema.get('name', field_name + 'Enum'))
         self.generated_types_structure_namespace[namespace_qualified_name] = "enum"
@@ -600,7 +696,9 @@ class StructureToJava:
         
         if is_numeric:
             java_base_type = self.map_primitive_to_java(base_type, False).type_name
-            symbol_list = [{'name': f"VALUE_{value}".upper(), 'value': value} for value in symbols]
+            symbol_list = [{'name': f"VALUE_{value}".upper(), 'value': value,
+                            'xml_value': json.dumps(xml_enum_wire_value(value, structure_schema))}
+                           for value in symbols]
             enum_definition = process_template(
                 "structuretojava/enum_core.jinja",
                 class_name=enum_name,
@@ -608,22 +706,32 @@ class StructureToJava:
                 deprecated=deprecated,
                 is_numeric=True,
                 numeric_type=java_base_type,
-                symbols=symbol_list
+                symbols=symbol_list,
+                xml_annotation=self.xml_annotations,
+                xml_name=json.dumps(xml_name),
+                xml_namespace=json.dumps(xml_namespace)
             )
         else:
             # String enum — member name from original value; JSON wire value via altenums.json
             symbol_list = [{'name': self.safe_identifier(pascal(str(symbol).replace('-', '_').replace(' ', '_'))),
-                            'value': json_enum_wire_value(symbol, structure_schema)} for symbol in symbols]
+                            'value': json_enum_wire_value(symbol, structure_schema),
+                            'xml_value': json.dumps(xml_enum_wire_value(symbol, structure_schema))}
+                           for symbol in symbols]
             enum_definition = process_template(
                 "structuretojava/enum_core.jinja",
                 class_name=enum_name,
                 docstring=doc,
                 deprecated=deprecated,
                 is_numeric=False,
-                symbols=symbol_list
+                symbols=symbol_list,
+                xml_annotation=self.xml_annotations,
+                xml_name=json.dumps(xml_name),
+                xml_namespace=json.dumps(xml_namespace)
             )
         
         if write_file:
+            if self.xml_annotations and xml_namespace:
+                self.write_package_info(package, xml_namespace)
             self.write_to_file(package, enum_name, enum_definition)
         return StructureToJava.JavaType(type_name, is_enum=True)
 
@@ -789,6 +897,27 @@ class StructureToJava:
         
         return code
 
+    def write_package_info(self, package: str, xml_namespace: str) -> None:
+        """Write JAXB package metadata for a package's default XML namespace."""
+        package = self.safe_package(package.lower())
+        package_name = package.replace('/', '.')
+        if not package_name:
+            return
+        previous = self.xml_package_namespaces.get(package_name)
+        if previous is not None and previous != xml_namespace:
+            return
+        self.xml_package_namespaces[package_name] = xml_namespace
+        directory_path = os.path.join(
+            self.output_dir, package.replace('.', os.sep).replace('/', os.sep))
+        os.makedirs(directory_path, exist_ok=True)
+        package_info_path = os.path.join(directory_path, "package-info.java")
+        with open(package_info_path, 'w', encoding='utf-8') as file:
+            file.write("@jakarta.xml.bind.annotation.XmlSchema(\n")
+            file.write(f"    namespace = {json.dumps(xml_namespace)},\n")
+            file.write("    elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED\n")
+            file.write(")\n")
+            file.write(f"package {package_name};\n")
+
     def write_to_file(self, package: str, name: str, definition: str):
         """ Writes a Java class or enum to a file """
         package = package.lower()
@@ -871,6 +1000,39 @@ class StructureToJava:
                     file.write("import com.fasterxml.jackson.core.JsonGenerator;\n")
                 if 'TypeReference' in definition:
                     file.write("import com.fasterxml.jackson.core.type.TypeReference;\n")
+            if self.xml_annotations:
+                if 'XmlRootElement' in definition:
+                    file.write("import jakarta.xml.bind.annotation.XmlRootElement;\n")
+                if 'XmlType' in definition:
+                    file.write("import jakarta.xml.bind.annotation.XmlType;\n")
+                if 'XmlAccessorType' in definition:
+                    file.write("import jakarta.xml.bind.annotation.XmlAccessorType;\n")
+                    file.write("import jakarta.xml.bind.annotation.XmlAccessType;\n")
+                if 'XmlElement' in definition:
+                    file.write("import jakarta.xml.bind.annotation.XmlElement;\n")
+                if 'XmlAttribute' in definition:
+                    file.write("import jakarta.xml.bind.annotation.XmlAttribute;\n")
+                if 'XmlEnumValue' in definition:
+                    file.write("import jakarta.xml.bind.annotation.XmlEnumValue;\n")
+                if '@XmlEnum' in definition:
+                    file.write("import jakarta.xml.bind.annotation.XmlEnum;\n")
+                if 'XmlMapper' in definition:
+                    file.write("import com.fasterxml.jackson.dataformat.xml.XmlMapper;\n")
+                if 'JakartaXmlBindAnnotationIntrospector' in definition:
+                    file.write("import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationIntrospector;\n")
+            if self.jackson_annotations or self.xml_annotations:
+                if 'GZIPOutputStream' in definition:
+                    file.write("import java.util.zip.GZIPOutputStream;\n")
+                if 'GZIPInputStream' in definition:
+                    file.write("import java.util.zip.GZIPInputStream;\n")
+                if 'ByteArrayInputStream' in definition:
+                    file.write("import java.io.ByteArrayInputStream;\n")
+                if 'ByteArrayOutputStream' in definition:
+                    file.write("import java.io.ByteArrayOutputStream;\n")
+                if 'InputStream' in definition:
+                    file.write("import java.io.InputStream;\n")
+                if 'IOException' in definition:
+                    file.write("import java.io.IOException;\n")
             file.write("\n")
             file.write(definition)
 
@@ -890,7 +1052,8 @@ class StructureToJava:
                 groupid=groupid,
                 artifactid=artifactid,
                 jackson_version=JACKSON_VERSION,
-                jackson_annotations_version=JACKSON_ANNOTATIONS_VERSION
+                jackson_annotations_version=JACKSON_ANNOTATIONS_VERSION,
+                jakarta_xml_bind_version=JAKARTA_XML_BIND_VERSION
             )
             with open(pom_path, 'w', encoding='utf-8') as file:
                 file.write(pom_content)
@@ -933,7 +1096,9 @@ class StructureToJava:
         self.convert_schema(schema, output_dir)
 
 
-def convert_structure_to_java(structure_schema_path, java_file_path, package_name='', pascal_properties=False, jackson_annotation=True):
+def convert_structure_to_java(structure_schema_path, java_file_path, package_name='',
+                              pascal_properties=False, jackson_annotation=True,
+                              xml_annotation=False):
     """
     Converts JSON Structure schema to Java classes
 
@@ -943,6 +1108,7 @@ def convert_structure_to_java(structure_schema_path, java_file_path, package_nam
         package_name: Base package name
         pascal_properties: Use PascalCase for properties
         jackson_annotation: Add Jackson annotations (always True for Structure)
+        xml_annotation: Add Jakarta JAXB annotations and XML serialization helpers
     """
     if not package_name:
         package_name = os.path.splitext(os.path.basename(java_file_path))[0].replace('-', '_').lower()
@@ -950,10 +1116,13 @@ def convert_structure_to_java(structure_schema_path, java_file_path, package_nam
     structuretojava.base_package = package_name
     structuretojava.pascal_properties = pascal_properties
     structuretojava.jackson_annotations = jackson_annotation
+    structuretojava.xml_annotations = xml_annotation
     structuretojava.convert(structure_schema_path, java_file_path)
 
 
-def convert_structure_schema_to_java(structure_schema: JsonNode, output_dir: str, package_name='', pascal_properties=False, jackson_annotation=True):
+def convert_structure_schema_to_java(structure_schema: JsonNode, output_dir: str, package_name='',
+                                     pascal_properties=False, jackson_annotation=True,
+                                     xml_annotation=False):
     """
     Converts JSON Structure schema to Java classes
 
@@ -963,9 +1132,11 @@ def convert_structure_schema_to_java(structure_schema: JsonNode, output_dir: str
         package_name: Base package name
         pascal_properties: Use PascalCase for properties
         jackson_annotation: Add Jackson annotations (always True for Structure)
+        xml_annotation: Add Jakarta JAXB annotations and XML serialization helpers
     """
     structuretojava = StructureToJava()
     structuretojava.base_package = package_name
     structuretojava.pascal_properties = pascal_properties
     structuretojava.jackson_annotations = jackson_annotation
+    structuretojava.xml_annotations = xml_annotation
     structuretojava.convert_schema(structure_schema, output_dir)

--- a/avrotize/structuretojava.py
+++ b/avrotize/structuretojava.py
@@ -420,9 +420,18 @@ class StructureToJava:
         if not is_abstract:
             create_test_instance = self.generate_create_test_instance_method(class_name, fields, schema_namespace)
 
-        serialization_methods = self.generate_serialization_methods(class_name)
+        xml_validation_metadata = ''
+        if self.xml_annotations:
+            xml_validation_metadata = self.generate_xml_validation_metadata(
+                structure_schema, xml_namespace)
+
+        serialization_methods = self.generate_serialization_methods(
+            class_name, xml_name, xml_namespace)
         
-        class_definition = class_definition.rstrip() + create_test_instance + serialization_methods + equals_hashcode + "\n}\n"
+        class_definition = (
+            class_definition.rstrip() + create_test_instance
+            + xml_validation_metadata + serialization_methods
+            + equals_hashcode + "\n}\n")
 
         if write_file:
             if self.xml_annotations and xml_namespace:
@@ -589,7 +598,73 @@ class StructureToJava:
         method += f"{INDENT}}}\n"
         return method
 
-    def generate_serialization_methods(self, class_name: str) -> str:
+    def is_structure_xml_scalar(self, structure_type) -> bool:
+        """Return whether a JSON Structure type has a scalar XML representation."""
+        if isinstance(structure_type, str):
+            return structure_type not in ('object', 'array', 'set', 'map', 'choice', 'tuple')
+        if isinstance(structure_type, list):
+            non_null = [item for item in structure_type if item != 'null']
+            return all(self.is_structure_xml_scalar(item) for item in non_null)
+        if isinstance(structure_type, dict):
+            if 'enum' in structure_type:
+                return True
+            return self.is_structure_xml_scalar(
+                structure_type.get('type', 'object'))
+        return False
+
+    def structure_xml_field_kind(self, prop_schema: Dict) -> str:
+        """Return the generated XML validation kind for a Structure property."""
+        structure_type = prop_schema.get('type', 'object')
+        if isinstance(structure_type, list):
+            non_null = [item for item in structure_type if item != 'null']
+            if len(non_null) > 1:
+                return "UNION_SCALAR" if all(
+                    self.is_structure_xml_scalar(item) for item in non_null
+                ) else "UNION_CONTAINER"
+            if non_null:
+                return self.structure_xml_field_kind({'type': non_null[0]})
+        if structure_type in ('array', 'set'):
+            return "COLLECTION"
+        if structure_type == 'map':
+            return "MAP_SCALAR" if self.is_structure_xml_scalar(
+                prop_schema.get('values', {'type': 'any'})) else "MAP_OBJECT"
+        return "SINGLE"
+
+    def generate_xml_validation_metadata(
+            self, structure_schema: Dict, xml_namespace: str) -> str:
+        """Generate schema-derived validation rules for XML input."""
+        support = f"{self.xml_support_package()}.AvrotizeXmlSupport"
+        required_props = structure_schema.get('required', [])
+        if required_props and isinstance(required_props[0], list):
+            required_names = set.intersection(
+                *(set(required_set) for required_set in required_props))
+        else:
+            required_names = set(required_props)
+        rules = []
+        for prop_name, prop_schema in structure_schema.get('properties', {}).items():
+            xml_name = json.dumps(xml_wire_name(prop_name, prop_schema))
+            required = prop_name in required_names and 'const' not in prop_schema
+            if prop_schema.get('xmlkind', 'element') == 'attribute':
+                rules.append(
+                    f"{support}.FieldRule.attribute({xml_name}, "
+                    f"{str(required).lower()})")
+                continue
+            kind = self.structure_xml_field_kind(prop_schema)
+            if kind == "COLLECTION":
+                required = False
+            rules.append(
+                f"{support}.FieldRule.element({xml_name}, "
+                f"{json.dumps(xml_namespace)}, {str(required).lower()}, "
+                f"{support}.FieldKind.{kind})")
+        joined = f",\n{INDENT*2}".join(rules)
+        return (
+            f"\n{INDENT}private static final {support}.FieldRule[] "
+            f"XML_FIELD_RULES = new {support}.FieldRule[] {{\n"
+            f"{INDENT*2}{joined}\n{INDENT}}};\n")
+
+    def generate_serialization_methods(
+            self, class_name: str, xml_name: str = '',
+            xml_namespace: str = '') -> str:
         """Generate JSON/XML content-type serialization helpers."""
         if not self.jackson_annotations and not self.xml_annotations:
             return ''
@@ -650,10 +725,8 @@ class StructureToJava:
             code += f"{INDENT*2}}}\n"
         if self.xml_annotations:
             code += f"{INDENT*2}if (mediaType.equals(\"application/xml\") || mediaType.equals(\"text/xml\")) {{\n"
-            code += f"{INDENT*3}if (data instanceof byte[]) return {xml_mapper}.readValue((byte[]) data, {class_name}.class);\n"
-            code += f"{INDENT*3}if (data instanceof InputStream) return {xml_mapper}.readValue((InputStream) data, {class_name}.class);\n"
-            code += f"{INDENT*3}if (data instanceof String) return {xml_mapper}.readValue((String) data, {class_name}.class);\n"
-            code += f"{INDENT*3}throw new UnsupportedOperationException(\"Data is not of a supported type for XML conversion to {class_name}\");\n"
+            support = f"{self.xml_support_package()}.AvrotizeXmlSupport"
+            code += f"{INDENT*3}return {support}.readValue(data, {class_name}.class, {json.dumps(xml_name)}, {json.dumps(xml_namespace)}, XML_FIELD_RULES);\n"
             code += f"{INDENT*2}}}\n"
         code += f"{INDENT*2}throw new UnsupportedOperationException(\"Unsupported media type \" + contentType);\n"
         code += f"{INDENT}}}\n"
@@ -923,11 +996,15 @@ class StructureToJava:
 
     def write_xml_support(self) -> None:
         """Generate one cached XML mapper holder for the output project."""
-        definition = process_template("java/xml_support.java.jinja")
-        self.write_to_file(
-            self.xml_support_package().replace('.', '/'),
-            "AvrotizeXmlSupport",
-            definition)
+        package = self.xml_support_package()
+        definition = process_template(
+            "java/xml_support.java.jinja", package=package)
+        directory_path = os.path.join(
+            self.output_dir, package.replace('.', os.sep))
+        os.makedirs(directory_path, exist_ok=True)
+        with open(os.path.join(directory_path, "AvrotizeXmlSupport.java"),
+                  'w', encoding='utf-8') as file:
+            file.write(definition)
 
     def write_to_file(self, package: str, name: str, definition: str):
         """ Writes a Java class or enum to a file """

--- a/avrotize/structuretojava/class_core.jinja
+++ b/avrotize/structuretojava/class_core.jinja
@@ -5,6 +5,11 @@
 {%- if deprecated %}
 @Deprecated
 {%- endif %}
+{%- if xml_annotation %}
+@XmlRootElement(name = {{ xml_name }}{% if xml_namespace != '""' %}, namespace = {{ xml_namespace }}{% endif %})
+@XmlType(name = {{ xml_name }}{% if xml_namespace != '""' %}, namespace = {{ xml_namespace }}{% endif %})
+@XmlAccessorType(XmlAccessType.FIELD)
+{%- endif %}
 public {{ 'abstract ' if is_abstract else '' }}class {{ class_name }}{% if base_class %} extends {{ base_class }}{% endif %} {
     {% if is_abstract %}protected{% else %}public{% endif %} {{ class_name }}() {}
 {%- for field in fields %}
@@ -15,6 +20,11 @@ public {{ 'abstract ' if is_abstract else '' }}class {{ class_name }}{% if base_
 {%- endif %}
 {%- if jackson_annotation and field.source_type in ['int64', 'uint64', 'int128', 'uint128', 'decimal'] %}
     @JsonFormat(shape = JsonFormat.Shape.STRING)
+{%- endif %}
+{%- if xml_annotation and field.xmlkind == 'attribute' %}
+    @XmlAttribute(name = {{ field.xml_name }})
+{%- elif xml_annotation %}
+    @XmlElement(name = {{ field.xml_name }}{% if field.xml_namespace != '""' %}, namespace = {{ field.xml_namespace }}{% endif %})
 {%- endif %}
 {%- if field.is_const %}
     public static final {{ field.type }} {{ field.name }} = {{ field.const_value }};

--- a/avrotize/structuretojava/enum_core.jinja
+++ b/avrotize/structuretojava/enum_core.jinja
@@ -2,10 +2,14 @@
 {%- if deprecated %}
 @Deprecated
 {%- endif %}
+{%- if xml_annotation %}
+@XmlType(name = {{ xml_name }}{% if xml_namespace != '""' %}, namespace = {{ xml_namespace }}{% endif %})
+@XmlEnum
+{%- endif %}
 public enum {{ class_name }} {
 {%- if is_numeric %}
 {%- for symbol in symbols %}
-    {{ symbol.name }}({{ symbol.value }}){% if not loop.last %},{% else %};{% endif %}
+    {% if xml_annotation %}@XmlEnumValue({{ symbol.xml_value }}) {% endif %}{{ symbol.name }}({{ symbol.value }}){% if not loop.last %},{% else %};{% endif %}
 
 {%- endfor %}
     
@@ -14,7 +18,7 @@ public enum {{ class_name }} {
     public {{ numeric_type }} getValue() { return value; }
 {%- else %}
 {%- for symbol in symbols %}
-    @com.fasterxml.jackson.annotation.JsonProperty("{{ symbol.value }}") {{ symbol.name }}{% if not loop.last %},{% else %};{% endif %}
+    {% if xml_annotation %}@XmlEnumValue({{ symbol.xml_value }}) {% endif %}@com.fasterxml.jackson.annotation.JsonProperty("{{ symbol.value }}") {{ symbol.name }}{% if not loop.last %},{% else %};{% endif %}
 {%- endfor %}
 {%- endif %}
 }

--- a/avrotize/structuretojava/pom.xml.jinja
+++ b/avrotize/structuretojava/pom.xml.jinja
@@ -28,5 +28,20 @@
             <artifactId>jackson-datatype-jsr310</artifactId>
             <version>${jackson.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-jakarta-xmlbind-annotations</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>{{ jakarta_xml_bind_version }}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/test/test_java_xml.py
+++ b/test/test_java_xml.py
@@ -24,6 +24,7 @@ def _avro_schema():
         "fields": [
             {"name": "id", "type": "string", "xmlkind": "attribute",
              "altnames": {"xml": "order-id"}},
+            {"name": "quantity", "type": "int"},
             {"name": "note", "type": ["null", "string"], "default": None},
             {"name": "status", "altnames": {"xml": "state"}, "type": {
                 "type": "enum", "name": "Status", "namespace": "example.model",
@@ -51,9 +52,11 @@ def _structure_schema():
         "namespace": "example.model",
         "xmlns": XML_NAMESPACE,
         "altnames": {"xml": "purchase-order"},
+        "required": ["id", "quantity", "status", "child", "metadata", "choice"],
         "properties": {
             "id": {"type": "string", "xmlkind": "attribute",
                    "altnames": {"xml": "order-id"}},
+            "quantity": {"type": "integer"},
             "note": {"type": ["null", "string"]},
             "status": {
                 "type": "string", "name": "Status", "xmlns": XML_NAMESPACE,
@@ -77,14 +80,40 @@ def _structure_schema():
 def _driver(package: str, enum_value: str, union_value: str) -> str:
     return f"""package {package};
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class XmlRoundTrip {{
+    @FunctionalInterface
+    private interface ThrowingAction {{
+        void run() throws Exception;
+    }}
+
+    private static Throwable expectFailure(
+            String name, String expectedMessage, ThrowingAction action) throws Exception {{
+        try {{
+            action.run();
+        }} catch (Throwable failure) {{
+            String message = failure.getMessage();
+            if (message == null || message.isBlank()) {{
+                throw new AssertionError(name + " did not provide an explicit error", failure);
+            }}
+            if (!message.toLowerCase().contains(expectedMessage.toLowerCase())) {{
+                throw new AssertionError(
+                    name + " returned an unclear error: " + message, failure);
+            }}
+            return failure;
+        }}
+        throw new AssertionError(name + " unexpectedly succeeded");
+    }}
+
     public static void main(String[] args) throws Exception {{
         Order value = new Order();
         value.setId("A1");
+        value.setQuantity(3);
         value.setNote("optional");
         value.setStatus(Status.{enum_value});
         Child child = new Child();
@@ -111,6 +140,120 @@ public class XmlRoundTrip {{
         if (!value.equals(Order.fromData(gzip, "text/xml+gzip"))) {{
             throw new AssertionError("gzip XML round-trip failed");
         }}
+
+        expectFailure("malformed XML", "XML",
+            () -> Order.fromData(xml.substring(0, xml.length() / 2), "application/xml"));
+        expectFailure("corrupt gzip", "gzip",
+            () -> Order.fromData(new byte[] {{1, 2, 3, 4}}, "application/xml+gzip"));
+        expectFailure("wrong root namespace", "Unexpected XML root",
+            () -> Order.fromData(xml.replace("{XML_NAMESPACE}", "urn:wrong"), "application/xml"));
+        expectFailure("missing required field", "Missing required XML field",
+            () -> Order.fromData(
+                xml.replaceFirst("<state>.*?</state>", ""), "application/xml"));
+        expectFailure("duplicate singleton", "Duplicate XML field",
+            () -> Order.fromData(
+                xml.replace("<state>working</state>",
+                    "<state>working</state><state>complete</state>"),
+                "application/xml"));
+        expectFailure("unknown attribute", "Unknown XML attribute",
+            () -> Order.fromData(
+                xml.replaceFirst("<purchase-order",
+                    "<purchase-order surprise=\\\"x\\\""),
+                "application/xml"));
+        expectFailure("unknown element", "Unknown XML element",
+            () -> Order.fromData(
+                xml.replace("</purchase-order>",
+                    "<surprise>value</surprise></purchase-order>"),
+                "application/xml"));
+        expectFailure("invalid enum", "Invalid XML value",
+            () -> Order.fromData(
+                xml.replace("<state>working</state>", "<state>invalid</state>"),
+                "application/xml"));
+        expectFailure("invalid scalar", "Invalid XML value",
+            () -> Order.fromData(
+                xml.replace("<quantity>3</quantity>", "<quantity>NaN</quantity>"),
+                "application/xml"));
+
+        int choiceEnd = xml.indexOf("</choice>");
+        String ambiguousUnion = xml.substring(0, choiceEnd)
+            + "<extra>7</extra>" + xml.substring(choiceEnd);
+        expectFailure("ambiguous union", "Ambiguous XML union",
+            () -> Order.fromData(ambiguousUnion, "application/xml"));
+
+        expectFailure("duplicate map key", "Duplicate XML map key",
+            () -> Order.fromData(
+                xml.replace("</metadata>",
+                    "<region>east</region></metadata>"),
+                "application/xml"));
+        expectFailure("malformed scalar map", "Malformed scalar XML map entry",
+            () -> Order.fromData(
+                xml.replace("<region>west</region>",
+                    "<region><nested>west</nested></region>"),
+                "application/xml"));
+        expectFailure("duplicate map field", "Duplicate XML field",
+            () -> Order.fromData(
+                xml.replace("</purchase-order>",
+                    "<metadata><other>value</other></metadata></purchase-order>"),
+                "application/xml"));
+
+        String deep = xml.replace("<note>optional</note>",
+            "<note>" + "<n>".repeat(101) + "x" + "</n>".repeat(101) + "</note>");
+        expectFailure("excessive XML depth", "depth limit",
+            () -> Order.fromData(deep, "application/xml"));
+        String oversized = xml.replace("<note>optional</note>",
+            "<note>" + "x".repeat(1_100_000) + "</note>");
+        expectFailure("excessive XML size", "size limit",
+            () -> Order.fromData(oversized, "application/xml"));
+
+        int declarationEnd = xml.indexOf("?>") + 2;
+        Path secretFile = Files.createTempFile("avrotize-xxe", ".txt");
+        String secret = "XXE_SECRET_MUST_NOT_BE_READ";
+        Files.writeString(secretFile, secret, StandardCharsets.UTF_8);
+        try {{
+            String fileDoctype = "<!DOCTYPE purchase-order [<!ENTITY xxe SYSTEM \\\""
+                + secretFile.toUri() + "\\\">]>";
+            String fileAttack = xml.substring(0, declarationEnd) + fileDoctype
+                + xml.substring(declarationEnd)
+                    .replace("<note>optional</note>", "<note>&xxe;</note>");
+            Throwable fileFailure = expectFailure(
+                "XXE file entity", "unsafe XML",
+                () -> Order.fromData(fileAttack, "application/xml"));
+            if (String.valueOf(fileFailure.getMessage()).contains(secret)) {{
+                throw new AssertionError("XXE file content leaked");
+            }}
+
+            String networkDoctype =
+                "<!DOCTYPE purchase-order [<!ENTITY xxe SYSTEM "
+                + "\\\"http://127.0.0.1:9/xxe\\\">]>";
+            String networkAttack = xml.substring(0, declarationEnd) + networkDoctype
+                + xml.substring(declarationEnd)
+                    .replace("<note>optional</note>", "<note>&xxe;</note>");
+            expectFailure("XXE network entity", "unsafe XML",
+                () -> Order.fromData(networkAttack, "application/xml"));
+
+            String entityAttack = xml.substring(0, declarationEnd)
+                + "<!DOCTYPE purchase-order ["
+                + "<!ENTITY a \\\"1234567890\\\">"
+                + "<!ENTITY b \\\"&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;\\\">"
+                + "]>" + xml.substring(declarationEnd)
+                    .replace("<note>optional</note>", "<note>&b;</note>");
+            expectFailure("DOCTYPE entity expansion", "unsafe XML",
+                () -> Order.fromData(entityAttack, "application/xml"));
+        }} finally {{
+            Files.deleteIfExists(secretFile);
+        }}
+
+        // Intentional stable Jackson tolerance: optional elements may be absent,
+        // known elements need not be schema-ordered, and collection elements repeat.
+        String tolerantXml = xml.replace("<note>optional</note>", "")
+            .replace("<quantity>3</quantity>", "")
+            .replace("<state>working</state>",
+                "<state>working</state><quantity>3</quantity>");
+        Order withoutOptional = Order.fromData(
+            tolerantXml, "application/xml");
+        if (withoutOptional.getNote() != null || withoutOptional.getTags().size() != 2) {{
+            throw new AssertionError("stable XML tolerance changed");
+        }}
     }}
 }}
 """
@@ -136,13 +279,20 @@ def _assert_xml_metadata(project: Path, package_path: Path):
     assert len(support_files) == 1
     support = support_files[0].read_text("utf-8")
     assert "public static final XmlMapper MAPPER = createMapper();" in support
-    assert support.count("new XmlMapper()") == 1
+    assert support.count("new XmlMapper(") == 1
+    assert "XMLInputFactory.SUPPORT_DTD, false" in support
+    assert "isSupportingExternalEntities" in support
+    assert "disallow-doctype-decl" in support
+    assert "ACCESS_EXTERNAL_DTD" in support
+    assert "MAX_XML_DEPTH" in support
+    assert "MAX_XML_BYTES" in support
+    assert "FAIL_ON_UNKNOWN_PROPERTIES" in support
     assert "AvrotizeXmlSupport.MAPPER" in order
     assert "AvrotizeXmlSupport.MAPPER" in child
     assert "createXmlMapper" not in order + child
-    assert "new XmlMapper()" not in order + child
+    assert "new XmlMapper(" not in order + child
     all_sources = "".join(path.read_text("utf-8") for path in source_root.glob("**/*.java"))
-    assert all_sources.count("new XmlMapper()") == 1
+    assert all_sources.count("new XmlMapper(") == 1
 
 
 def test_java_xml_public_flags_and_annotations(tmp_path):

--- a/test/test_java_xml.py
+++ b/test/test_java_xml.py
@@ -117,9 +117,11 @@ public class XmlRoundTrip {{
 
 
 def _assert_xml_metadata(project: Path, package_path: Path):
-    order = (project / "src" / "main" / "java" / package_path / "Order.java").read_text("utf-8")
-    status = (project / "src" / "main" / "java" / package_path / "Status.java").read_text("utf-8")
-    package_info = (project / "src" / "main" / "java" / package_path / "package-info.java").read_text("utf-8")
+    source_root = project / "src" / "main" / "java"
+    order = (source_root / package_path / "Order.java").read_text("utf-8")
+    child = (source_root / package_path / "Child.java").read_text("utf-8")
+    status = (source_root / package_path / "Status.java").read_text("utf-8")
+    package_info = (source_root / package_path / "package-info.java").read_text("utf-8")
     pom = (project / "pom.xml").read_text("utf-8")
     assert '@XmlRootElement(name = "purchase-order", namespace = "urn:test:orders")' in order
     assert '@XmlAttribute(name = "order-id")' in order
@@ -129,6 +131,18 @@ def _assert_xml_metadata(project: Path, package_path: Path):
     assert "jackson-dataformat-xml" in pom
     assert "jackson-module-jakarta-xmlbind-annotations" in pom
     assert "jakarta.xml.bind-api" in pom
+
+    support_files = list(source_root.glob("**/AvrotizeXmlSupport.java"))
+    assert len(support_files) == 1
+    support = support_files[0].read_text("utf-8")
+    assert "public static final XmlMapper MAPPER = createMapper();" in support
+    assert support.count("new XmlMapper()") == 1
+    assert "AvrotizeXmlSupport.MAPPER" in order
+    assert "AvrotizeXmlSupport.MAPPER" in child
+    assert "createXmlMapper" not in order + child
+    assert "new XmlMapper()" not in order + child
+    all_sources = "".join(path.read_text("utf-8") for path in source_root.glob("**/*.java"))
+    assert all_sources.count("new XmlMapper()") == 1
 
 
 def test_java_xml_public_flags_and_annotations(tmp_path):
@@ -157,6 +171,8 @@ def test_java_xml_public_flags_and_annotations(tmp_path):
         plain_project / "src" / "main" / "java" / "test" / "xml" / "plain"
         / "example" / "model" / "Order.java").read_text("utf-8")
     assert "XmlRootElement" not in plain_order
+    assert not list((plain_project / "src" / "main" / "java").glob(
+        "**/AvrotizeXmlSupport.java"))
 
 
 @pytest.mark.skipif(shutil.which("mvn") is None or shutil.which("java") is None,

--- a/test/test_java_xml.py
+++ b/test/test_java_xml.py
@@ -1,0 +1,193 @@
+"""Focused XML serialization tests for the Java generators."""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from avrotize.avrotojava import convert_avro_schema_to_java
+from avrotize.structuretojava import convert_structure_schema_to_java
+
+
+XML_NAMESPACE = "urn:test:orders"
+
+
+def _avro_schema():
+    return {
+        "type": "record",
+        "name": "Order",
+        "namespace": "example.model",
+        "xmlns": XML_NAMESPACE,
+        "altnames": {"xml": "purchase-order"},
+        "fields": [
+            {"name": "id", "type": "string", "xmlkind": "attribute",
+             "altnames": {"xml": "order-id"}},
+            {"name": "note", "type": ["null", "string"], "default": None},
+            {"name": "status", "altnames": {"xml": "state"}, "type": {
+                "type": "enum", "name": "Status", "namespace": "example.model",
+                "xmlns": XML_NAMESPACE, "symbols": ["IN_PROGRESS", "DONE"],
+                "altenums": {"xml": {"IN_PROGRESS": "working", "DONE": "complete"}},
+            }},
+            {"name": "child", "type": {
+                "type": "record", "name": "Child", "namespace": "example.model",
+                "xmlns": XML_NAMESPACE, "fields": [
+                    {"name": "code", "type": "string", "xmlkind": "attribute"},
+                    {"name": "value", "type": "string"},
+                ],
+            }},
+            {"name": "tags", "type": {"type": "array", "items": "string"}},
+            {"name": "metadata", "type": {"type": "map", "values": "string"}},
+            {"name": "choice", "type": ["string", "int"]},
+        ],
+    }
+
+
+def _structure_schema():
+    return {
+        "type": "object",
+        "name": "Order",
+        "namespace": "example.model",
+        "xmlns": XML_NAMESPACE,
+        "altnames": {"xml": "purchase-order"},
+        "properties": {
+            "id": {"type": "string", "xmlkind": "attribute",
+                   "altnames": {"xml": "order-id"}},
+            "note": {"type": ["null", "string"]},
+            "status": {
+                "type": "string", "name": "Status", "xmlns": XML_NAMESPACE,
+                "altnames": {"xml": "state"}, "enum": ["IN_PROGRESS", "DONE"],
+                "altenums": {"xml": {"IN_PROGRESS": "working", "DONE": "complete"}},
+            },
+            "child": {
+                "type": "object", "name": "Child", "xmlns": XML_NAMESPACE,
+                "properties": {
+                    "code": {"type": "string", "xmlkind": "attribute"},
+                    "value": {"type": "string"},
+                },
+            },
+            "tags": {"type": "array", "items": {"type": "string"}},
+            "metadata": {"type": "map", "values": {"type": "string"}},
+            "choice": {"type": ["string", "integer"]},
+        },
+    }
+
+
+def _driver(package: str, enum_value: str, union_value: str) -> str:
+    return f"""package {package};
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class XmlRoundTrip {{
+    public static void main(String[] args) throws Exception {{
+        Order value = new Order();
+        value.setId("A1");
+        value.setNote("optional");
+        value.setStatus(Status.{enum_value});
+        Child child = new Child();
+        child.setCode("C1");
+        child.setValue("nested");
+        value.setChild(child);
+        value.setTags(Arrays.asList("one", "two"));
+        Map<String, String> metadata = new LinkedHashMap<>();
+        metadata.put("region", "west");
+        value.setMetadata(metadata);
+        value.setChoice({union_value});
+
+        byte[] xmlBytes = value.toByteArray("application/xml");
+        String xml = new String(xmlBytes, StandardCharsets.UTF_8);
+        if (!xml.contains("purchase-order") || !xml.contains("{XML_NAMESPACE}")
+                || !xml.contains("order-id=\\\"A1\\\"") || !xml.contains("working")
+                || !xml.contains("nested") || !xml.contains("west")) {{
+            throw new AssertionError(xml);
+        }}
+        if (!value.equals(Order.fromData(xmlBytes, "application/xml"))) {{
+            throw new AssertionError("XML round-trip failed: " + xml);
+        }}
+        byte[] gzip = value.toByteArray("text/xml+gzip");
+        if (!value.equals(Order.fromData(gzip, "text/xml+gzip"))) {{
+            throw new AssertionError("gzip XML round-trip failed");
+        }}
+    }}
+}}
+"""
+
+
+def _assert_xml_metadata(project: Path, package_path: Path):
+    order = (project / "src" / "main" / "java" / package_path / "Order.java").read_text("utf-8")
+    status = (project / "src" / "main" / "java" / package_path / "Status.java").read_text("utf-8")
+    package_info = (project / "src" / "main" / "java" / package_path / "package-info.java").read_text("utf-8")
+    pom = (project / "pom.xml").read_text("utf-8")
+    assert '@XmlRootElement(name = "purchase-order", namespace = "urn:test:orders")' in order
+    assert '@XmlAttribute(name = "order-id")' in order
+    assert '@XmlElement(name = "state", namespace = "urn:test:orders")' in order
+    assert '@XmlEnumValue("working")' in status
+    assert 'namespace = "urn:test:orders"' in package_info
+    assert "jackson-dataformat-xml" in pom
+    assert "jackson-module-jakarta-xmlbind-annotations" in pom
+    assert "jakarta.xml.bind-api" in pom
+
+
+def test_java_xml_public_flags_and_annotations(tmp_path):
+    commands = json.loads(
+        (Path(__file__).parents[1] / "avrotize" / "commands.json").read_text("utf-8"))
+    for command_name in ("a2java", "s2java"):
+        command = next(command for command in commands if command["command"] == command_name)
+        assert command["function"]["args"]["xml_annotation"] == "args.xml_annotation"
+        assert any(arg["name"] == "--xml-annotation" for arg in command["args"])
+
+    avro_project = tmp_path / "avro"
+    structure_project = tmp_path / "structure"
+    convert_avro_schema_to_java(
+        _avro_schema(), str(avro_project), package_name="test.xml.avro",
+        jackson_annotation=True, avro_annotation=True, xml_annotation=True)
+    convert_structure_schema_to_java(
+        _structure_schema(), str(structure_project), package_name="test.xml.structure",
+        jackson_annotation=True, xml_annotation=True)
+    _assert_xml_metadata(avro_project, Path("test/xml/avro/example/model"))
+    _assert_xml_metadata(structure_project, Path("test/xml/structure/example/model"))
+
+    plain_project = tmp_path / "plain"
+    convert_avro_schema_to_java(
+        _avro_schema(), str(plain_project), package_name="test.xml.plain")
+    plain_order = (
+        plain_project / "src" / "main" / "java" / "test" / "xml" / "plain"
+        / "example" / "model" / "Order.java").read_text("utf-8")
+    assert "XmlRootElement" not in plain_order
+
+
+@pytest.mark.skipif(shutil.which("mvn") is None or shutil.which("java") is None,
+                    reason="Maven and Java are required for generated-code round-trip")
+@pytest.mark.parametrize(
+    ("kind", "package", "enum_value", "union_value"),
+    [
+        ("avro", "test.xml.avro.example.model", "IN_PROGRESS",
+         'new OrderChoiceUnion("selected")'),
+        ("structure", "test.xml.structure.example.model", "InProgress", '"selected"'),
+    ],
+)
+def test_generated_java_xml_round_trip(tmp_path, kind, package, enum_value, union_value):
+    project = tmp_path / kind
+    if kind == "avro":
+        convert_avro_schema_to_java(
+            _avro_schema(), str(project), package_name="test.xml.avro",
+            jackson_annotation=True, avro_annotation=True, xml_annotation=True)
+    else:
+        convert_structure_schema_to_java(
+            _structure_schema(), str(project), package_name="test.xml.structure",
+            jackson_annotation=True, xml_annotation=True)
+
+    package_path = Path(*package.split("."))
+    driver = project / "src" / "main" / "java" / package_path / "XmlRoundTrip.java"
+    driver.write_text(_driver(package, enum_value, union_value), encoding="utf-8")
+    command = (
+        "mvn package org.codehaus.mojo:exec-maven-plugin:3.5.0:java "
+        f"-Dexec.mainClass={package}.XmlRoundTrip -B -q"
+    )
+    result = subprocess.run(
+        command, cwd=project, capture_output=True, text=True, timeout=600,
+        shell=True)
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
Closes #409

Adds JAXB XML metadata and shared cached Jackson XML runtime support to both Java generators. Includes namespaces, attributes/elements, enums, maps/unions, XML media types, gzip, XXE protection, and adversarial validation.