### PR TITLE
Go: add XML serialization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1633,6 +1633,7 @@ Parameters:
 - `--namespace`: (optional) The namespace to use in the C++ classes.
 - `--avro-annotation`: (optional) Use Avro annotations.
 - `--json-annotation`: (optional) Use JSON annotations.
+- `--xml-annotation`: (optional) Use `encoding/xml` tags and XML serialization.
 
 Conversion notes:
 
@@ -1641,12 +1642,12 @@ Conversion notes:
 rotize Schema is converted to a C++ class.
 
 - The fields of the record are mapped to properties in the C++ class. Nested records are mapped to nested classes in the C++ class.
-- The tool supports adding annotations to the properties in the C++ class. The `--avro-annotation` option adds Avro annotations, and the `--json-annotation` option adds JSON annotations.
+- The tool supports adding annotations to the properties in the C++ class. The `--avro-annotation` option adds Avro annotations, the `--json-annotation` option adds JSON annotations, and the `--xml-annotation` option adds XML annotations.
 
 ### Convert Avrotize Schema to Go classes
 
 ```bash
-avrotize a2go <path_to_avro_schema_file> [--out <path_to_go_dir>] [--package <go_package>] [--avro-annotation] [--json-annotation] [--package-site <go_package_site>] [--package-username <go_package_username>]
+avrotize a2go <path_to_avro_schema_file> [--out <path_to_go_dir>] [--package <go_package>] [--avro-annotation] [--json-annotation] [--xml-annotation] [--package-site <go_package_site>] [--package-username <go_package_username>]
 ```
 
 Parameters:
@@ -1739,7 +1740,7 @@ Conversion notes:
 ### Convert JSON Structure to Go classes
 
 ```bash
-avrotize s2go <path_to_structure_file> --out <path_to_go_dir> [--package <go_package>] [--json-annotation] [--avro-annotation] [--package-site <package_site>] [--package-username <username>]
+avrotize s2go <path_to_structure_file> --out <path_to_go_dir> [--package <go_package>] [--json-annotation] [--avro-annotation] [--xml-annotation] [--package-site <package_site>] [--package-username <username>]
 ```
 
 Parameters:
@@ -1748,6 +1749,7 @@ Parameters:
 - `--out`: The path to the directory to write the Go structs to. Required.
 - `--package`: (optional) The package name to use in the Go code.
 - `--json-annotation`: (optional) Add JSON struct tags for encoding/json.
+- `--xml-annotation`: (optional) Add `encoding/xml` tags and XML serialization.
 - `--avro-annotation`: (optional) Add Avro struct tags.
 - `--package-site`: (optional) The package site for the Go module (e.g., github.com).
 - `--package-username`: (optional) The username/organization for the Go module.

--- a/avrotize/avrotogo.py
+++ b/avrotize/avrotogo.py
@@ -174,12 +174,17 @@ class AvroToGo:
 
         fields = []
         for field in avro_schema.get('fields', []):
+            field_type = self.convert_avro_type_to_go(field['name'], field['type'], parent_namespace=namespace)
+            raw_type = field['type']
             fields.append({
                 'name': pascal(field['name']),
-                'type': self.convert_avro_type_to_go(field['name'], field['type'], parent_namespace=namespace),
+                'type': field_type,
                 'original_name': field['name'],
                 'xml_name': xml_wire_name(field['name'], field),
                 'xml_kind': field.get('xmlkind', 'element'),
+                'xml_required': not (isinstance(raw_type, list) and 'null' in raw_type) and not (isinstance(raw_type, dict) and raw_type.get('type') in ('array', 'map')),
+                'xml_repeated': isinstance(raw_type, dict) and raw_type.get('type') == 'array',
+                'xml_ambiguous': field_type.lstrip('*') == 'interface{}',
             })
 
         # Collect imports from field types

--- a/avrotize/avrotogo.py
+++ b/avrotize/avrotogo.py
@@ -1,7 +1,8 @@
 import json
 import os
 from typing import Dict, List, Union, Set
-from avrotize.common import get_longest_namespace_prefix, is_generic_avro_type, is_any_value_type, pascal, render_template, format_go_files
+from avrotize.common import (get_longest_namespace_prefix, is_generic_avro_type, is_any_value_type, pascal,
+                              render_template, format_go_files, xml_wire_name, xml_enum_wire_value)
 
 INDENT = '    '
 
@@ -26,6 +27,7 @@ class AvroToGo:
         self.referenced_packages_stack: List[Dict[str, Set[str]]] = []
         self.avro_annotation = False
         self.json_annotation = False
+        self.xml_annotation = False
         self.longest_common_prefix = ''
         self.package_site = 'github.com'
         self.package_username = 'username'
@@ -126,9 +128,8 @@ class AvroToGo:
                 return f"[]{item_type}"
             elif avro_type['type'] == 'map':
                 values_type = self.convert_avro_type_to_go(field_name, avro_type['values'], nullable=True, parent_namespace=parent_namespace)
-                if values_type.startswith('*'): 
-                    return f"map[string]{values_type}"
-                return f"map[string]{values_type}"
+                map_type = f"map[string]{values_type}"
+                return f"XMLMap[{values_type}]" if self.xml_annotation else map_type
             elif 'logicalType' in avro_type:
                 if avro_type['logicalType'] == 'date':
                     return 'time.Time'
@@ -171,11 +172,15 @@ class AvroToGo:
         self.generated_types_avro_namespace[avro_fullname] = "struct"
         self.generated_types_go_package[go_struct_name] = "struct"
 
-        fields = [{
-            'name': pascal(field['name']),
-            'type': self.convert_avro_type_to_go(field['name'], field['type'], parent_namespace=namespace),
-            'original_name': field['name']
-        } for field in avro_schema.get('fields', [])]
+        fields = []
+        for field in avro_schema.get('fields', []):
+            fields.append({
+                'name': pascal(field['name']),
+                'type': self.convert_avro_type_to_go(field['name'], field['type'], parent_namespace=namespace),
+                'original_name': field['name'],
+                'xml_name': xml_wire_name(field['name'], field),
+                'xml_kind': field.get('xmlkind', 'element'),
+            })
 
         # Collect imports from field types
         go_types = [f['type'] for f in fields]
@@ -187,6 +192,10 @@ class AvroToGo:
             'fields': fields,
             'avro_schema': json.dumps(avro_schema),
             'json_annotation': self.json_annotation,
+            'xml_annotation': self.xml_annotation,
+            'xml_name': xml_wire_name(avro_schema['name'], avro_schema),
+            'xml_namespace': avro_schema.get('xmlns', ''),
+            'needs_xml_name': bool(avro_schema.get('xmlns')) or xml_wire_name(avro_schema['name'], avro_schema) != go_struct_name,
             'avro_annotation': self.avro_annotation,
             'json_match_predicates': [self.get_is_json_match_clause(f['name'], f['type']) for f in fields],
             'base_package': self.base_package,
@@ -223,9 +232,14 @@ class AvroToGo:
         context = {
             'doc': avro_schema.get('doc', ''),
             'struct_name': enum_name,
-            'symbols': avro_schema.get('symbols', []),
+            'symbols': [
+                {'name': symbol, 'xml_value': xml_enum_wire_value(symbol, avro_schema)}
+                for symbol in avro_schema.get('symbols', [])
+            ],
             'imports': imports,
             'base_package': self.base_package,
+            'xml_annotation': self.xml_annotation,
+            'string_enum': self.avro_annotation,
             'referenced_packages': self.referenced_packages.keys()
         }
 
@@ -238,9 +252,10 @@ class AvroToGo:
         self.enums.append({
             'name': enum_name,
             'symbols': avro_schema.get('symbols', []),
+            'string_enum': self.avro_annotation,
         })
 
-        self.generate_unit_test('enum', enum_name, context['symbols'])
+        self.generate_unit_test('enum', enum_name, avro_schema.get('symbols', []))
 
         return enum_name
 
@@ -256,6 +271,7 @@ class AvroToGo:
             'union_class_name': union_class_name,
             'union_types': union_types,
             'json_annotation': self.json_annotation,
+            'xml_annotation': self.xml_annotation,
             'avro_annotation': self.avro_annotation,
             'get_is_json_match_clause': self.get_is_json_match_clause,
             'base_package': self.base_package,
@@ -303,14 +319,14 @@ class AvroToGo:
             return f"if _, ok := node[\"{field_name}\"].([]byte); !ok {{ return false }}"
         elif field_type == 'interface{}':
             return f"if _, ok := node[\"{field_name}\"].(interface{{}}); !ok {{ return false }}"
-        elif field_type.startswith('map[string]'):
+        elif field_type.startswith('map[string]') or field_type.startswith('XMLMap['):
             return f"if _, ok := node[\"{field_name}\"].(map[string]interface{{}}); !ok {{ return false }}"
         elif field_type.startswith('[]'):
             return f"if _, ok := node[\"{field_name}\"].([]interface{{}}); !ok {{ return false }}"
         elif field_type in self.generated_types_go_package:
             return f"if _, ok := node[\"{field_name}\"].({field_type}); !ok {{ return false }}"
         else:
-            return f"if _, ok := node[\"{field_name}\"].(map[string.interface{{}}); !ok {{ return false }}"
+            return f"if _, ok := node[\"{field_name}\"].(map[string]interface{{}}); !ok {{ return false }}"
 
     def get_imports_for_definition(self, types: List[str]) -> Set[str]:
         """Collects necessary imports for the Go definition based on the Go types"""
@@ -402,6 +418,7 @@ class AvroToGo:
             'package_site': self.package_site,
             'package_username': self.package_username,
             'json_annotation': self.json_annotation,
+            'xml_annotation': self.xml_annotation,
             'avro_annotation': self.avro_annotation
         }
 
@@ -427,7 +444,15 @@ class AvroToGo:
         self.write_go_mod_file()
         self.write_modname_go_file()
         self.generate_helpers()
+        self.write_xml_helpers()
         format_go_files(self.output_dir)
+
+    def write_xml_helpers(self) -> None:
+        """Write generic XML support for map fields."""
+        if not self.xml_annotation:
+            return
+        helper_path = os.path.join(self.output_dir, 'pkg', self.base_package, 'xml_helpers.go')
+        render_template('avrotogo/xml_helpers.jinja', helper_path, base_package=self.base_package)
 
     def write_go_mod_file(self):
         """Writes the go.mod file for the Go project"""
@@ -463,7 +488,7 @@ class AvroToGo:
         self.convert_schema(schema, output_dir)
 
 
-def convert_avro_to_go(avro_schema_path, go_file_path, package_name='', avro_annotation=False, json_annotation=False, package_site='github.com', package_username='username'):
+def convert_avro_to_go(avro_schema_path, go_file_path, package_name='', avro_annotation=False, json_annotation=False, xml_annotation=False, package_site='github.com', package_username='username'):
     """Converts Avro schema to Go structs
 
     Args:
@@ -472,6 +497,7 @@ def convert_avro_to_go(avro_schema_path, go_file_path, package_name='', avro_ann
         package_name (str): Base package name
         avro_annotation (bool): Include Avro annotations
         json_annotation (bool): Include JSON annotations
+        xml_annotation (bool): Include XML annotations and serialization
     """
     if not package_name:
         package_name = os.path.splitext(os.path.basename(avro_schema_path))[0]
@@ -479,12 +505,13 @@ def convert_avro_to_go(avro_schema_path, go_file_path, package_name='', avro_ann
     avrotogo = AvroToGo(package_name)
     avrotogo.avro_annotation = avro_annotation
     avrotogo.json_annotation = json_annotation
+    avrotogo.xml_annotation = xml_annotation
     avrotogo.package_site = package_site if package_site else 'github.com'
     avrotogo.package_username = package_username if package_username else 'username'
     avrotogo.convert(avro_schema_path, go_file_path)
 
 
-def convert_avro_schema_to_go(avro_schema: JsonNode, output_dir: str, package_name='', avro_annotation=False, json_annotation=False, package_site='github.com', package_username='username'):
+def convert_avro_schema_to_go(avro_schema: JsonNode, output_dir: str, package_name='', avro_annotation=False, json_annotation=False, xml_annotation=False, package_site='github.com', package_username='username'):
     """Converts Avro schema to Go structs
 
     Args:
@@ -493,10 +520,12 @@ def convert_avro_schema_to_go(avro_schema: JsonNode, output_dir: str, package_na
         package_name (str): Base package name
         avro_annotation (bool): Include Avro annotations
         json_annotation (bool): Include JSON annotations
+        xml_annotation (bool): Include XML annotations and serialization
     """
     avrotogo = AvroToGo(package_name)
     avrotogo.avro_annotation = avro_annotation
     avrotogo.json_annotation = json_annotation
+    avrotogo.xml_annotation = xml_annotation
     avrotogo.package_site = package_site if package_site else 'github.com'
     avrotogo.package_username = package_username if package_username else 'username'
     avrotogo.convert_schema(avro_schema, output_dir)

--- a/avrotize/avrotogo/go_enum.jinja
+++ b/avrotize/avrotogo/go_enum.jinja
@@ -1,12 +1,65 @@
 package {{ base_package }}
 
-{%- if doc %}
-    // {{ doc }}
+{%- if xml_annotation %}
+import (
+    "encoding/xml"
+    "fmt"
+)
 {%- endif %}
-type {{ struct_name }} int
+
+{%- if doc %}
+// {{ doc }}
+{%- endif %}
+type {{ struct_name }} {% if string_enum %}string{% else %}int{% endif %}
 
 const (
 {%- for symbol in symbols %}
-    {{ struct_name }}_{{ symbol }} {{ struct_name }} = {{ loop.index0 }}
+    {{ struct_name }}_{{ symbol.name }} {{ struct_name }} = {% if string_enum %}"{{ symbol.name }}"{% else %}{{ loop.index0 }}{% endif %}
 {%- endfor %}
 )
+
+{%- if xml_annotation %}
+func (v {{ struct_name }}) xmlValue() (string, error) {
+    switch v {
+    {%- for symbol in symbols %}
+    case {{ struct_name }}_{{ symbol.name }}:
+        return "{{ symbol.xml_value }}", nil
+    {%- endfor %}
+    default:
+        return "", fmt.Errorf("invalid {{ struct_name }} value: %v", v)
+    }
+}
+
+func (v *{{ struct_name }}) setXMLValue(value string) error {
+    switch value {
+    {%- for symbol in symbols %}
+    case "{{ symbol.xml_value }}":
+        *v = {{ struct_name }}_{{ symbol.name }}
+    {%- endfor %}
+    default:
+        return fmt.Errorf("invalid {{ struct_name }} XML value: %s", value)
+    }
+    return nil
+}
+
+func (v {{ struct_name }}) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+    value, err := v.xmlValue()
+    if err != nil { return err }
+    return e.EncodeElement(value, start)
+}
+
+func (v *{{ struct_name }}) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+    var value string
+    if err := d.DecodeElement(&value, &start); err != nil { return err }
+    return v.setXMLValue(value)
+}
+
+func (v {{ struct_name }}) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
+    value, err := v.xmlValue()
+    return xml.Attr{Name: name, Value: value}, err
+}
+
+func (v *{{ struct_name }}) UnmarshalXMLAttr(attr xml.Attr) error {
+    return v.setXMLValue(attr.Value)
+}
+{%- endif %}

--- a/avrotize/avrotogo/go_helpers.jinja
+++ b/avrotize/avrotogo/go_helpers.jinja
@@ -25,7 +25,7 @@ func random{{ struct.name }}() {{ struct.name }} {
 
 {%- for enum in enums %}
 func random{{ enum.name }}() {{ enum.name }} {
-    return 0
+    return {% if enum.string_enum %}{{ enum.name }}_{{ enum.symbols[0] }}{% else %}0{% endif %}
 }
 {%- endfor %}
 

--- a/avrotize/avrotogo/go_struct.jinja
+++ b/avrotize/avrotogo/go_struct.jinja
@@ -7,7 +7,10 @@ import (
     {%- if json_annotation %}
     "encoding/json"
     {%- endif %}
-    {%- if json_annotation or avro_annotation %}
+    {%- if xml_annotation %}
+    "encoding/xml"
+    {%- endif %}
+    {%- if json_annotation or xml_annotation or avro_annotation %}
     "compress/gzip"
     "bytes"
     "fmt"
@@ -26,8 +29,11 @@ import (
     // {{ doc }}
 {%- endif %}
 type {{ struct_name }} struct {
+    {%- if xml_annotation and needs_xml_name %}
+    XMLName xml.Name `{% if json_annotation %}json:"-" {% endif %}{% if avro_annotation %}avro:"-" {% endif %}xml:"{% if xml_namespace %}{{ xml_namespace }} {% endif %}{{ xml_name }}"`
+    {%- endif %}
     {%- for field in fields %}
-    {{ field.name }} {{ field.type }}{% if json_annotation or avro_annotation %} `{% if json_annotation %}json:"{{ field.original_name }}"{% endif %}{% if json_annotation and avro_annotation %} {% endif %}{% if avro_annotation %}avro:"{{ field.original_name }}"{% endif %}`{% endif %}
+    {{ field.name }} {{ field.type }}{% if json_annotation or xml_annotation or avro_annotation %} `{% if json_annotation %}json:"{{ field.original_name }}"{% endif %}{% if json_annotation and (xml_annotation or avro_annotation) %} {% endif %}{% if xml_annotation %}xml:"{{ field.xml_name }}{% if field.xml_kind == 'attribute' %},attr{% endif %}"{% endif %}{% if xml_annotation and avro_annotation %} {% endif %}{% if avro_annotation %}avro:"{{ field.original_name }}"{% endif %}`{% endif %}
     {%- endfor %}
 }
 
@@ -35,38 +41,44 @@ type {{ struct_name }} struct {
 var {{ struct_name }}Schema, _ = avro.Parse(`{{ avro_schema }}`)
 {% endif %}
 
-{%- if json_annotation or avro_annotation %}
+{%- if json_annotation or xml_annotation or avro_annotation %}
 func (s *{{ struct_name }}) ToByteArray(contentType string) ([]byte, error) {
     var result []byte
     var err error
-    mediaType := strings.Split(contentType, ";")[0]
+    mediaType := strings.TrimSpace(strings.Split(contentType, ";")[0])
+    isGzipped := strings.HasSuffix(mediaType, "+gzip")
+    if isGzipped {
+        mediaType = strings.TrimSuffix(mediaType, "+gzip")
+    }
     switch mediaType {
     {%- if json_annotation %}
     case "application/json":
         result, err = json.Marshal(s)
-        if err != nil {
-            return nil, err
-        }
+    {%- endif %}
+    {%- if xml_annotation %}
+    case "application/xml", "text/xml":
+        {%- if needs_xml_name %}
+        s.XMLName = xml.Name{Space: "{{ xml_namespace }}", Local: "{{ xml_name }}"}
+        {%- endif %}
+        result, err = xml.Marshal(s)
     {%- endif %}
     {%- if avro_annotation %}
     case "avro/binary", "application/vnd.apache.avro+avro":
         result, err = avro.Marshal({{ struct_name }}Schema, s)
-        if err != nil {
-            return nil, err
-        }
     {%- endif %}
     default:
         return nil, fmt.Errorf("unsupported media type: %s", mediaType)
     }
-    if strings.HasSuffix(mediaType, "+gzip") {
+    if err != nil {
+        return nil, err
+    }
+    if isGzipped {
         var buf bytes.Buffer
         gzipWriter := gzip.NewWriter(&buf)
-        _, err = gzipWriter.Write(result)
-        if err != nil {
+        if _, err = gzipWriter.Write(result); err != nil {
             return nil, err
         }
-        err = gzipWriter.Close()
-        if err != nil {
+        if err = gzipWriter.Close(); err != nil {
             return nil, err
         }
         result = buf.Bytes()
@@ -77,8 +89,10 @@ func (s *{{ struct_name }}) ToByteArray(contentType string) ([]byte, error) {
 func {{ struct_name }}FromData(data interface{}, contentType string) (*{{ struct_name }}, error) {
     var err error
     var s {{ struct_name }}
-    mediaType := strings.Split(contentType, ";")[0]
-    if strings.HasSuffix(mediaType, "+gzip") {
+    mediaType := strings.TrimSpace(strings.Split(contentType, ";")[0])
+    isGzipped := strings.HasSuffix(mediaType, "+gzip")
+    if isGzipped {
+        mediaType = strings.TrimSuffix(mediaType, "+gzip")
         var reader io.Reader
         switch v := data.(type) {
         case []byte:
@@ -88,9 +102,9 @@ func {{ struct_name }}FromData(data interface{}, contentType string) (*{{ struct
         default:
             return nil, fmt.Errorf("unsupported data type for gzip: %T", data)
         }
-        gzipReader, err := gzip.NewReader(reader)
-        if err != nil {
-            return nil, err
+        gzipReader, gzipErr := gzip.NewReader(reader)
+        if gzipErr != nil {
+            return nil, gzipErr
         }
         defer gzipReader.Close()
         data, err = io.ReadAll(gzipReader)
@@ -112,15 +126,28 @@ func {{ struct_name }}FromData(data interface{}, contentType string) (*{{ struct
             return nil, fmt.Errorf("unsupported data type for JSON: %T", data)
         }
     {%- endif %}
+    {%- if xml_annotation %}
+    case "application/xml", "text/xml":
+        switch v := data.(type) {
+        case []byte:
+            err = xml.Unmarshal(v, &s)
+        case string:
+            err = xml.Unmarshal([]byte(v), &s)
+        case io.Reader:
+            err = xml.NewDecoder(v).Decode(&s)
+        default:
+            return nil, fmt.Errorf("unsupported data type for XML: %T", data)
+        }
+    {%- endif %}
     {%- if avro_annotation %}
     case "avro/binary", "application/vnd.apache.avro+avro":
         switch v := data.(type) {
         case []byte:
             err = avro.Unmarshal({{ struct_name }}Schema, v, &s)
         case io.Reader:
-            rawData, err := io.ReadAll(v)
-            if err != nil {
-                return nil, err
+            rawData, readErr := io.ReadAll(v)
+            if readErr != nil {
+                return nil, readErr
             }
             err = avro.Unmarshal({{ struct_name }}Schema, rawData, &s)
         default:

--- a/avrotize/avrotogo/go_struct.jinja
+++ b/avrotize/avrotogo/go_struct.jinja
@@ -107,7 +107,15 @@ func {{ struct_name }}FromData(data interface{}, contentType string) (*{{ struct
             return nil, gzipErr
         }
         defer gzipReader.Close()
+        {%- if xml_annotation %}
+        if mediaType == "application/xml" || mediaType == "text/xml" {
+            data, err = readXMLBytes(gzipReader)
+        } else {
+            data, err = io.ReadAll(gzipReader)
+        }
+        {%- else %}
         data, err = io.ReadAll(gzipReader)
+        {%- endif %}
         if err != nil {
             return nil, err
         }
@@ -128,16 +136,11 @@ func {{ struct_name }}FromData(data interface{}, contentType string) (*{{ struct
     {%- endif %}
     {%- if xml_annotation %}
     case "application/xml", "text/xml":
-        switch v := data.(type) {
-        case []byte:
-            err = xml.Unmarshal(v, &s)
-        case string:
-            err = xml.Unmarshal([]byte(v), &s)
-        case io.Reader:
-            err = xml.NewDecoder(v).Decode(&s)
-        default:
-            return nil, fmt.Errorf("unsupported data type for XML: %T", data)
-        }
+        err = secureXMLUnmarshal(data, &s, xml.Name{Space: "{{ xml_namespace }}", Local: "{{ xml_name }}"}, map[string]xmlFieldRule{
+            {%- for field in fields %}
+            "{% if field.xml_kind == 'attribute' %}@{% endif %}{{ field.xml_name }}": xmlFieldRule{Attribute: {{ 'true' if field.xml_kind == 'attribute' else 'false' }}, Required: {{ 'true' if field.xml_required else 'false' }}, Repeated: {{ 'true' if field.xml_repeated else 'false' }}, Ambiguous: {{ 'true' if field.xml_ambiguous else 'false' }}},
+            {%- endfor %}
+        })
     {%- endif %}
     {%- if avro_annotation %}
     case "avro/binary", "application/vnd.apache.avro+avro":

--- a/avrotize/avrotogo/go_test.jinja
+++ b/avrotize/avrotogo/go_test.jinja
@@ -1,47 +1,35 @@
 package {{ base_package }}
 
-import (
-    "testing"
-)
+import "testing"
 
-func Test{{ struct_name }}_Instantiate(t *testing.T) {
-    random{{ struct_name }}()
-}
-
-{%- if kind == "struct" and (json_annotation or avro_annotation) %}
-
-func Test{{ struct_name }}_ToByteArray(t *testing.T) {
-    s := random{{ struct_name }}()
+func Test{{ struct_name }}(t *testing.T) {
+    {%- if kind == 'struct' %}
+    instance := random{{ struct_name }}()
     {%- if json_annotation %}
-    _, err := s.ToByteArray("application/json")
-    if err != nil {
-        t.Errorf("ToByteArray failed: %v", err)
+    {
+        data, err := instance.ToByteArray("application/json")
+        if err != nil { t.Fatalf("JSON marshal failed: %v", err) }
+        if _, err = {{ struct_name }}FromData(data, "application/json"); err != nil { t.Fatalf("JSON unmarshal failed: %v", err) }
+    }
+    {%- endif %}
+    {%- if xml_annotation %}
+    for _, contentType := range []string{"application/xml", "text/xml", "application/xml+gzip"} {
+        data, err := instance.ToByteArray(contentType)
+        if err != nil { t.Fatalf("XML marshal for %s failed: %v", contentType, err) }
+        if _, err = {{ struct_name }}FromData(data, contentType); err != nil { t.Fatalf("XML unmarshal for %s failed: %v", contentType, err) }
     }
     {%- endif %}
     {%- if avro_annotation %}
-    _, err := s.ToByteArray("avro/binary")
-    if err != nil {
-        t.Errorf("ToByteArray failed: %v", err)
+    {
+        data, err := instance.ToByteArray("avro/binary")
+        if err != nil { t.Fatalf("Avro marshal failed: %v", err) }
+        if _, err = {{ struct_name }}FromData(data, "avro/binary"); err != nil { t.Fatalf("Avro unmarshal failed: %v", err) }
     }
+    {%- endif %}
+    _ = instance
+    {%- elif kind == 'enum' %}
+    {%- for symbol in fields %}
+    _ = {{ struct_name }}_{{ symbol }}
+    {%- endfor %}
     {%- endif %}
 }
-
-func Test{{ struct_name }}_FromData(t *testing.T) {
-    input := random{{struct_name}}()
-    {%- if json_annotation %}    
-	dataj, _ := input.ToByteArray("application/json")
-    _, err := {{struct_name}}FromData(dataj, "application/json")
-    if err != nil {
-        t.Errorf("FromData failed: %v", err)
-    }
-    {%- endif %}
-    {%- if avro_annotation %}
-    dataa, _ := input.ToByteArray("avro/binary")
-    _, err := {{struct_name}}FromData(dataa, "avro/binary")
-    if err != nil {
-        t.Errorf("FromData failed: %v", err)
-    }
-    {%- endif %}
-}
-
-{%- endif %}

--- a/avrotize/avrotogo/xml_helpers.jinja
+++ b/avrotize/avrotogo/xml_helpers.jinja
@@ -1,0 +1,45 @@
+package {{ base_package }}
+
+import (
+    "encoding/xml"
+    "fmt"
+    "sort"
+)
+
+// XMLMap provides deterministic XML encoding for Go maps. Entries are encoded
+// as <entry key="..."></entry> children of the field element.
+type XMLMap[T any] map[string]T
+
+func (m XMLMap[T]) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+    if err := e.EncodeToken(start); err != nil { return err }
+    keys := make([]string, 0, len(m))
+    for key := range m { keys = append(keys, key) }
+    sort.Strings(keys)
+    for _, key := range keys {
+        entry := xml.StartElement{Name: xml.Name{Local: "entry"}, Attr: []xml.Attr{xml.Attr{Name: xml.Name{Local: "key"}, Value: key}}}
+        if err := e.EncodeElement(m[key], entry); err != nil { return err }
+    }
+    return e.EncodeToken(start.End())
+}
+
+func (m *XMLMap[T]) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+    if *m == nil { *m = make(XMLMap[T]) }
+    for {
+        token, err := d.Token()
+        if err != nil { return err }
+        switch element := token.(type) {
+        case xml.StartElement:
+            if element.Name.Local != "entry" { return fmt.Errorf("unexpected XML map element: %s", element.Name.Local) }
+            var key string
+            for _, attr := range element.Attr {
+                if attr.Name.Local == "key" { key = attr.Value; break }
+            }
+            if key == "" { return fmt.Errorf("XML map entry is missing key attribute") }
+            var value T
+            if err := d.DecodeElement(&value, &element); err != nil { return err }
+            (*m)[key] = value
+        case xml.EndElement:
+            if element.Name == start.Name { return nil }
+        }
+    }
+}

--- a/avrotize/avrotogo/xml_helpers.jinja
+++ b/avrotize/avrotogo/xml_helpers.jinja
@@ -3,8 +3,106 @@ package {{ base_package }}
 import (
     "encoding/xml"
     "fmt"
+    "io"
     "sort"
+    "strings"
 )
+
+const (
+    maxXMLBytes = 1 << 20
+    maxXMLDepth = 100
+)
+
+type xmlFieldRule struct {
+    Attribute bool
+    Required  bool
+    Repeated  bool
+    Ambiguous bool
+}
+
+func readXMLBytes(reader io.Reader) ([]byte, error) {
+    data, err := io.ReadAll(io.LimitReader(reader, maxXMLBytes+1))
+    if err != nil { return nil, err }
+    if len(data) > maxXMLBytes { return nil, fmt.Errorf("XML payload exceeds %d bytes", maxXMLBytes) }
+    return data, nil
+}
+
+func xmlInputBytes(data interface{}) ([]byte, error) {
+    switch value := data.(type) {
+    case []byte:
+        if len(value) > maxXMLBytes { return nil, fmt.Errorf("XML payload exceeds %d bytes", maxXMLBytes) }
+        return value, nil
+    case string:
+        if len(value) > maxXMLBytes { return nil, fmt.Errorf("XML payload exceeds %d bytes", maxXMLBytes) }
+        return []byte(value), nil
+    case io.Reader:
+        return readXMLBytes(value)
+    default:
+        return nil, fmt.Errorf("unsupported data type for XML: %T", data)
+    }
+}
+
+func secureXMLUnmarshal(data interface{}, destination interface{}, root xml.Name, rules map[string]xmlFieldRule) error {
+    raw, err := xmlInputBytes(data)
+    if err != nil { return err }
+
+    decoder := xml.NewDecoder(strings.NewReader(string(raw)))
+    counts := make(map[string]int, len(rules))
+    depth := 0
+    rootSeen := false
+    for {
+        token, tokenErr := decoder.Token()
+        if tokenErr == io.EOF { break }
+        if tokenErr != nil { return fmt.Errorf("invalid XML: %w", tokenErr) }
+        switch value := token.(type) {
+        case xml.Directive:
+            return fmt.Errorf("XML directives and DOCTYPE declarations are not allowed")
+        case xml.ProcInst:
+            if value.Target != "xml" || rootSeen { return fmt.Errorf("XML processing instructions are not allowed") }
+        case xml.StartElement:
+            if depth == 0 {
+                if rootSeen { return fmt.Errorf("XML contains multiple root elements") }
+                rootSeen = true
+                if value.Name != root {
+                    return fmt.Errorf("unexpected XML root namespace=%q local=%q; expected namespace=%q local=%q", value.Name.Space, value.Name.Local, root.Space, root.Local)
+                }
+                for _, attr := range value.Attr {
+                    if attr.Name.Local == "xmlns" || attr.Name.Space == "xmlns" || attr.Name.Space == "http://www.w3.org/2000/xmlns/" { continue }
+                    if attr.Name.Space != "" { return fmt.Errorf("unexpected namespace %q for XML attribute %s", attr.Name.Space, attr.Name.Local) }
+                    key := "@" + attr.Name.Local
+                    rule, ok := rules[key]
+                    if !ok || !rule.Attribute { return fmt.Errorf("unknown XML attribute: %s", attr.Name.Local) }
+                    counts[key]++
+                    if counts[key] > 1 { return fmt.Errorf("duplicate XML attribute: %s", attr.Name.Local) }
+                }
+            } else if depth == 1 {
+                if value.Name.Space != root.Space {
+                    return fmt.Errorf("unexpected namespace %q for XML element %s", value.Name.Space, value.Name.Local)
+                }
+                rule, ok := rules[value.Name.Local]
+                if !ok || rule.Attribute { return fmt.Errorf("unknown XML element: %s", value.Name.Local) }
+                if rule.Ambiguous { return fmt.Errorf("XML field %s has an ambiguous interface union", value.Name.Local) }
+                counts[value.Name.Local]++
+                if !rule.Repeated && counts[value.Name.Local] > 1 { return fmt.Errorf("duplicate XML element: %s", value.Name.Local) }
+            }
+            depth++
+            if depth > maxXMLDepth { return fmt.Errorf("XML nesting exceeds %d elements", maxXMLDepth) }
+        case xml.EndElement:
+            depth--
+            if depth < 0 { return fmt.Errorf("invalid XML nesting") }
+        case xml.CharData:
+            if depth == 0 && strings.TrimSpace(string(value)) != "" { return fmt.Errorf("non-whitespace data outside XML root") }
+        }
+    }
+    if !rootSeen || depth != 0 { return fmt.Errorf("XML document is incomplete") }
+    for key, rule := range rules {
+        if rule.Required && counts[key] == 0 {
+            return fmt.Errorf("required XML field is missing: %s", strings.TrimPrefix(key, "@"))
+        }
+    }
+    if err := xml.Unmarshal(raw, destination); err != nil { return fmt.Errorf("invalid XML value: %w", err) }
+    return nil
+}
 
 // XMLMap provides deterministic XML encoding for Go maps. Entries are encoded
 // as <entry key="..."></entry> children of the field element.
@@ -30,11 +128,15 @@ func (m *XMLMap[T]) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
         switch element := token.(type) {
         case xml.StartElement:
             if element.Name.Local != "entry" { return fmt.Errorf("unexpected XML map element: %s", element.Name.Local) }
-            var key string
+            key := ""
+            foundKey := false
             for _, attr := range element.Attr {
-                if attr.Name.Local == "key" { key = attr.Value; break }
+                if attr.Name.Local != "key" { return fmt.Errorf("unexpected XML map attribute: %s", attr.Name.Local) }
+                if foundKey { return fmt.Errorf("duplicate XML map key attribute") }
+                key, foundKey = attr.Value, true
             }
-            if key == "" { return fmt.Errorf("XML map entry is missing key attribute") }
+            if !foundKey { return fmt.Errorf("XML map entry is missing key attribute") }
+            if _, exists := (*m)[key]; exists { return fmt.Errorf("duplicate XML map entry: %s", key) }
             var value T
             if err := d.DecodeElement(&value, &element); err != nil { return err }
             (*m)[key] = value

--- a/avrotize/commands.json
+++ b/avrotize/commands.json
@@ -3550,6 +3550,7 @@
         "package_name": "args.package",
         "json_annotation": "args.json_annotation",
         "avro_annotation": "args.avro_annotation",
+        "xml_annotation": "args.xml_annotation",
         "package_site": "args.package_site",
         "package_username": "args.package_username"
       }
@@ -3593,6 +3594,13 @@
         "required": false
       },
       {
+        "name": "--xml-annotation",
+        "type": "bool",
+        "help": "Add encoding/xml struct tags and serialization support",
+        "default": false,
+        "required": false
+      },
+      {
         "name": "--package-site",
         "type": "str",
         "help": "Package site for Go module (e.g., github.com)",
@@ -3619,6 +3627,12 @@
       {
         "name": "--json-annotation",
         "message": "Add JSON struct tags?",
+        "type": "bool",
+        "default": false
+      },
+      {
+        "name": "--xml-annotation",
+        "message": "Use XML annotations?",
         "type": "bool",
         "default": false
       }
@@ -3922,6 +3936,7 @@
         "package_name": "args.package",
         "avro_annotation": "args.avro_annotation",
         "json_annotation": "args.json_annotation",
+        "xml_annotation": "args.xml_annotation",
         "package_site": "args.package_site",
         "package_username": "args.package_username"
       }
@@ -3980,6 +3995,13 @@
         "help": "Use JSON annotations",
         "default": false,
         "required": false
+      },
+      {
+        "name": "--xml-annotation",
+        "type": "bool",
+        "help": "Use encoding/xml annotations and serialization support",
+        "default": false,
+        "required": false
       }
     ],
     "suggested_output_file_path": "{input_file_name}-go",
@@ -3993,6 +4015,12 @@
       {
         "name": "--json-annotation",
         "message": "Use JSON annotations?",
+        "type": "bool",
+        "default": false
+      },
+      {
+        "name": "--xml-annotation",
+        "message": "Use XML annotations?",
         "type": "bool",
         "default": false
       },

--- a/avrotize/common.py
+++ b/avrotize/common.py
@@ -870,6 +870,29 @@ def json_wire_name(prop_name: str, prop_schema: Any) -> str:
     return prop_name
 
 
+def xml_wire_name(name: str, schema: Any) -> str:
+    """Resolve an XML local name, honoring ``altnames.xml``."""
+    if isinstance(schema, dict):
+        altnames = schema.get("altnames")
+        if isinstance(altnames, dict) and isinstance(altnames.get("xml"), str):
+            return altnames["xml"]
+    return name
+
+
+def xml_enum_wire_value(value: Any, enum_schema: Any) -> str:
+    """Resolve an XML enum value, honoring XML alternate-symbol maps."""
+    if isinstance(enum_schema, dict):
+        # JSON Structure calls this map ``altenums`` while Avrotize/Avro
+        # schemas historically use ``altsymbols``. Accept both spellings.
+        for key in ("altenums", "altsymbols"):
+            alternates = enum_schema.get(key)
+            if isinstance(alternates, dict):
+                xml_values = alternates.get("xml")
+                if isinstance(xml_values, dict) and str(value) in xml_values:
+                    return str(xml_values[str(value)])
+    return str(value)
+
+
 def json_enum_wire_value(value: Any, enum_schema: Any) -> str:
     """
     Resolve the JSON wire string for an enum value, honoring JSON Structure ``altenums.json``.

--- a/avrotize/structuretogo.py
+++ b/avrotize/structuretogo.py
@@ -356,6 +356,9 @@ class StructureToGo:
                 'original_name': json_wire_name(prop_name, prop_schema),
                 'xml_name': xml_wire_name(prop_name, prop_schema),
                 'xml_kind': prop_schema.get('xmlkind', 'element'),
+                'xml_required': is_required and source_type not in ('array', 'set', 'map'),
+                'xml_repeated': isinstance(raw_type, str) and raw_type in ('array', 'set'),
+                'xml_ambiguous': field_type.lstrip('*') == 'interface{}',
                 'source_type': source_type
             })
 

--- a/avrotize/structuretogo.py
+++ b/avrotize/structuretogo.py
@@ -6,7 +6,8 @@ import json
 import os
 from typing import Any, Dict, List, Set, Union, Optional, cast
 
-from avrotize.common import pascal, render_template, json_wire_name, json_enum_wire_value, format_go_files
+from avrotize.common import (pascal, render_template, json_wire_name, json_enum_wire_value, format_go_files,
+                              xml_wire_name, xml_enum_wire_value)
 
 JsonNode = Dict[str, 'JsonNode'] | List['JsonNode'] | str | None
 
@@ -27,6 +28,7 @@ class StructureToGo:
         self.base_package = self._safe_package_name(base_package) if base_package else base_package
         self.output_dir = os.getcwd()
         self.json_annotation = False
+        self.xml_annotation = False
         self.avro_annotation = False
         self.package_site = 'github.com'
         self.package_username = 'username'
@@ -264,7 +266,8 @@ class StructureToGo:
                 values_type = self.convert_structure_type_to_go(
                     class_name, field_name+'Map', structure_type.get('values', {'type': 'any'}), 
                     parent_namespace, nullable=True)
-                return f"map[string]{values_type}"
+                map_type = f"map[string]{values_type}"
+                return f"XMLMap[{values_type}]" if self.xml_annotation else map_type
             elif struct_type == 'choice':
                 return self.generate_choice(structure_type, parent_namespace, write_file=True)
             elif struct_type == 'tuple':
@@ -335,7 +338,7 @@ class StructureToGo:
                 class_name, prop_name, prop_schema, schema_namespace, nullable=not is_required)
             
             # Add nullable marker if not required and not already nullable
-            if not is_required and not field_type.startswith('*') and not field_type.startswith('[') and not field_type.startswith('map[') and field_type != 'interface{}':
+            if not is_required and not field_type.startswith('*') and not field_type.startswith('[') and not field_type.startswith('map[') and not field_type.startswith('XMLMap[') and field_type != 'interface{}':
                 field_type = f'*{field_type}'
             
             # Get source type - handle nullable unions like ["int64", "null"]
@@ -351,6 +354,8 @@ class StructureToGo:
                 'name': pascal(prop_name),
                 'type': field_type,
                 'original_name': json_wire_name(prop_name, prop_schema),
+                'xml_name': xml_wire_name(prop_name, prop_schema),
+                'xml_kind': prop_schema.get('xmlkind', 'element'),
                 'source_type': source_type
             })
 
@@ -375,6 +380,10 @@ class StructureToGo:
             'fields': fields,
             'imports': imports,
             'json_annotation': self.json_annotation,
+            'xml_annotation': self.xml_annotation,
+            'xml_name': xml_wire_name(explicit_name if explicit_name else structure_schema.get('name', 'UnnamedClass'), structure_schema),
+            'xml_namespace': structure_schema.get('xmlns', ''),
+            'needs_xml_name': bool(structure_schema.get('xmlns')) or xml_wire_name(explicit_name if explicit_name else structure_schema.get('name', 'UnnamedClass'), structure_schema) != go_struct_name,
             'avro_annotation': self.avro_annotation,
             'avro_schema': avro_schema_str,
             'base_package': self.base_package,
@@ -411,7 +420,8 @@ class StructureToGo:
         self.generated_structure_types[go_enum_name] = structure_schema
 
         raw_symbols = structure_schema.get('enum', [])
-        symbols = [{'name': str(s), 'value': json_enum_wire_value(s, structure_schema)} for s in raw_symbols]
+        symbols = [{'name': str(s), 'value': json_enum_wire_value(s, structure_schema),
+                    'xml_value': xml_enum_wire_value(s, structure_schema)} for s in raw_symbols]
         
         # Determine base type
         base_type = structure_schema.get('type', 'string')
@@ -423,6 +433,7 @@ class StructureToGo:
             'symbols': symbols,
             'base_type': go_base_type,
             'base_package': self.base_package,
+            'xml_annotation': self.xml_annotation,
         }
 
         pkg_dir = os.path.join(self.output_dir, 'pkg', self.base_package)
@@ -468,7 +479,7 @@ class StructureToGo:
                 interface_name, prop_name, prop_schema, schema_namespace, nullable=not is_required)
             
             # Add nullable marker if not required and not already nullable
-            if not is_required and not field_type.startswith('*') and not field_type.startswith('[') and not field_type.startswith('map[') and field_type != 'interface{}':
+            if not is_required and not field_type.startswith('*') and not field_type.startswith('[') and not field_type.startswith('map[') and not field_type.startswith('XMLMap[') and field_type != 'interface{}':
                 field_type = f'*{field_type}'
             
             # Generate getter method
@@ -622,6 +633,7 @@ class StructureToGo:
             'package_site': self.package_site,
             'package_username': self.package_username,
             'json_annotation': self.json_annotation,
+            'xml_annotation': self.xml_annotation,
             'avro_annotation': self.avro_annotation
         }
 
@@ -630,6 +642,13 @@ class StructureToGo:
             os.makedirs(pkg_dir, exist_ok=True)
         test_file_name = os.path.join(pkg_dir, f"{name}_test.go")
         render_template('structuretogo/go_test.jinja', test_file_name, **context)
+
+    def write_xml_helpers(self) -> None:
+        """Write generic XML support for map fields."""
+        if not self.xml_annotation:
+            return
+        helper_path = os.path.join(self.output_dir, 'pkg', self.base_package, 'xml_helpers.go')
+        render_template('structuretogo/xml_helpers.jinja', helper_path, base_package=self.base_package)
 
     def write_go_mod_file(self):
         """Writes the go.mod file for the Go project"""
@@ -718,6 +737,7 @@ class StructureToGo:
         self.write_go_mod_file()
         self.write_modname_go_file()
         self.generate_helpers()
+        self.write_xml_helpers()
         format_go_files(self.output_dir)
 
     def convert(self, structure_schema_path: str, output_dir: str):
@@ -733,7 +753,7 @@ class StructureToGo:
 
 def convert_structure_to_go(structure_schema_path: str, go_file_path: str, package_name: str = '',
                             json_annotation: bool = False, avro_annotation: bool = False,
-                            package_site: str = 'github.com', package_username: str = 'username'):
+                            xml_annotation: bool = False, package_site: str = 'github.com', package_username: str = 'username'):
     """Converts JSON Structure schema to Go structs
 
     Args:
@@ -742,6 +762,7 @@ def convert_structure_to_go(structure_schema_path: str, go_file_path: str, packa
         package_name (str): Base package name
         json_annotation (bool): Include JSON annotations
         avro_annotation (bool): Include Avro annotations
+        xml_annotation (bool): Include XML annotations and serialization
         package_site (str): Package site for Go module
         package_username (str): Package username for Go module
     """
@@ -751,6 +772,7 @@ def convert_structure_to_go(structure_schema_path: str, go_file_path: str, packa
     structuretogo = StructureToGo(package_name)
     structuretogo.json_annotation = json_annotation
     structuretogo.avro_annotation = avro_annotation
+    structuretogo.xml_annotation = xml_annotation
     structuretogo.package_site = package_site
     structuretogo.package_username = package_username
     structuretogo.convert(structure_schema_path, go_file_path)
@@ -758,7 +780,7 @@ def convert_structure_to_go(structure_schema_path: str, go_file_path: str, packa
 
 def convert_structure_schema_to_go(structure_schema: JsonNode, output_dir: str, package_name: str = '',
                                    json_annotation: bool = False, avro_annotation: bool = False,
-                                   package_site: str = 'github.com', package_username: str = 'username'):
+                                   xml_annotation: bool = False, package_site: str = 'github.com', package_username: str = 'username'):
     """Converts JSON Structure schema to Go structs
 
     Args:
@@ -767,12 +789,14 @@ def convert_structure_schema_to_go(structure_schema: JsonNode, output_dir: str, 
         package_name (str): Base package name
         json_annotation (bool): Include JSON annotations
         avro_annotation (bool): Include Avro annotations
+        xml_annotation (bool): Include XML annotations and serialization
         package_site (str): Package site for Go module
         package_username (str): Package username for Go module
     """
     structuretogo = StructureToGo(package_name)
     structuretogo.json_annotation = json_annotation
     structuretogo.avro_annotation = avro_annotation
+    structuretogo.xml_annotation = xml_annotation
     structuretogo.package_site = package_site
     structuretogo.package_username = package_username
     structuretogo.convert_schema(structure_schema, output_dir)

--- a/avrotize/structuretogo/go_enum.jinja
+++ b/avrotize/structuretogo/go_enum.jinja
@@ -1,5 +1,12 @@
 package {{ base_package }}
 
+{%- if xml_annotation %}
+import (
+    "encoding/xml"
+    "fmt"
+)
+{%- endif %}
+
 {%- if doc %}
 // {{ doc }}
 {%- endif %}
@@ -10,3 +17,40 @@ const (
     {{ enum_name }}_{{ symbol.name }} {{ enum_name }} = {% if base_type == 'string' %}"{{ symbol.value }}"{% else %}{{ loop.index0 }}{% endif %}
 {%- endfor %}
 )
+
+{%- if xml_annotation %}
+func (v {{ enum_name }}) xmlValue() (string, error) {
+    switch v {
+    {%- for symbol in symbols %}
+    case {{ enum_name }}_{{ symbol.name }}:
+        return "{{ symbol.xml_value }}", nil
+    {%- endfor %}
+    default:
+        return "", fmt.Errorf("invalid {{ enum_name }} value: %v", v)
+    }
+}
+
+func (v *{{ enum_name }}) setXMLValue(value string) error {
+    switch value {
+    {%- for symbol in symbols %}
+    case "{{ symbol.xml_value }}": *v = {{ enum_name }}_{{ symbol.name }}
+    {%- endfor %}
+    default: return fmt.Errorf("invalid {{ enum_name }} XML value: %s", value)
+    }
+    return nil
+}
+
+func (v {{ enum_name }}) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+    value, err := v.xmlValue(); if err != nil { return err }
+    return e.EncodeElement(value, start)
+}
+func (v *{{ enum_name }}) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+    var value string
+    if err := d.DecodeElement(&value, &start); err != nil { return err }
+    return v.setXMLValue(value)
+}
+func (v {{ enum_name }}) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
+    value, err := v.xmlValue(); return xml.Attr{Name: name, Value: value}, err
+}
+func (v *{{ enum_name }}) UnmarshalXMLAttr(attr xml.Attr) error { return v.setXMLValue(attr.Value) }
+{%- endif %}

--- a/avrotize/structuretogo/go_struct.jinja
+++ b/avrotize/structuretogo/go_struct.jinja
@@ -7,7 +7,10 @@ import (
     {%- if json_annotation %}
     "encoding/json"
     {%- endif %}
-    {%- if json_annotation or avro_annotation %}
+    {%- if xml_annotation %}
+    "encoding/xml"
+    {%- endif %}
+    {%- if json_annotation or xml_annotation or avro_annotation %}
     "compress/gzip"
     "bytes"
     "fmt"
@@ -26,88 +29,65 @@ import (
 // {{ doc }}
 {%- endif %}
 type {{ struct_name }} struct {
+    {%- if xml_annotation and needs_xml_name %}
+    XMLName xml.Name `{% if json_annotation %}json:"-" {% endif %}{% if avro_annotation %}avro:"-" {% endif %}xml:"{% if xml_namespace %}{{ xml_namespace }} {% endif %}{{ xml_name }}"`
+    {%- endif %}
     {%- for field in fields %}
     {%- set is_json_string = field.source_type in ['int64', 'uint64', 'int128', 'uint128', 'decimal'] %}
-    {{ field.name }} {{ field.type }}{% if json_annotation or avro_annotation %} `{% if json_annotation %}json:"{{ field.original_name }}{% if is_json_string %},string{% endif %}"{% endif %}{% if json_annotation and avro_annotation %} {% endif %}{% if avro_annotation %}avro:"{{ field.original_name }}"{% endif %}`{% endif %}
+    {{ field.name }} {{ field.type }}{% if json_annotation or xml_annotation or avro_annotation %} `{% if json_annotation %}json:"{{ field.original_name }}{% if is_json_string %},string{% endif %}"{% endif %}{% if json_annotation and (xml_annotation or avro_annotation) %} {% endif %}{% if xml_annotation %}xml:"{{ field.xml_name }}{% if field.xml_kind == 'attribute' %},attr{% endif %}"{% endif %}{% if xml_annotation and avro_annotation %} {% endif %}{% if avro_annotation %}avro:"{{ field.original_name }}"{% endif %}`{% endif %}
     {%- endfor %}
 }
 
 {%- if base_interface %}
 
-// Verify that {{ struct_name }} implements {{ base_interface }} interface
 var _ {{ base_interface }} = (*{{ struct_name }})(nil)
-
 {%- for field in fields %}
 
-// Get{{ field.name }} returns the {{ field.original_name }} field
-func (s *{{ struct_name }}) Get{{ field.name }}() {{ field.type }} {
-    return s.{{ field.name }}
-}
-
-// Set{{ field.name }} sets the {{ field.original_name }} field
-func (s *{{ struct_name }}) Set{{ field.name }}(value {{ field.type }}) {
-    s.{{ field.name }} = value
-}
+func (s *{{ struct_name }}) Get{{ field.name }}() {{ field.type }} { return s.{{ field.name }} }
+func (s *{{ struct_name }}) Set{{ field.name }}(value {{ field.type }}) { s.{{ field.name }} = value }
 {%- endfor %}
 {%- endif %}
 
 {%- if avro_annotation and avro_schema %}
 
-// AvroSchema is the embedded Avro schema for {{ struct_name }}
 const {{ struct_name }}AvroSchema = `{{ avro_schema }}`
-
-// GetAvroSchema returns the parsed Avro schema for {{ struct_name }}
-func (s *{{ struct_name }}) GetAvroSchema() (avro.Schema, error) {
-    return avro.Parse({{ struct_name }}AvroSchema)
-}
+func (s *{{ struct_name }}) GetAvroSchema() (avro.Schema, error) { return avro.Parse({{ struct_name }}AvroSchema) }
 {%- endif %}
 
-{%- if json_annotation or avro_annotation %}
+{%- if json_annotation or xml_annotation or avro_annotation %}
 func (s *{{ struct_name }}) ToByteArray(contentType string) ([]byte, error) {
     var result []byte
     var err error
-    
-    // Strip +gzip suffix to get the base media type
-    mediaType := strings.Split(contentType, ";")[0]
+    mediaType := strings.TrimSpace(strings.Split(contentType, ";")[0])
     isGzipped := strings.HasSuffix(mediaType, "+gzip")
-    if isGzipped {
-        mediaType = strings.TrimSuffix(mediaType, "+gzip")
-    }
-    
+    if isGzipped { mediaType = strings.TrimSuffix(mediaType, "+gzip") }
     switch mediaType {
     {%- if json_annotation %}
     case "application/json":
         result, err = json.Marshal(s)
-        if err != nil {
-            return nil, err
-        }
+    {%- endif %}
+    {%- if xml_annotation %}
+    case "application/xml", "text/xml":
+        {%- if needs_xml_name %}
+        s.XMLName = xml.Name{Space: "{{ xml_namespace }}", Local: "{{ xml_name }}"}
+        {%- endif %}
+        result, err = xml.Marshal(s)
     {%- endif %}
     {%- if avro_annotation %}
     case "avro/binary", "application/vnd.apache.avro+avro":
-        schema, err := s.GetAvroSchema()
-        if err != nil {
-            return nil, fmt.Errorf("failed to parse Avro schema: %w", err)
-        }
+        schema, schemaErr := s.GetAvroSchema()
+        if schemaErr != nil { return nil, fmt.Errorf("failed to parse Avro schema: %w", schemaErr) }
         result, err = avro.Marshal(schema, s)
-        if err != nil {
-            return nil, fmt.Errorf("failed to marshal Avro: %w", err)
-        }
     {%- endif %}
     default:
         return nil, fmt.Errorf("unsupported media type: %s", mediaType)
     }
-    
+    if err != nil { return nil, err }
     if isGzipped {
         var buf bytes.Buffer
         gzipWriter := gzip.NewWriter(&buf)
-        _, err = gzipWriter.Write(result)
-        if err != nil {
-            return nil, err
-        }
-        err = gzipWriter.Close()
-        if err != nil {
-            return nil, err
-        }
+        if _, err = gzipWriter.Write(result); err != nil { return nil, err }
+        if err = gzipWriter.Close(); err != nil { return nil, err }
         result = buf.Bytes()
     }
     return result, nil
@@ -116,73 +96,60 @@ func (s *{{ struct_name }}) ToByteArray(contentType string) ([]byte, error) {
 func {{ struct_name }}FromData(data interface{}, contentType string) (*{{ struct_name }}, error) {
     var err error
     var s {{ struct_name }}
-    
-    // Strip +gzip suffix to get the base media type
-    mediaType := strings.Split(contentType, ";")[0]
+    mediaType := strings.TrimSpace(strings.Split(contentType, ";")[0])
     isGzipped := strings.HasSuffix(mediaType, "+gzip")
     if isGzipped {
         mediaType = strings.TrimSuffix(mediaType, "+gzip")
-    }
-    
-    if isGzipped {
         var reader io.Reader
         switch v := data.(type) {
-        case []byte:
-            reader = bytes.NewReader(v)
-        case io.Reader:
-            reader = v
-        default:
-            return nil, fmt.Errorf("unsupported data type for gzip: %T", data)
+        case []byte: reader = bytes.NewReader(v)
+        case io.Reader: reader = v
+        default: return nil, fmt.Errorf("unsupported data type for gzip: %T", data)
         }
-        gzipReader, err := gzip.NewReader(reader)
-        if err != nil {
-            return nil, err
-        }
+        gzipReader, gzipErr := gzip.NewReader(reader)
+        if gzipErr != nil { return nil, gzipErr }
         defer gzipReader.Close()
         data, err = io.ReadAll(gzipReader)
-        if err != nil {
-            return nil, err
-        }
+        if err != nil { return nil, err }
     }
-    
     switch mediaType {
     {%- if json_annotation %}
     case "application/json":
         switch v := data.(type) {
-        case []byte:
-            err = json.Unmarshal(v, &s)
-        case string:
-            err = json.Unmarshal([]byte(v), &s)
-        case io.Reader:
-            err = json.NewDecoder(v).Decode(&s)
-        default:
-            return nil, fmt.Errorf("unsupported data type for JSON: %T", data)
+        case []byte: err = json.Unmarshal(v, &s)
+        case string: err = json.Unmarshal([]byte(v), &s)
+        case io.Reader: err = json.NewDecoder(v).Decode(&s)
+        default: return nil, fmt.Errorf("unsupported data type for JSON: %T", data)
+        }
+    {%- endif %}
+    {%- if xml_annotation %}
+    case "application/xml", "text/xml":
+        switch v := data.(type) {
+        case []byte: err = xml.Unmarshal(v, &s)
+        case string: err = xml.Unmarshal([]byte(v), &s)
+        case io.Reader: err = xml.NewDecoder(v).Decode(&s)
+        default: return nil, fmt.Errorf("unsupported data type for XML: %T", data)
         }
     {%- endif %}
     {%- if avro_annotation %}
     case "avro/binary", "application/vnd.apache.avro+avro":
-        var tempInstance {{ struct_name }}
-        schema, schemaErr := tempInstance.GetAvroSchema()
-        if schemaErr != nil {
-            return nil, fmt.Errorf("failed to parse Avro schema: %w", schemaErr)
-        }
+        schema, schemaErr := s.GetAvroSchema()
+        if schemaErr != nil { return nil, fmt.Errorf("failed to parse Avro schema: %w", schemaErr) }
         switch v := data.(type) {
-        case []byte:
-            err = avro.Unmarshal(schema, v, &s)
-        default:
-            return nil, fmt.Errorf("unsupported data type for Avro: %T", data)
+        case []byte: err = avro.Unmarshal(schema, v, &s)
+        case io.Reader:
+            rawData, readErr := io.ReadAll(v)
+            if readErr != nil { return nil, readErr }
+            err = avro.Unmarshal(schema, rawData, &s)
+        default: return nil, fmt.Errorf("unsupported data type for Avro: %T", data)
         }
     {%- endif %}
     default:
         return nil, fmt.Errorf("unsupported media type: %s", mediaType)
     }
-    if err != nil {
-        return nil, err
-    }
+    if err != nil { return nil, err }
     return &s, nil
 }
 {%- endif %}
 
-func (s *{{ struct_name }}) ToObject() interface{} {
-    return s
-}
+func (s *{{ struct_name }}) ToObject() interface{} { return s }

--- a/avrotize/structuretogo/go_struct.jinja
+++ b/avrotize/structuretogo/go_struct.jinja
@@ -109,7 +109,15 @@ func {{ struct_name }}FromData(data interface{}, contentType string) (*{{ struct
         gzipReader, gzipErr := gzip.NewReader(reader)
         if gzipErr != nil { return nil, gzipErr }
         defer gzipReader.Close()
+        {%- if xml_annotation %}
+        if mediaType == "application/xml" || mediaType == "text/xml" {
+            data, err = readXMLBytes(gzipReader)
+        } else {
+            data, err = io.ReadAll(gzipReader)
+        }
+        {%- else %}
         data, err = io.ReadAll(gzipReader)
+        {%- endif %}
         if err != nil { return nil, err }
     }
     switch mediaType {
@@ -124,12 +132,11 @@ func {{ struct_name }}FromData(data interface{}, contentType string) (*{{ struct
     {%- endif %}
     {%- if xml_annotation %}
     case "application/xml", "text/xml":
-        switch v := data.(type) {
-        case []byte: err = xml.Unmarshal(v, &s)
-        case string: err = xml.Unmarshal([]byte(v), &s)
-        case io.Reader: err = xml.NewDecoder(v).Decode(&s)
-        default: return nil, fmt.Errorf("unsupported data type for XML: %T", data)
-        }
+        err = secureXMLUnmarshal(data, &s, xml.Name{Space: "{{ xml_namespace }}", Local: "{{ xml_name }}"}, map[string]xmlFieldRule{
+            {%- for field in fields %}
+            "{% if field.xml_kind == 'attribute' %}@{% endif %}{{ field.xml_name }}": xmlFieldRule{Attribute: {{ 'true' if field.xml_kind == 'attribute' else 'false' }}, Required: {{ 'true' if field.xml_required else 'false' }}, Repeated: {{ 'true' if field.xml_repeated else 'false' }}, Ambiguous: {{ 'true' if field.xml_ambiguous else 'false' }}},
+            {%- endfor %}
+        })
     {%- endif %}
     {%- if avro_annotation %}
     case "avro/binary", "application/vnd.apache.avro+avro":

--- a/avrotize/structuretogo/go_test.jinja
+++ b/avrotize/structuretogo/go_test.jinja
@@ -1,70 +1,35 @@
 package {{ base_package }}
 
-import (
-    "testing"
-    {%- if json_annotation and kind == 'struct' %}
-    "encoding/json"
-    {%- endif %}
-)
+import "testing"
 
-func Test{{ struct_name }}(t *testing.T) {
-    {%- if kind == 'struct' %}
+func Test{{ struct_name }}_Instantiate(t *testing.T) {
+    value := CreateInstance{{ struct_name }}()
+    _ = value
+}
+
+{%- if kind == "struct" and (json_annotation or xml_annotation or avro_annotation) %}
+func Test{{ struct_name }}_Serialization(t *testing.T) {
+    input := CreateInstance{{ struct_name }}()
     {%- if json_annotation %}
-    instance := CreateInstance{{ struct_name }}()
-    
-    // Test JSON marshaling
-    data, err := json.Marshal(&instance)
-    if err != nil {
-        t.Fatalf("Failed to marshal {{ struct_name }}: %v", err)
+    {
+        data, err := input.ToByteArray("application/json")
+        if err != nil { t.Fatalf("JSON marshal failed: %v", err) }
+        if _, err = {{ struct_name }}FromData(data, "application/json"); err != nil { t.Fatalf("JSON unmarshal failed: %v", err) }
     }
-    
-    // Test JSON unmarshaling
-    var decoded {{ struct_name }}
-    err = json.Unmarshal(data, &decoded)
-    if err != nil {
-        t.Fatalf("Failed to unmarshal {{ struct_name }}: %v", err)
-    }
-    
-    // Test ToByteArray and FromData methods
-    contentType := "application/json"
-    byteArray, err := instance.ToByteArray(contentType)
-    if err != nil {
-        t.Fatalf("Failed to convert to byte array: %v", err)
-    }
-    
-    fromData, err := {{ struct_name }}FromData(byteArray, contentType)
-    if err != nil {
-        t.Fatalf("Failed to create from data: %v", err)
-    }
-    
-    if fromData == nil {
-        t.Fatal("FromData returned nil")
-    }
-    
-    // Test with gzipped data
-    contentTypeGzip := "application/json+gzip"
-    byteArrayGzip, err := instance.ToByteArray(contentTypeGzip)
-    if err != nil {
-        t.Fatalf("Failed to convert to gzipped byte array: %v", err)
-    }
-    
-    fromDataGzip, err := {{ struct_name }}FromData(byteArrayGzip, contentTypeGzip)
-    if err != nil {
-        t.Fatalf("Failed to create from gzipped data: %v", err)
-    }
-    
-    if fromDataGzip == nil {
-        t.Fatal("FromData with gzip returned nil")
-    }
-    {%- else %}
-    // Basic instance creation test (no JSON serialization without json annotation)
-    instance := CreateInstance{{ struct_name }}()
-    _ = instance // Verify instance creation works
     {%- endif %}
-    {%- elif kind == 'enum' %}
-    // Test enum values
-    {%- for symbol in fields %}
-    _ = {{ struct_name }}_{{ symbol }}
-    {%- endfor %}
+    {%- if xml_annotation %}
+    for _, contentType := range []string{"application/xml", "text/xml", "application/xml+gzip"} {
+        data, err := input.ToByteArray(contentType)
+        if err != nil { t.Fatalf("XML marshal for %s failed: %v", contentType, err) }
+        if _, err = {{ struct_name }}FromData(data, contentType); err != nil { t.Fatalf("XML unmarshal for %s failed: %v", contentType, err) }
+    }
+    {%- endif %}
+    {%- if avro_annotation %}
+    {
+        data, err := input.ToByteArray("avro/binary")
+        if err != nil { t.Fatalf("Avro marshal failed: %v", err) }
+        if _, err = {{ struct_name }}FromData(data, "avro/binary"); err != nil { t.Fatalf("Avro unmarshal failed: %v", err) }
+    }
     {%- endif %}
 }
+{%- endif %}

--- a/avrotize/structuretogo/go_test.jinja
+++ b/avrotize/structuretogo/go_test.jinja
@@ -1,5 +1,67 @@
 package {{ base_package }}
 
+{%- if not xml_annotation %}
+import (
+    "testing"
+    {%- if json_annotation and kind == 'struct' %}
+    "encoding/json"
+    {%- endif %}
+)
+
+func Test{{ struct_name }}(t *testing.T) {
+    {%- if kind == 'struct' %}
+    {%- if json_annotation %}
+    instance := CreateInstance{{ struct_name }}()
+
+    data, err := json.Marshal(&instance)
+    if err != nil {
+        t.Fatalf("Failed to marshal {{ struct_name }}: %v", err)
+    }
+
+    var decoded {{ struct_name }}
+    err = json.Unmarshal(data, &decoded)
+    if err != nil {
+        t.Fatalf("Failed to unmarshal {{ struct_name }}: %v", err)
+    }
+
+    contentType := "application/json"
+    byteArray, err := instance.ToByteArray(contentType)
+    if err != nil {
+        t.Fatalf("Failed to convert to byte array: %v", err)
+    }
+
+    fromData, err := {{ struct_name }}FromData(byteArray, contentType)
+    if err != nil {
+        t.Fatalf("Failed to create from data: %v", err)
+    }
+    if fromData == nil {
+        t.Fatal("FromData returned nil")
+    }
+
+    contentTypeGzip := "application/json+gzip"
+    byteArrayGzip, err := instance.ToByteArray(contentTypeGzip)
+    if err != nil {
+        t.Fatalf("Failed to convert to gzipped byte array: %v", err)
+    }
+
+    fromDataGzip, err := {{ struct_name }}FromData(byteArrayGzip, contentTypeGzip)
+    if err != nil {
+        t.Fatalf("Failed to create from gzipped data: %v", err)
+    }
+    if fromDataGzip == nil {
+        t.Fatal("FromData with gzip returned nil")
+    }
+    {%- else %}
+    instance := CreateInstance{{ struct_name }}()
+    _ = instance
+    {%- endif %}
+    {%- elif kind == 'enum' %}
+    {%- for symbol in fields %}
+    _ = {{ struct_name }}_{{ symbol }}
+    {%- endfor %}
+    {%- endif %}
+}
+{%- else %}
 import "testing"
 
 func Test{{ struct_name }}_Instantiate(t *testing.T) {
@@ -7,7 +69,7 @@ func Test{{ struct_name }}_Instantiate(t *testing.T) {
     _ = value
 }
 
-{%- if kind == "struct" and (json_annotation or xml_annotation or avro_annotation) %}
+{%- if kind == "struct" %}
 func Test{{ struct_name }}_Serialization(t *testing.T) {
     input := CreateInstance{{ struct_name }}()
     {%- if json_annotation %}
@@ -17,19 +79,11 @@ func Test{{ struct_name }}_Serialization(t *testing.T) {
         if _, err = {{ struct_name }}FromData(data, "application/json"); err != nil { t.Fatalf("JSON unmarshal failed: %v", err) }
     }
     {%- endif %}
-    {%- if xml_annotation %}
     for _, contentType := range []string{"application/xml", "text/xml", "application/xml+gzip"} {
         data, err := input.ToByteArray(contentType)
         if err != nil { t.Fatalf("XML marshal for %s failed: %v", contentType, err) }
         if _, err = {{ struct_name }}FromData(data, contentType); err != nil { t.Fatalf("XML unmarshal for %s failed: %v", contentType, err) }
     }
-    {%- endif %}
-    {%- if avro_annotation %}
-    {
-        data, err := input.ToByteArray("avro/binary")
-        if err != nil { t.Fatalf("Avro marshal failed: %v", err) }
-        if _, err = {{ struct_name }}FromData(data, "avro/binary"); err != nil { t.Fatalf("Avro unmarshal failed: %v", err) }
-    }
-    {%- endif %}
 }
+{%- endif %}
 {%- endif %}

--- a/avrotize/structuretogo/xml_helpers.jinja
+++ b/avrotize/structuretogo/xml_helpers.jinja
@@ -1,0 +1,45 @@
+package {{ base_package }}
+
+import (
+    "encoding/xml"
+    "fmt"
+    "sort"
+)
+
+// XMLMap provides deterministic XML encoding for Go maps. Entries are encoded
+// as <entry key="..."></entry> children of the field element.
+type XMLMap[T any] map[string]T
+
+func (m XMLMap[T]) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+    if err := e.EncodeToken(start); err != nil { return err }
+    keys := make([]string, 0, len(m))
+    for key := range m { keys = append(keys, key) }
+    sort.Strings(keys)
+    for _, key := range keys {
+        entry := xml.StartElement{Name: xml.Name{Local: "entry"}, Attr: []xml.Attr{xml.Attr{Name: xml.Name{Local: "key"}, Value: key}}}
+        if err := e.EncodeElement(m[key], entry); err != nil { return err }
+    }
+    return e.EncodeToken(start.End())
+}
+
+func (m *XMLMap[T]) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+    if *m == nil { *m = make(XMLMap[T]) }
+    for {
+        token, err := d.Token()
+        if err != nil { return err }
+        switch element := token.(type) {
+        case xml.StartElement:
+            if element.Name.Local != "entry" { return fmt.Errorf("unexpected XML map element: %s", element.Name.Local) }
+            var key string
+            for _, attr := range element.Attr {
+                if attr.Name.Local == "key" { key = attr.Value; break }
+            }
+            if key == "" { return fmt.Errorf("XML map entry is missing key attribute") }
+            var value T
+            if err := d.DecodeElement(&value, &element); err != nil { return err }
+            (*m)[key] = value
+        case xml.EndElement:
+            if element.Name == start.Name { return nil }
+        }
+    }
+}

--- a/avrotize/structuretogo/xml_helpers.jinja
+++ b/avrotize/structuretogo/xml_helpers.jinja
@@ -3,8 +3,106 @@ package {{ base_package }}
 import (
     "encoding/xml"
     "fmt"
+    "io"
     "sort"
+    "strings"
 )
+
+const (
+    maxXMLBytes = 1 << 20
+    maxXMLDepth = 100
+)
+
+type xmlFieldRule struct {
+    Attribute bool
+    Required  bool
+    Repeated  bool
+    Ambiguous bool
+}
+
+func readXMLBytes(reader io.Reader) ([]byte, error) {
+    data, err := io.ReadAll(io.LimitReader(reader, maxXMLBytes+1))
+    if err != nil { return nil, err }
+    if len(data) > maxXMLBytes { return nil, fmt.Errorf("XML payload exceeds %d bytes", maxXMLBytes) }
+    return data, nil
+}
+
+func xmlInputBytes(data interface{}) ([]byte, error) {
+    switch value := data.(type) {
+    case []byte:
+        if len(value) > maxXMLBytes { return nil, fmt.Errorf("XML payload exceeds %d bytes", maxXMLBytes) }
+        return value, nil
+    case string:
+        if len(value) > maxXMLBytes { return nil, fmt.Errorf("XML payload exceeds %d bytes", maxXMLBytes) }
+        return []byte(value), nil
+    case io.Reader:
+        return readXMLBytes(value)
+    default:
+        return nil, fmt.Errorf("unsupported data type for XML: %T", data)
+    }
+}
+
+func secureXMLUnmarshal(data interface{}, destination interface{}, root xml.Name, rules map[string]xmlFieldRule) error {
+    raw, err := xmlInputBytes(data)
+    if err != nil { return err }
+
+    decoder := xml.NewDecoder(strings.NewReader(string(raw)))
+    counts := make(map[string]int, len(rules))
+    depth := 0
+    rootSeen := false
+    for {
+        token, tokenErr := decoder.Token()
+        if tokenErr == io.EOF { break }
+        if tokenErr != nil { return fmt.Errorf("invalid XML: %w", tokenErr) }
+        switch value := token.(type) {
+        case xml.Directive:
+            return fmt.Errorf("XML directives and DOCTYPE declarations are not allowed")
+        case xml.ProcInst:
+            if value.Target != "xml" || rootSeen { return fmt.Errorf("XML processing instructions are not allowed") }
+        case xml.StartElement:
+            if depth == 0 {
+                if rootSeen { return fmt.Errorf("XML contains multiple root elements") }
+                rootSeen = true
+                if value.Name != root {
+                    return fmt.Errorf("unexpected XML root namespace=%q local=%q; expected namespace=%q local=%q", value.Name.Space, value.Name.Local, root.Space, root.Local)
+                }
+                for _, attr := range value.Attr {
+                    if attr.Name.Local == "xmlns" || attr.Name.Space == "xmlns" || attr.Name.Space == "http://www.w3.org/2000/xmlns/" { continue }
+                    if attr.Name.Space != "" { return fmt.Errorf("unexpected namespace %q for XML attribute %s", attr.Name.Space, attr.Name.Local) }
+                    key := "@" + attr.Name.Local
+                    rule, ok := rules[key]
+                    if !ok || !rule.Attribute { return fmt.Errorf("unknown XML attribute: %s", attr.Name.Local) }
+                    counts[key]++
+                    if counts[key] > 1 { return fmt.Errorf("duplicate XML attribute: %s", attr.Name.Local) }
+                }
+            } else if depth == 1 {
+                if value.Name.Space != root.Space {
+                    return fmt.Errorf("unexpected namespace %q for XML element %s", value.Name.Space, value.Name.Local)
+                }
+                rule, ok := rules[value.Name.Local]
+                if !ok || rule.Attribute { return fmt.Errorf("unknown XML element: %s", value.Name.Local) }
+                if rule.Ambiguous { return fmt.Errorf("XML field %s has an ambiguous interface union", value.Name.Local) }
+                counts[value.Name.Local]++
+                if !rule.Repeated && counts[value.Name.Local] > 1 { return fmt.Errorf("duplicate XML element: %s", value.Name.Local) }
+            }
+            depth++
+            if depth > maxXMLDepth { return fmt.Errorf("XML nesting exceeds %d elements", maxXMLDepth) }
+        case xml.EndElement:
+            depth--
+            if depth < 0 { return fmt.Errorf("invalid XML nesting") }
+        case xml.CharData:
+            if depth == 0 && strings.TrimSpace(string(value)) != "" { return fmt.Errorf("non-whitespace data outside XML root") }
+        }
+    }
+    if !rootSeen || depth != 0 { return fmt.Errorf("XML document is incomplete") }
+    for key, rule := range rules {
+        if rule.Required && counts[key] == 0 {
+            return fmt.Errorf("required XML field is missing: %s", strings.TrimPrefix(key, "@"))
+        }
+    }
+    if err := xml.Unmarshal(raw, destination); err != nil { return fmt.Errorf("invalid XML value: %w", err) }
+    return nil
+}
 
 // XMLMap provides deterministic XML encoding for Go maps. Entries are encoded
 // as <entry key="..."></entry> children of the field element.
@@ -30,11 +128,15 @@ func (m *XMLMap[T]) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
         switch element := token.(type) {
         case xml.StartElement:
             if element.Name.Local != "entry" { return fmt.Errorf("unexpected XML map element: %s", element.Name.Local) }
-            var key string
+            key := ""
+            foundKey := false
             for _, attr := range element.Attr {
-                if attr.Name.Local == "key" { key = attr.Value; break }
+                if attr.Name.Local != "key" { return fmt.Errorf("unexpected XML map attribute: %s", attr.Name.Local) }
+                if foundKey { return fmt.Errorf("duplicate XML map key attribute") }
+                key, foundKey = attr.Value, true
             }
-            if key == "" { return fmt.Errorf("XML map entry is missing key attribute") }
+            if !foundKey { return fmt.Errorf("XML map entry is missing key attribute") }
+            if _, exists := (*m)[key]; exists { return fmt.Errorf("duplicate XML map entry: %s", key) }
             var value T
             if err := d.DecodeElement(&value, &element); err != nil { return err }
             (*m)[key] = value

--- a/test/test_go_xml.py
+++ b/test/test_go_xml.py
@@ -1,0 +1,126 @@
+"Focused XML parity tests for the Go generators (issue #412)."
+
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+import pytest
+
+from avrotize.avrotogo import convert_avro_schema_to_go
+from avrotize.common import xml_enum_wire_value, xml_wire_name
+from avrotize.structuretogo import convert_structure_schema_to_go
+
+AVRO_SCHEMA = {
+    "type": "record", "name": "Order", "xmlns": "urn:orders", "altnames": {"xml": "order-doc"},
+    "fields": [
+        {"name": "id", "type": "string", "xmlkind": "attribute", "altnames": {"xml": "order-id"}},
+        {"name": "note", "type": ["null", "string"], "default": None},
+        {"name": "child", "type": {"type": "record", "name": "Child", "fields": [{"name": "value", "type": "string"}]}},
+        {"name": "items", "type": {"type": "array", "items": "string"}},
+        {"name": "labels", "type": {"type": "map", "values": "string"}},
+        {"name": "status", "type": {"type": "enum", "name": "Status", "symbols": ["NEW", "DONE"], "altsymbols": {"xml": {"NEW": "new-order"}}}},
+    ],
+}
+
+STRUCTURE_SCHEMA = {
+    "type": "object", "name": "Order", "xmlns": "urn:orders", "altnames": {"xml": "order-doc"},
+    "properties": {
+        "id": {"type": "string", "xmlkind": "attribute", "altnames": {"xml": "order-id"}},
+        "note": {"type": "string"},
+        "child": {"type": "object", "name": "Child", "properties": {"value": {"type": "string"}}, "required": ["value"]},
+        "items": {"type": "array", "items": {"type": "string"}},
+        "labels": {"type": "map", "values": {"type": "string"}},
+        "status": {"type": "string", "name": "Status", "enum": ["NEW", "DONE"], "altenums": {"xml": {"NEW": "new-order"}}},
+    },
+    "required": ["id", "child", "items", "labels", "status"],
+}
+
+
+def _generate(converter, schema, name):
+    output = Path(tempfile.mkdtemp(prefix=f"avrotize-{name}-xml-"))
+    converter(schema, str(output), package_name="xmltest", xml_annotation=True, json_annotation=True)
+    return output
+
+
+def _source(output, name):
+    return (output / "pkg" / "xmltest" / f"{name}.go").read_text(encoding="utf-8")
+
+
+def test_xml_alternate_name_helpers():
+    assert xml_wire_name("safe", {"altnames": {"xml": "wire-name"}}) == "wire-name"
+    assert xml_wire_name("safe", {"altnames": {"json": "ignored"}}) == "safe"
+    assert xml_enum_wire_value("A", {"altenums": {"xml": {"A": "alpha"}}}) == "alpha"
+    assert xml_enum_wire_value("A", {"altsymbols": {"xml": {"A": "alpha"}}}) == "alpha"
+
+
+@pytest.mark.parametrize("converter,schema", [(convert_avro_schema_to_go, AVRO_SCHEMA), (convert_structure_schema_to_go, STRUCTURE_SCHEMA)])
+def test_go_xml_generator_metadata_and_runtime_branches(converter, schema):
+    output = _generate(converter, schema, converter.__name__)
+    source = _source(output, "Order")
+    child = _source(output, "Child")
+    enum = _source(output, "Status")
+    assert 'XMLName xml.Name `json:"-" xml:"urn:orders order-doc"`' in ' '.join(source.split())
+    assert 'xml:"order-id,attr"' in source
+    assert 'xml:"note"' in source
+    assert "XMLName" not in child
+    assert 'case "application/xml", "text/xml":' in source
+    assert 'strings.TrimSuffix(mediaType, "+gzip")' in source
+    assert "MarshalXML" in enum and 'return "new-order", nil' in enum
+    assert "type XMLMap[T any] map[string]T" in _source(output, "xml_helpers")
+
+
+def test_go_cli_exposes_xml_annotation_for_both_converters():
+    commands_path = Path(__file__).parents[1] / "avrotize" / "commands.json"
+    commands = {item["command"]: item for item in json.loads(commands_path.read_text(encoding="utf-8"))}
+    for command in ("a2go", "s2go"):
+        assert "xml_annotation" in commands[command]["function"]["args"]
+        assert "--xml-annotation" in [arg["name"] for arg in commands[command]["args"]]
+
+
+GO_RUNTIME_TEST = r'''package xmltest
+
+import (
+    "reflect"
+    "strings"
+    "testing"
+)
+
+func strptr(value string) *string { return &value }
+
+func TestIssue412XMLRoundTrip(t *testing.T) {
+    input := &Order{
+        Id: "42", Note: strptr("optional"), Child: Child{Value: "nested"},
+        Items: []string{"one", "two"}, Labels: XMLMap[*string]{"a": strptr("A")},
+        Status: Status_NEW,
+    }
+    for _, contentType := range []string{"application/xml", "text/xml", "application/xml+gzip"} {
+        data, err := input.ToByteArray(contentType)
+        if err != nil { t.Fatalf("marshal %s: %v", contentType, err) }
+        output, err := OrderFromData(data, contentType)
+        if err != nil { t.Fatalf("unmarshal %s: %v", contentType, err) }
+        if !reflect.DeepEqual(input, output) { t.Fatalf("round trip differs: %#v != %#v", input, output) }
+        if contentType == "application/xml" {
+            wire := string(data)
+            for _, want := range []string{`<order-doc xmlns="urn:orders"`, `order-id="42"`, `<child>`, `<items>one</items>`, `<labels>`, `key="a"`, `<status>new-order</status>`} {
+                if !strings.Contains(wire, want) { t.Fatalf("XML %q does not contain %q", wire, want) }
+            }
+        }
+    }
+}
+'''
+
+
+@pytest.mark.parametrize("converter,schema", [(convert_avro_schema_to_go, AVRO_SCHEMA), (convert_structure_schema_to_go, STRUCTURE_SCHEMA)])
+def test_generated_go_xml_round_trip(converter, schema):
+    go = shutil.which("go")
+    gofmt = shutil.which("gofmt")
+    if not go or not gofmt:
+        pytest.skip("Go toolchain is not installed")
+    output = _generate(converter, schema, f"runtime-{converter.__name__}")
+    package = output / "pkg" / "xmltest"
+    (package / "issue412_runtime_test.go").write_text(GO_RUNTIME_TEST, encoding="utf-8")
+    subprocess.run([gofmt, "-w", str(output)], check=True, timeout=60)
+    subprocess.run([go, "build", "./..."], cwd=output, check=True, timeout=120)
+    subprocess.run([go, "test", "./..."], cwd=output, check=True, timeout=120)

--- a/test/test_go_xml.py
+++ b/test/test_go_xml.py
@@ -9,18 +9,20 @@ import tempfile
 import pytest
 
 from avrotize.avrotogo import convert_avro_schema_to_go
-from avrotize.common import xml_enum_wire_value, xml_wire_name
+from avrotize.common import generic_type, xml_enum_wire_value, xml_wire_name
 from avrotize.structuretogo import convert_structure_schema_to_go
 
 AVRO_SCHEMA = {
     "type": "record", "name": "Order", "xmlns": "urn:orders", "altnames": {"xml": "order-doc"},
     "fields": [
         {"name": "id", "type": "string", "xmlkind": "attribute", "altnames": {"xml": "order-id"}},
+        {"name": "count", "type": "int"},
         {"name": "note", "type": ["null", "string"], "default": None},
         {"name": "child", "type": {"type": "record", "name": "Child", "fields": [{"name": "value", "type": "string"}]}},
         {"name": "items", "type": {"type": "array", "items": "string"}},
         {"name": "labels", "type": {"type": "map", "values": "string"}},
         {"name": "status", "type": {"type": "enum", "name": "Status", "symbols": ["NEW", "DONE"], "altsymbols": {"xml": {"NEW": "new-order"}}}},
+        {"name": "payload", "type": generic_type()},
     ],
 }
 
@@ -28,13 +30,15 @@ STRUCTURE_SCHEMA = {
     "type": "object", "name": "Order", "xmlns": "urn:orders", "altnames": {"xml": "order-doc"},
     "properties": {
         "id": {"type": "string", "xmlkind": "attribute", "altnames": {"xml": "order-id"}},
+        "count": {"type": "int32"},
         "note": {"type": "string"},
         "child": {"type": "object", "name": "Child", "properties": {"value": {"type": "string"}}, "required": ["value"]},
         "items": {"type": "array", "items": {"type": "string"}},
         "labels": {"type": "map", "values": {"type": "string"}},
         "status": {"type": "string", "name": "Status", "enum": ["NEW", "DONE"], "altenums": {"xml": {"NEW": "new-order"}}},
+        "payload": {"type": ["string", "int32"]},
     },
-    "required": ["id", "child", "items", "labels", "status"],
+    "required": ["id", "count", "child", "items", "labels", "status"],
 }
 
 
@@ -91,7 +95,7 @@ func strptr(value string) *string { return &value }
 
 func TestIssue412XMLRoundTrip(t *testing.T) {
     input := &Order{
-        Id: "42", Note: strptr("optional"), Child: Child{Value: "nested"},
+        Id: "42", Count: 3, Note: strptr("optional"), Child: Child{Value: "nested"},
         Items: []string{"one", "two"}, Labels: XMLMap[*string]{"a": strptr("A")},
         Status: Status_NEW,
     }
@@ -121,6 +125,71 @@ def test_generated_go_xml_round_trip(converter, schema):
     output = _generate(converter, schema, f"runtime-{converter.__name__}")
     package = output / "pkg" / "xmltest"
     (package / "issue412_runtime_test.go").write_text(GO_RUNTIME_TEST, encoding="utf-8")
+    subprocess.run([gofmt, "-w", str(output)], check=True, timeout=60)
+    subprocess.run([go, "build", "./..."], cwd=output, check=True, timeout=120)
+    subprocess.run([go, "test", "./..."], cwd=output, check=True, timeout=120)
+
+
+GO_ADVERSARIAL_TEST = r'''package xmltest
+
+import (
+    "strings"
+    "testing"
+)
+
+func validIssue412XML() string {
+    return `<order-doc xmlns="urn:orders" order-id="7"><count>1</count><child><value>x</value></child><items>x</items><labels><entry key="a">b</entry></labels><status>new-order</status></order-doc>`
+}
+
+func requireXMLFailure(t *testing.T, name string, data interface{}, contentType string) {
+    t.Helper()
+    value, err := OrderFromData(data, contentType)
+    if err == nil {
+        t.Fatalf("%s silently returned success-shaped value: %#v", name, value)
+    }
+}
+
+func TestIssue412AdversarialXML(t *testing.T) {
+    valid := validIssue412XML()
+    cases := []struct{name, xml string}{
+        {"malformed", `<order-doc xmlns="urn:orders"><count>1</oops>`},
+        {"truncated", valid[:len(valid)-12]},
+        {"doctype", `<!DOCTYPE order-doc>` + valid},
+        {"entity", `<!DOCTYPE order-doc [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>` + strings.Replace(valid, `<items>x</items>`, `<items>&xxe;</items>`, 1)},
+        {"namespace mismatch", strings.Replace(valid, `urn:orders`, `urn:attacker`, 1)},
+        {"attribute namespace mismatch", strings.Replace(valid, `order-id="7"`, `xmlns:a="urn:attacker" a:order-id="7"`, 1)},
+        {"missing required attribute", strings.Replace(valid, ` order-id="7"`, ``, 1)},
+        {"missing required element", strings.Replace(valid, `<count>1</count>`, ``, 1)},
+        {"duplicate singleton", strings.Replace(valid, `<count>1</count>`, `<count>1</count><count>2</count>`, 1)},
+        {"unknown field", strings.Replace(valid, `</order-doc>`, `<surprise>x</surprise></order-doc>`, 1)},
+        {"unknown attribute", strings.Replace(valid, `order-id="7"`, `order-id="7" surprise="x"`, 1)},
+        {"invalid scalar", strings.Replace(valid, `<count>1</count>`, `<count>not-an-int</count>`, 1)},
+        {"invalid enum", strings.Replace(valid, `<status>new-order</status>`, `<status>INVALID</status>`, 1)},
+        {"excessive nesting", strings.Replace(valid, `<items>x</items>`, `<items>` + strings.Repeat(`<x>`, 110) + `v` + strings.Repeat(`</x>`, 110) + `</items>`, 1)},
+        {"excessive size", strings.Replace(valid, `<items>x</items>`, `<items>` + strings.Repeat(`x`, maxXMLBytes+1) + `</items>`, 1)},
+        {"ambiguous interface union", strings.Replace(valid, `</order-doc>`, `<payload><string>x</string></payload></order-doc>`, 1)},
+        {"map missing key", strings.Replace(valid, `<entry key="a">b</entry>`, `<entry>b</entry>`, 1)},
+        {"map duplicate entry", strings.Replace(valid, `<entry key="a">b</entry>`, `<entry key="a">b</entry><entry key="a">c</entry>`, 1)},
+        {"map duplicate key attribute", strings.Replace(valid, `key="a"`, `key="a" key="b"`, 1)},
+        {"map unknown entry", strings.Replace(valid, `<entry key="a">b</entry>`, `<other key="a">b</other>`, 1)},
+    }
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) { requireXMLFailure(t, tc.name, tc.xml, "application/xml") })
+    }
+    requireXMLFailure(t, "corrupt gzip", []byte("not gzip"), "application/xml+gzip")
+}
+'''
+
+
+@pytest.mark.parametrize("converter,schema", [(convert_avro_schema_to_go, AVRO_SCHEMA), (convert_structure_schema_to_go, STRUCTURE_SCHEMA)])
+def test_generated_go_rejects_adversarial_xml(converter, schema):
+    go = shutil.which("go")
+    gofmt = shutil.which("gofmt")
+    if not go or not gofmt:
+        pytest.skip("Go toolchain is not installed")
+    output = _generate(converter, schema, f"adversarial-{converter.__name__}")
+    package = output / "pkg" / "xmltest"
+    (package / "issue412_adversarial_test.go").write_text(GO_ADVERSARIAL_TEST, encoding="utf-8")
     subprocess.run([gofmt, "-w", str(output)], check=True, timeout=60)
     subprocess.run([go, "build", "./..."], cwd=output, check=True, timeout=120)
     subprocess.run([go, "test", "./..."], cwd=output, check=True, timeout=120)


### PR DESCRIPTION
Closes #412

Adds encoding/xml tags and shared helpers to both Go generators. Includes root namespaces, attributes/elements, enum/map handling, XML media types, gzip, and bounded strict adversarial decoding.