### PR TITLE
Rust: add XML serialization support

### DIFF
--- a/avrotize/avrotorust.py
+++ b/avrotize/avrotorust.py
@@ -8,9 +8,8 @@ from avrotize.common import (
     pascal,
     camel,
     snake,
-    xml_wire_name,
-    xml_enum_wire_value,
 )
+from avrotize.rust_xml import xml_wire_name, xml_enum_wire_value
 
 INDENT = '    '
 

--- a/avrotize/avrotorust.py
+++ b/avrotize/avrotorust.py
@@ -25,6 +25,7 @@ class AvroToRust:
         self.output_dir = os.getcwd()
         self.generated_types_avro_namespace: Dict[str, str] = {}
         self.generated_types_rust_package: Dict[str, str] = {}
+        self.avro_named_types: Dict[str, Dict] = {}
         self.avro_annotation = False
         self.serde_annotation = False
         self.xml_annotation = False
@@ -149,6 +150,114 @@ class AvroToRust:
             return self.generate_enum(avro_schema, namespace)
         return 'serde_json::Value'
 
+    def index_avro_named_types(self, node, parent_namespace=''):
+        """Indexes named Avro types so XML validation metadata can follow references."""
+        if isinstance(node, list):
+            for item in node:
+                self.index_avro_named_types(item, parent_namespace)
+            return
+        if not isinstance(node, dict):
+            return
+
+        node_type = node.get('type')
+        namespace = node.get('namespace', parent_namespace)
+        if node_type in ('record', 'enum', 'fixed') and node.get('name'):
+            name = node['name']
+            self.avro_named_types[name] = node
+            if namespace:
+                self.avro_named_types[f"{namespace}.{name}"] = node
+        if node_type == 'record':
+            for field in node.get('fields', []):
+                self.index_avro_named_types(field.get('type'), namespace)
+        elif node_type == 'array':
+            self.index_avro_named_types(node.get('items'), namespace)
+        elif node_type == 'map':
+            self.index_avro_named_types(node.get('values'), namespace)
+        elif isinstance(node_type, (dict, list)):
+            self.index_avro_named_types(node_type, namespace)
+
+    def collect_xml_field_metadata(
+        self, avro_type
+    ) -> tuple[
+        set[str],
+        set[str],
+        set[str],
+        set[tuple[str, str]],
+        set[tuple[str, str, str]],
+        set[tuple[str, str]],
+    ]:
+        """Collects nested XML element, attribute, and map field names."""
+        elements: set[str] = set()
+        attributes: set[str] = set()
+        maps: set[str] = set()
+        relationships: set[tuple[str, str]] = set()
+        namespaces: set[tuple[str, str, str]] = set()
+        attribute_owners: set[tuple[str, str]] = set()
+        visited: set[tuple[int, str]] = set()
+
+        def nested_records(node):
+            if isinstance(node, str):
+                resolved = self.avro_named_types.get(node)
+                return [resolved] if resolved and resolved.get('type') == 'record' else []
+            if isinstance(node, list):
+                return [record for item in node for record in nested_records(item)]
+            if not isinstance(node, dict):
+                return []
+            node_type = node.get('type')
+            if node_type == 'record':
+                return [node]
+            if node_type == 'array':
+                return nested_records(node.get('items'))
+            if isinstance(node_type, (dict, list)):
+                return nested_records(node_type)
+            return []
+
+        def visit(node, parent_element=None, inherited_namespace=''):
+            if isinstance(node, str):
+                resolved = self.avro_named_types.get(node)
+                if resolved:
+                    visit(resolved, parent_element, inherited_namespace)
+                return
+            if isinstance(node, list):
+                for item in node:
+                    visit(item, parent_element, inherited_namespace)
+            elif isinstance(node, dict):
+                node_type = node.get('type')
+                if node_type == 'record':
+                    visit_key = (id(node), parent_element or '')
+                    if visit_key in visited:
+                        return
+                    visited.add(visit_key)
+                    record_namespace = node.get('xmlns', inherited_namespace)
+                    for nested_field in node.get('fields', []):
+                        name = xml_wire_name(nested_field['name'], nested_field)
+                        if nested_field.get('xmlkind', 'element') == 'attribute':
+                            attributes.add(name)
+                            attribute_owners.add((parent_element or '', name))
+                        else:
+                            elements.add(name)
+                            parent = parent_element or ''
+                            if parent_element:
+                                relationships.add((parent_element, name))
+                            nested_type = nested_field.get('type')
+                            if isinstance(nested_type, dict) and nested_type.get('type') == 'map':
+                                maps.add(name)
+                            records = nested_records(nested_type)
+                            field_namespaces = {
+                                record.get('xmlns', record_namespace) for record in records
+                            } or {record_namespace}
+                            namespaces.update((parent, name, namespace) for namespace in field_namespaces)
+                        visit(nested_field.get('type'), name, record_namespace)
+                elif node_type == 'array':
+                    visit(node.get('items'), parent_element, inherited_namespace)
+                elif node_type == 'map':
+                    visit(node.get('values'), parent_element, inherited_namespace)
+                elif isinstance(node_type, (dict, list)):
+                    visit(node_type, parent_element, inherited_namespace)
+
+        visit(avro_type)
+        return elements, attributes, maps, relationships, namespaces, attribute_owners
+
     def generate_struct(self, avro_schema: Dict, parent_namespace: str) -> str:
         """Generates a Rust struct from an Avro record schema"""
         fields = []
@@ -190,6 +299,14 @@ class AvroToRust:
             [avro_schema_str[i:i+80] for i in range(0, len(avro_schema_str), 80)])
         avro_schema_str = avro_schema_str.replace('§', '\\"')
         avro_schema_str = f"concat!(\"{avro_schema_str}\")"
+        (
+            descendant_elements,
+            descendant_attributes,
+            descendant_maps,
+            descendant_relationships,
+            element_namespaces,
+            attribute_owners,
+        ) = self.collect_xml_field_metadata(avro_schema)
 
         context = {
             'avro_annotation': self.avro_annotation,
@@ -199,6 +316,12 @@ class AvroToRust:
             'struct_name': struct_name,
             'xml_name': xml_wire_name(avro_schema['name'], avro_schema),
             'xml_namespace': avro_schema.get('xmlns', ''),
+            'xml_descendant_elements': sorted(descendant_elements),
+            'xml_descendant_attributes': sorted(descendant_attributes),
+            'xml_descendant_maps': sorted(descendant_maps),
+            'xml_descendant_relationships': sorted(descendant_relationships),
+            'xml_element_namespaces': sorted(element_namespaces),
+            'xml_attribute_owners': sorted(attribute_owners),
             'fields': fields,
             'avro_schema': avro_schema_str,
             'json_match_predicates': [self.get_is_json_match_clause(f['original_name'], f['type']) for f in fields]
@@ -337,6 +460,34 @@ class AvroToRust:
                 'json_match_predicate': predicate,
                 'is_first_with_predicate': is_first_with_predicate,
             })
+        scalar_kinds = {
+            'String': 'string',
+            'bool': 'bool',
+            'i8': 'integer', 'i16': 'integer', 'i32': 'integer', 'i64': 'integer',
+            'u8': 'integer', 'u16': 'integer', 'u32': 'integer', 'u64': 'integer',
+            'isize': 'integer', 'usize': 'integer',
+            'f32': 'float', 'f64': 'float',
+        }
+        present_scalar_kinds = {scalar_kinds[field['type']] for field in union_fields if field['type'] in scalar_kinds}
+        predicate_counts = {
+            predicate: sum(1 for field in union_fields if field['json_match_predicate'] == predicate)
+            for predicate in {field['json_match_predicate'] for field in union_fields}
+        }
+        for field in union_fields:
+            scalar_kind = scalar_kinds.get(field['type'])
+            field['xml_scalar_kind'] = scalar_kind or ''
+            field['xml_guard_string'] = scalar_kind == 'string' and len(present_scalar_kinds) > 1
+            field['xml_reject_value'] = (
+                (scalar_kind is not None and scalar_kind != 'string' and 'string' in present_scalar_kinds)
+                or (scalar_kind == 'integer' and 'float' in present_scalar_kinds)
+                or predicate_counts[field['json_match_predicate']] > 1
+            )
+            field['xml_safe_for_random'] = not field['xml_reject_value']
+        xml_string_guards = {
+            'bool': 'bool' in present_scalar_kinds,
+            'integer': 'integer' in present_scalar_kinds,
+            'float': 'float' in present_scalar_kinds,
+        }
         
         qualified_union_enum_name = self.safe_package(self.concat_package(ns, union_enum_name))
         context = {
@@ -345,6 +496,7 @@ class AvroToRust:
             'xml_annotation': self.xml_annotation,
             'union_enum_name': union_enum_name,
             'union_fields': union_fields,
+            'xml_string_guards': xml_string_guards,
             'json_match_predicates': [self.get_is_json_match_clause(f['name'], f['type'], for_union=True) for f in union_fields]
         }
 
@@ -449,6 +601,8 @@ class AvroToRust:
         """Writes the lib.rs file for the Rust project"""
         modules = {name[(len('crate::')):].split('::')[0] for name in self.generated_types_rust_package}
         mod_statements = '\n'.join(f'pub mod {module};' for module in modules)
+        if self.xml_annotation:
+            mod_statements = 'pub(crate) mod xml_support;\n' + mod_statements
         
         lib_rs_content = f"""
 // This is the library entry point
@@ -461,6 +615,14 @@ class AvroToRust:
         with open(lib_rs_path, 'w', encoding='utf-8') as file:
             file.write(lib_rs_content)
 
+    def write_xml_support_rs(self):
+        """Writes shared XML validation and bounded decompression helpers."""
+        if self.xml_annotation:
+            render_template(
+                'rust/xml_support.rs.jinja',
+                os.path.join(self.output_dir, "src", "xml_support.rs"),
+            )
+
     def convert_schema(self, schema: JsonNode, output_dir: str):
         """Converts Avro schema to Rust"""
         if not isinstance(schema, list):
@@ -468,10 +630,12 @@ class AvroToRust:
         if not os.path.exists(output_dir):
             os.makedirs(output_dir, exist_ok=True)
         self.output_dir = output_dir
+        self.index_avro_named_types(schema)
         for avro_schema in (x for x in schema if isinstance(x, dict)):
             self.generate_class_or_enum(avro_schema)
 
         self.write_cargo_toml()
+        self.write_xml_support_rs()
         self.write_lib_rs()
 
     def convert(self, avro_schema_path: str, output_dir: str):

--- a/avrotize/avrotorust.py
+++ b/avrotize/avrotorust.py
@@ -1,7 +1,16 @@
 import json
 import os
 from typing import Dict, List, Union
-from avrotize.common import is_generic_avro_type, is_any_value_type, render_template, pascal, camel, snake
+from avrotize.common import (
+    is_generic_avro_type,
+    is_any_value_type,
+    render_template,
+    pascal,
+    camel,
+    snake,
+    xml_wire_name,
+    xml_enum_wire_value,
+)
 
 INDENT = '    '
 
@@ -18,6 +27,7 @@ class AvroToRust:
         self.generated_types_rust_package: Dict[str, str] = {}
         self.avro_annotation = False
         self.serde_annotation = False
+        self.xml_annotation = False
         
     reserved_words = [
             'as', 'break', 'const', 'continue', 'crate', 'else', 'enum', 'extern', 'false', 'fn', 'for', 'if', 'impl',
@@ -89,7 +99,7 @@ class AvroToRust:
             type_name = self.map_primitive_to_rust(avro_type, nullable)
         elif isinstance(avro_type, list):
             if is_generic_avro_type(avro_type):
-                return 'serde_json::Value' if self.serde_annotation else 'std::collections::HashMap<String, String>'
+                return 'serde_json::Value' if self.serde_annotation or self.xml_annotation else 'std::collections::HashMap<String, String>'
             non_null_types = [t for t in avro_type if t != 'null']
             if len(non_null_types) == 1:
                 # Rust apache-avro has a bug in the union type handling, so we need to swap the types
@@ -128,7 +138,7 @@ class AvroToRust:
                 type_name = self.convert_avro_type_to_rust(field_name, avro_type['type'], namespace)
         if type_name:
             return type_name
-        return 'serde_json::Value' if self.serde_annotation else 'std::collections::HashMap<String, String>'
+        return 'serde_json::Value' if self.serde_annotation or self.xml_annotation else 'std::collections::HashMap<String, String>'
 
     def generate_class_or_enum(self, avro_schema: Dict, parent_namespace: str = '') -> str:
         """Generates a Rust struct or enum from an Avro schema"""
@@ -146,14 +156,25 @@ class AvroToRust:
             original_field_name = field['name']
             field_name = self.safe_identifier(snake(original_field_name))
             field_type = self.convert_avro_type_to_rust(field_name, field['type'], parent_namespace)
-            serde_rename = field_name != original_field_name
+            xml_name = xml_wire_name(original_field_name, field)
+            xml_kind = field.get('xmlkind', 'element')
+            serde_name = f"@{xml_name}" if self.xml_annotation and xml_kind == 'attribute' else (
+                xml_name if self.xml_annotation else original_field_name
+            )
+            serde_rename = field_name != serde_name
             # Check if this is a generated type (enum, union, or record) where random values may match default
             is_generated_type = field_type in self.generated_types_rust_package or '::' in field_type
             fields.append({
                 'original_name': original_field_name,
+                'json_name': original_field_name,
+                'serde_name': serde_name,
+                'serde_alias': original_field_name if self.xml_annotation and (self.serde_annotation or self.avro_annotation) and original_field_name != serde_name else '',
+                'xml_name': xml_name,
+                'xml_kind': xml_kind,
                 'name': field_name,
                 'type': field_type,
                 'serde_rename': serde_rename,
+                'is_optional': field_type.startswith('Option<'),
                 'random_value': self.generate_random_value(field_type),
                 'is_generated_type': is_generated_type
             })
@@ -173,8 +194,11 @@ class AvroToRust:
         context = {
             'avro_annotation': self.avro_annotation,
             'serde_annotation': self.serde_annotation,
+            'xml_annotation': self.xml_annotation,
             'doc': avro_schema.get('doc', ''),
             'struct_name': struct_name,
+            'xml_name': xml_wire_name(avro_schema['name'], avro_schema),
+            'xml_namespace': avro_schema.get('xmlns', ''),
             'fields': fields,
             'avro_schema': avro_schema_str,
             'json_match_predicates': [self.get_is_json_match_clause(f['original_name'], f['type']) for f in fields]
@@ -242,7 +266,11 @@ class AvroToRust:
 
     def generate_enum(self, avro_schema: Dict, parent_namespace: str) -> str:
         """Generates a Rust enum from an Avro enum schema"""
-        symbols = avro_schema.get('symbols', [])
+        symbols = [{
+            'name': symbol,
+            'value': xml_enum_wire_value(symbol, avro_schema) if self.xml_annotation else symbol,
+            'json_value': symbol,
+        } for symbol in avro_schema.get('symbols', [])]
         enum_name = self.safe_identifier(pascal(avro_schema['name']))
         ns = parent_namespace.replace('.', '::').lower()
         qualified_enum_name = self.safe_package(self.concat_package(ns, enum_name))
@@ -259,8 +287,10 @@ class AvroToRust:
         context = {
             'avro_annotation': self.avro_annotation,
             'serde_annotation': self.serde_annotation,
+            'xml_annotation': self.xml_annotation,
             'enum_name': enum_name,
             'symbols': symbols,
+            'xml_name': xml_wire_name(avro_schema['name'], avro_schema),
             'avro_schema': avro_schema_str,
         }
 
@@ -312,6 +342,7 @@ class AvroToRust:
         context = {
             'serde_annotation': self.serde_annotation,
             'avro_annotation': self.avro_annotation,
+            'xml_annotation': self.xml_annotation,
             'union_enum_name': union_enum_name,
             'union_fields': union_fields,
             'json_match_predicates': [self.get_is_json_match_clause(f['name'], f['type'], for_union=True) for f in union_fields]
@@ -390,13 +421,15 @@ class AvroToRust:
     def write_cargo_toml(self):
         """Writes the Cargo.toml file for the Rust project"""
         dependencies = []
-        if self.serde_annotation or self.avro_annotation:
+        if self.serde_annotation or self.avro_annotation or self.xml_annotation:
             dependencies.append('serde = { version = "1.0", features = ["derive"] }')
         dependencies.append('serde_json = "1.0"')
         dependencies.append('chrono = { version = "0.4", features = ["serde"] }')
         dependencies.append('uuid = { version = "1.11", features = ["serde", "v4"] }')
-        if self.avro_annotation or self.serde_annotation:
+        if self.avro_annotation or self.serde_annotation or self.xml_annotation:
             dependencies.append('flate2 = "1.0"')
+        if self.xml_annotation:
+            dependencies.append('quick-xml = { version = "0.38", features = ["serialize"] }')
         if self.avro_annotation:
             dependencies.append('apache-avro = "0.17"')
             dependencies.append('lazy_static = "1.4"')
@@ -448,7 +481,7 @@ class AvroToRust:
         self.convert_schema(schema, output_dir)
 
 
-def convert_avro_to_rust(avro_schema_path, rust_file_path, package_name='', avro_annotation=False, serde_annotation=False):
+def convert_avro_to_rust(avro_schema_path, rust_file_path, package_name='', avro_annotation=False, serde_annotation=False, xml_annotation=False):
     """Converts Avro schema to Rust structs
 
     Args:
@@ -457,6 +490,7 @@ def convert_avro_to_rust(avro_schema_path, rust_file_path, package_name='', avro
         package_name (str): Base package name
         avro_annotation (bool): Include Avro annotations
         serde_annotation (bool): Include Serde annotations
+        xml_annotation (bool): Include quick-xml compatible Serde annotations
     """
     
     if not package_name:
@@ -466,10 +500,11 @@ def convert_avro_to_rust(avro_schema_path, rust_file_path, package_name='', avro
     avrotorust.base_package = package_name
     avrotorust.avro_annotation = avro_annotation
     avrotorust.serde_annotation = serde_annotation
+    avrotorust.xml_annotation = xml_annotation
     avrotorust.convert(avro_schema_path, rust_file_path)
 
 
-def convert_avro_schema_to_rust(avro_schema: JsonNode, output_dir: str, package_name='', avro_annotation=False, serde_annotation=False):
+def convert_avro_schema_to_rust(avro_schema: JsonNode, output_dir: str, package_name='', avro_annotation=False, serde_annotation=False, xml_annotation=False):
     """Converts Avro schema to Rust structs
 
     Args:
@@ -478,9 +513,11 @@ def convert_avro_schema_to_rust(avro_schema: JsonNode, output_dir: str, package_
         package_name (str): Base package name
         avro_annotation (bool): Include Avro annotations
         serde_annotation (bool): Include Serde annotations
+        xml_annotation (bool): Include quick-xml compatible Serde annotations
     """
     avrotorust = AvroToRust()
     avrotorust.base_package = package_name
     avrotorust.avro_annotation = avro_annotation
     avrotorust.serde_annotation = serde_annotation
+    avrotorust.xml_annotation = xml_annotation
     avrotorust.convert_schema(avro_schema, output_dir)

--- a/avrotize/avrotorust/dataclass_enum.rs.jinja
+++ b/avrotize/avrotorust/dataclass_enum.rs.jinja
@@ -1,30 +1,62 @@
 {%- if avro_annotation %}
 use lazy_static::lazy_static;
 use apache_avro::Schema;
-use apache_avro::{Reader, Writer};
 {%- endif %}
-{%- if serde_annotation %}
+{%- if serde_annotation or avro_annotation or xml_annotation %}
 use serde::{self,Serialize, Deserialize};
 {%- endif %}
 
-#[derive(Debug{%- if serde_annotation %}, Serialize, Deserialize{%- endif %}, PartialEq, Clone, Default)]
+#[derive(Debug{%- if serde_annotation or avro_annotation or xml_annotation %}{%- if not (xml_annotation and (serde_annotation or avro_annotation)) %}, Serialize{%- endif %}, Deserialize{%- endif %}, PartialEq, Clone, Default)]
+{%- if xml_annotation %}
+#[serde(rename = "{{ xml_name }}")]
+{%- endif %}
 pub enum {{ enum_name }} {
     #[default]
 {%- for symbol in symbols %}
-    {{ symbol }},
+    {%- if (serde_annotation or xml_annotation) and (symbol.name != symbol.value or (xml_annotation and (serde_annotation or avro_annotation) and symbol.json_value != symbol.value)) %}
+    #[serde(rename = "{{ symbol.value }}"{%- if xml_annotation and (serde_annotation or avro_annotation) and symbol.json_value != symbol.value %}, alias = "{{ symbol.json_value }}"{%- endif %})]
+    {%- endif %}
+    {{ symbol.name }},
 {%- endfor %}
 }
 
-impl {{ enum_name }} {
-    {%- if avro_annotation %}
-    lazy_static! {
-        /// The static Avro schema as a parsed object
-        pub static ref SCHEMA: Schema = Schema::parse_str(r#"{{ avro_schema | escape }}"#).unwrap();
+{%- if xml_annotation and (serde_annotation or avro_annotation) %}
+impl Serialize for {{ enum_name }} {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let is_xml = std::any::type_name::<S>().contains("quick_xml");
+        let is_avro = std::any::type_name::<S>().contains("apache_avro");
+        match self {
+            {%- for symbol in symbols %}
+            {{ enum_name }}::{{ symbol.name }} => {
+                if is_xml {
+                    serializer.serialize_str("{{ symbol.value }}")
+                } else if is_avro {
+                    serializer.serialize_unit_variant(
+                        "{{ enum_name }}",
+                        {{ loop.index0 }},
+                        "{{ symbol.json_value }}",
+                    )
+                } else {
+                    serializer.serialize_str("{{ symbol.json_value }}")
+                }
+            },
+            {%- endfor %}
+        }
     }
-    {%- endif %}
 }
+{%- endif %}
 
-{%- if serde_annotation or avro_annotation %}
+{%- if avro_annotation %}
+lazy_static! {
+    /// The static Avro schema as a parsed object
+    pub static ref SCHEMA: Schema = Schema::parse_str({{ avro_schema }}).unwrap();
+}
+{%- endif %}
+
+{%- if serde_annotation or avro_annotation or xml_annotation %}
 impl {{ enum_name }} {
     pub fn is_json_match(node: &serde_json::Value) -> bool {
         return node.is_string();
@@ -43,7 +75,7 @@ impl {{ enum_name }} {
         let mut rng = rand::thread_rng();
         match rand::Rng::gen_range(&mut rng, 0..{{ symbols | length }}) {
             {%- for symbol in symbols %}
-            {{ loop.index0 }} => {{ enum_name }}::{{ symbol }},
+            {{ loop.index0 }} => {{ enum_name }}::{{ symbol.name }},
             {%- endfor %}
             _ => panic!("Invalid random index generated"),
         }
@@ -55,11 +87,11 @@ mod tests {
     use super::*;
     use rand::Rng;
 
-    {%- if serde_annotation %}
+    {%- if serde_annotation or xml_annotation %}
     #[test]
     fn test_serialize_deserialize_{{ enum_name.lower() }}() {
         {%- for symbol in symbols %}
-        let instance = {{ enum_name }}::{{ symbol }};
+        let instance = {{ enum_name }}::{{ symbol.name }};
         let json_bytes = serde_json::to_vec(&instance).unwrap();
         let deserialized_instance: {{ enum_name }} = serde_json::from_slice(&json_bytes).unwrap();
         assert_eq!(instance, deserialized_instance);
@@ -70,7 +102,7 @@ mod tests {
     #[test]
     fn test_enum_variants_{{ enum_name.lower() }}() {
         {%- for symbol in symbols %}
-        let _instance = {{ enum_name }}::{{ symbol }};
+        let _instance = {{ enum_name }}::{{ symbol.name }};
         {%- endfor %}
     }
 }

--- a/avrotize/avrotorust/dataclass_struct.rs.jinja
+++ b/avrotize/avrotorust/dataclass_struct.rs.jinja
@@ -9,7 +9,9 @@ use serde::ser::SerializeStruct;
 {%- endif %}
 use std::io::Write;
 use flate2::write::GzEncoder;
+{%- if not xml_annotation %}
 use flate2::read::GzDecoder;
+{%- endif %}
 {%- endif %}
 {%- set uses_chrono = false %}
 {%- set uses_uuid = false %}
@@ -125,6 +127,9 @@ impl {{ struct_name }} {
            media_type.starts_with("text/xml") {
             let xml = quick_xml::se::to_string(self)?;
             result = xml.into_bytes();
+            if result.len() > crate::xml_support::MAX_XML_DATA_SIZE {
+                return Err("serialized XML exceeds the generated data size limit".into());
+            }
         }
         else {% endif -%}
         {%- if avro_annotation %}
@@ -152,6 +157,15 @@ impl {{ struct_name }} {
     /// Deserializes the struct from a byte array based on the provided content type
     pub fn from_data(data: impl AsRef<[u8]>, content_type: &str) -> Result<Self, Box<dyn std::error::Error>> {
         let media_type = content_type.split(';').next().unwrap_or("");
+        {%- if xml_annotation %}
+        let is_xml = media_type.starts_with("application/xml") ||
+                     media_type.starts_with("text/xml");
+        let data = crate::xml_support::decode_data(
+            data.as_ref(),
+            media_type.ends_with("+gzip"),
+            is_xml,
+        )?;
+        {%- else %}
         let data = if media_type.ends_with("+gzip") {
             let mut decoder = GzDecoder::new(data.as_ref());
             let mut decompressed_data = Vec::new();
@@ -160,6 +174,7 @@ impl {{ struct_name }} {
         } else {
             data.as_ref().to_vec()
         };
+        {%- endif %}
         {%- if serde_annotation %}
         if media_type.starts_with("application/json") {
             let result = serde_json::from_slice(&data)?;
@@ -167,8 +182,60 @@ impl {{ struct_name }} {
         }
         {%- endif %}
         {%- if xml_annotation %}
-        if media_type.starts_with("application/xml") ||
-           media_type.starts_with("text/xml") {
+        if is_xml {
+            crate::xml_support::validate_xml_document(
+                &data,
+                "{{ xml_name }}",
+                r#"{{ xml_namespace }}"#,
+                &[
+                    {%- for field in fields %}
+                    {%- if field.xml_kind != "attribute" %}
+                    (
+                        "{{ field.xml_name }}",
+                        {{ "true" if field.type.startswith("Vec<") or field.type.startswith("std::collections::HashSet<") else "false" }},
+                        {{ "true" if "std::collections::HashMap<String, " in field.type else "false" }},
+                    ),
+                    {%- endif %}
+                    {%- endfor %}
+                ],
+                &[
+                    {%- for field in fields %}
+                    {%- if field.xml_kind == "attribute" %}
+                    "{{ field.xml_name }}",
+                    {%- endif %}
+                    {%- endfor %}
+                ],
+                &[
+                    {%- for name in xml_descendant_elements %}
+                    "{{ name }}",
+                    {%- endfor %}
+                ],
+                &[
+                    {%- for name in xml_descendant_attributes %}
+                    "{{ name }}",
+                    {%- endfor %}
+                ],
+                &[
+                    {%- for name in xml_descendant_maps %}
+                    "{{ name }}",
+                    {%- endfor %}
+                ],
+                &[
+                    {%- for parent, child in xml_descendant_relationships %}
+                    ("{{ parent }}", "{{ child }}"),
+                    {%- endfor %}
+                ],
+                &[
+                    {%- for parent, element, namespace in xml_element_namespaces %}
+                    ("{{ parent }}", "{{ element }}", r#"{{ namespace }}"#),
+                    {%- endfor %}
+                ],
+                &[
+                    {%- for owner, attribute in xml_attribute_owners %}
+                    ("{{ owner }}", "{{ attribute }}"),
+                    {%- endfor %}
+                ],
+            )?;
             let result = quick_xml::de::from_str(std::str::from_utf8(&data)?)?;
             return Ok(result)
         }

--- a/avrotize/avrotorust/dataclass_struct.rs.jinja
+++ b/avrotize/avrotorust/dataclass_struct.rs.jinja
@@ -2,8 +2,11 @@
 use lazy_static::lazy_static;
 use apache_avro::Schema;
 {%- endif %}
-{%- if serde_annotation or avro_annotation %}
+{%- if serde_annotation or avro_annotation or xml_annotation %}
 use serde::{Serialize, Deserialize};
+{%- if xml_annotation %}
+use serde::ser::SerializeStruct;
+{%- endif %}
 use std::io::Write;
 use flate2::write::GzEncoder;
 use flate2::read::GzDecoder;
@@ -36,15 +39,67 @@ use std::collections::HashMap;
 {% if doc %}
 /// {{ doc }}
 {%- endif %}
-#[derive(Debug{%- if serde_annotation or avro_annotation %}, Serialize, Deserialize{%- endif %}, PartialEq, Clone, Default)]
+#[derive(Debug{%- if serde_annotation or avro_annotation or xml_annotation %}{%- if not xml_annotation %}, Serialize{%- endif %}, Deserialize{%- endif %}, PartialEq, Clone, Default)]
+{%- if xml_annotation %}
+#[serde(rename = "{{ xml_name }}")]
+{%- endif %}
 pub struct {{ struct_name }} {
 {%- for field in fields %}
-    {%- if field.serde_rename and (serde_annotation or avro_annotation) %}
-    #[serde(rename = "{{ field.original_name }}")]
+    {%- if field.serde_rename and (serde_annotation or avro_annotation or xml_annotation) %}
+    #[serde(rename = "{{ field.serde_name }}"{%- if field.serde_alias %}, alias = "{{ field.serde_alias }}"{%- endif %})]
+    {%- endif %}
+    {%- if xml_annotation and field.is_optional %}
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     {%- endif %}
     pub {{ field.name }}: {{ field.type }},
 {%- endfor %}
 }
+
+{% if xml_annotation %}
+impl Serialize for {{ struct_name }} {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let is_xml = std::any::type_name::<S>().contains("quick_xml");
+        let field_count = {{ fields | length }}
+            {%- if xml_namespace %}
+            + usize::from(is_xml)
+            {%- endif %}
+            {%- for field in fields %}
+            {%- if field.is_optional %}
+            - usize::from(is_xml && self.{{ field.name }}.is_none())
+            {%- endif %}
+            {%- endfor %};
+        let mut state = serializer.serialize_struct(
+            if is_xml { "{{ xml_name }}" } else { "{{ struct_name }}" },
+            field_count,
+        )?;
+        {%- if xml_namespace %}
+        if is_xml {
+            state.serialize_field("@xmlns", XML_NAMESPACE)?;
+        }
+        {%- endif %}
+        {%- for field in fields %}
+        {%- if field.is_optional %}
+        if !is_xml || self.{{ field.name }}.is_some() {
+        {%- endif %}
+            state.serialize_field(
+                if is_xml { "{{ field.serde_name }}" } else { "{{ field.json_name }}" },
+                &self.{{ field.name }},
+            )?;
+        {%- if field.is_optional %}
+        }
+        {%- endif %}
+        {%- endfor %}
+        state.end()
+    }
+}
+{%- endif %}
+
+{% if xml_annotation and xml_namespace %}
+const XML_NAMESPACE: &str = r#"{{ xml_namespace }}"#;
+{%- endif %}
 
 {% if avro_annotation %}
 lazy_static! {
@@ -55,7 +110,7 @@ lazy_static! {
 {%- endif %}
 
 impl {{ struct_name }} {
-{%- if serde_annotation or avro_annotation %}
+{%- if serde_annotation or avro_annotation or xml_annotation %}
    /// Serializes the struct to a byte array based on the provided content type
     pub fn to_byte_array(&self, content_type: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
         let result: Vec<u8>;
@@ -63,6 +118,13 @@ impl {{ struct_name }} {
         {%- if serde_annotation %}
         if media_type.starts_with("application/json") {
             result = serde_json::to_vec(self)?;
+        }
+        else {% endif -%}
+        {%- if xml_annotation %}
+        if media_type.starts_with("application/xml") ||
+           media_type.starts_with("text/xml") {
+            let xml = quick_xml::se::to_string(self)?;
+            result = xml.into_bytes();
         }
         else {% endif -%}
         {%- if avro_annotation %}
@@ -86,7 +148,7 @@ impl {{ struct_name }} {
     }
 {%- endif %}
 
-{%- if serde_annotation or avro_annotation %}
+{%- if serde_annotation or avro_annotation or xml_annotation %}
     /// Deserializes the struct from a byte array based on the provided content type
     pub fn from_data(data: impl AsRef<[u8]>, content_type: &str) -> Result<Self, Box<dyn std::error::Error>> {
         let media_type = content_type.split(';').next().unwrap_or("");
@@ -104,6 +166,13 @@ impl {{ struct_name }} {
             return Ok(result)
         }
         {%- endif %}
+        {%- if xml_annotation %}
+        if media_type.starts_with("application/xml") ||
+           media_type.starts_with("text/xml") {
+            let result = quick_xml::de::from_str(std::str::from_utf8(&data)?)?;
+            return Ok(result)
+        }
+        {%- endif %}
         {%- if avro_annotation %}
         if media_type.starts_with("avro/binary") || 
            media_type.starts_with("application/vnd.apache.avro+avro") {
@@ -115,7 +184,7 @@ impl {{ struct_name }} {
     }
 {%- endif %}
 
-{%- if serde_annotation or avro_annotation %}
+{%- if serde_annotation or avro_annotation or xml_annotation %}
     /// Checks if the given JSON value matches the schema of the struct
     pub fn is_json_match(node: &serde_json::Value) -> bool {
         {%- for predicate in json_match_predicates %}
@@ -174,7 +243,7 @@ mod tests {
         {%- endfor %}
     }
 
-    {%- if serde_annotation or avro_annotation %}
+    {%- if serde_annotation or avro_annotation or xml_annotation %}
     #[test]
     fn test_serialize_deserialize_{{ struct_name.lower() }}() {
         let instance = {{struct_name}}::generate_random_instance();
@@ -197,6 +266,44 @@ mod tests {
         let avro_gzip_bytes = instance.to_byte_array("avro/binary+gzip").unwrap();
         let deserialized_avro_gzip_instance: {{ struct_name }} = {{ struct_name }}::from_data(&avro_gzip_bytes, "avro/binary+gzip").unwrap();
         assert_eq!(instance, deserialized_avro_gzip_instance);
+        {%- endif %}
+        {%- if xml_annotation %}
+        // Test XML serialization and deserialization
+        let xml_bytes = instance.to_byte_array("application/xml").unwrap();
+        let xml = String::from_utf8(xml_bytes.clone()).unwrap();
+        assert!(xml.starts_with("<{{ xml_name }}"), "unexpected XML root: {}", xml);
+        {%- if xml_namespace %}
+        assert!(xml.contains("xmlns=\"{{ xml_namespace }}\""), "missing XML namespace: {}", xml);
+        {%- endif %}
+        {%- for field in fields %}
+        {%- if field.xml_kind == "attribute" %}
+        assert!(xml.contains(" {{ field.xml_name }}=\""), "missing XML attribute {{ field.xml_name }}: {}", xml);
+        {%- else %}
+        assert!(xml.contains("<{{ field.xml_name }}"), "missing XML element {{ field.xml_name }}: {}", xml);
+        {%- endif %}
+        {%- endfor %}
+        let deserialized_xml_instance = {{ struct_name }}::from_data(&xml_bytes, "application/xml").unwrap();
+        assert_eq!(instance, deserialized_xml_instance);
+        let text_xml_bytes = instance.to_byte_array("text/xml").unwrap();
+        let deserialized_text_xml_instance = {{ struct_name }}::from_data(&text_xml_bytes, "text/xml").unwrap();
+        assert_eq!(instance, deserialized_text_xml_instance);
+        let xml_gzip_bytes = instance.to_byte_array("application/xml+gzip").unwrap();
+        let deserialized_xml_gzip_instance = {{ struct_name }}::from_data(&xml_gzip_bytes, "application/xml+gzip").unwrap();
+        assert_eq!(instance, deserialized_xml_gzip_instance);
+        let text_xml_gzip_bytes = instance.to_byte_array("text/xml+gzip").unwrap();
+        let deserialized_text_xml_gzip_instance = {{ struct_name }}::from_data(&text_xml_gzip_bytes, "text/xml+gzip").unwrap();
+        assert_eq!(instance, deserialized_text_xml_gzip_instance);
+        {%- if fields | selectattr("is_optional") | list | length > 0 %}
+        let mut optional_instance = {{ struct_name }}::generate_random_instance();
+        {%- for field in fields %}
+        {%- if field.is_optional %}
+        optional_instance.{{ field.name }} = None;
+        {%- endif %}
+        {%- endfor %}
+        let optional_xml_bytes = optional_instance.to_byte_array("application/xml").unwrap();
+        let deserialized_optional_instance = {{ struct_name }}::from_data(&optional_xml_bytes, "application/xml").unwrap();
+        assert_eq!(optional_instance, deserialized_optional_instance);
+        {%- endif %}
         {%- endif %}
     }
     {%- endif %}

--- a/avrotize/avrotorust/dataclass_union.rs.jinja
+++ b/avrotize/avrotorust/dataclass_union.rs.jinja
@@ -22,9 +22,35 @@ impl Serialize for {{ union_enum_name }} {
     where
         S: serde::ser::Serializer
     {
+        {%- if xml_annotation %}
+        let is_xml = std::any::type_name::<S>().contains("quick_xml");
+        {%- endif %}
         match self {
             {%- for union_field in union_fields %}
-            {{ union_enum_name }}::{{ union_field.name}}(value) => value.serialize(serializer),
+            {{ union_enum_name }}::{{ union_field.name}}(value) => {
+                {%- if xml_annotation and union_field.xml_reject_value %}
+                if is_xml {
+                    return Err(serde::ser::Error::custom("ambiguous XML union value"));
+                }
+                {%- endif %}
+                {%- if xml_annotation and union_field.xml_guard_string %}
+                if is_xml && (
+                    {%- if xml_string_guards.bool %}
+                    value.parse::<bool>().is_ok() ||
+                    {%- endif %}
+                    {%- if xml_string_guards.integer %}
+                    value.parse::<i128>().is_ok() ||
+                    {%- endif %}
+                    {%- if xml_string_guards.float %}
+                    value.parse::<f64>().is_ok() ||
+                    {%- endif %}
+                    false
+                ) {
+                    return Err(serde::ser::Error::custom("ambiguous XML union scalar"));
+                }
+                {%- endif %}
+                value.serialize(serializer)
+            },
             {%- endfor %}
         }
     }
@@ -40,18 +66,30 @@ impl<'de> Deserialize<'de> for {{ union_enum_name }} {
         {%- endif %}
         let node = serde_json::Value::deserialize(deserializer)?;
         {%- if xml_annotation %}
+        if is_xml && xml_scalar_match_count(&node) > 1 {
+            return Err(serde::de::Error::custom("ambiguous XML union scalar"));
+        }
         let node = if is_xml { normalize_xml_value(node) } else { node };
+        if is_xml {
+            let match_count = 0usize
+                {%- for union_field in union_fields %}
+                + usize::from({{ union_field.json_match_predicate }})
+                {%- endfor %};
+            if match_count > 1 {
+                return Err(serde::de::Error::custom("ambiguous XML union value"));
+            }
+        }
         {%- endif %}
         {%- for union_field in union_fields %}
         if {{ union_field.json_match_predicate }} {
             {%- if union_field.type.startswith("Vec<") %}
             {%- set field_type = 'Vec::<'+union_field.type[4:] %}
-            let result = {{ field_type }}::deserialize(node).unwrap();
+            let result = {{ field_type }}::deserialize(node).map_err(serde::de::Error::custom)?;
             {%- elif union_field.type.startswith("std::collections::HashMap<") %}
             {%- set field_type = 'std::collections::HashMap::<'+union_field.type[26:] %}
-            let result = {{ field_type }}::deserialize(node).unwrap();
+            let result = {{ field_type }}::deserialize(node).map_err(serde::de::Error::custom)?;
             {%-else %}
-            let result = {{ union_field.type }}::deserialize(node).unwrap();
+            let result = {{ union_field.type }}::deserialize(node).map_err(serde::de::Error::custom)?;
             {%-endif %}
             return Ok({{ union_enum_name }}::{{ union_field.name }}(result));
         }
@@ -61,6 +99,30 @@ impl<'de> Deserialize<'de> for {{ union_enum_name }} {
 }
 
 {%- if xml_annotation %}
+fn xml_scalar_match_count(value: &serde_json::Value) -> usize {
+    let serde_json::Value::Object(object) = value else {
+        return 0;
+    };
+    if object.len() != 1 {
+        return 0;
+    }
+    let Some(serde_json::Value::String(text)) = object.get("$text") else {
+        return 0;
+    };
+    0usize
+        {%- for union_field in union_fields %}
+        {%- if union_field.type == "String" %}
+        + 1
+        {%- elif union_field.type == "bool" %}
+        + usize::from(text.parse::<bool>().is_ok())
+        {%- elif union_field.type in ["i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64", "isize", "usize"] %}
+        + usize::from(text.parse::<i128>().is_ok())
+        {%- elif union_field.type in ["f32", "f64"] %}
+        + usize::from(text.parse::<f64>().is_ok())
+        {%- endif %}
+        {%- endfor %}
+}
+
 fn normalize_xml_value(value: serde_json::Value) -> serde_json::Value {
     match value {
         serde_json::Value::Object(mut object) if object.len() == 1 && object.contains_key("$text") => {
@@ -115,9 +177,18 @@ impl {{ union_enum_name }} {
 #[cfg(test)]
 impl {{ union_enum_name }} {
 {%- set unique_fields = union_fields | selectattr('is_first_with_predicate') | list %}
+{%- set xml_safe_fields = union_fields | selectattr('xml_safe_for_random') | list %}
     pub fn generate_random_instance() -> {{ union_enum_name }} {
         let mut rng = rand::thread_rng();
-        {%- if serde_annotation and unique_fields | length < union_fields | length %}
+        {%- if xml_annotation and xml_safe_fields | length > 0 and xml_safe_fields | length < union_fields | length %}
+        // Avoid variants whose XML lexical form is inherently ambiguous.
+        match rand::Rng::gen_range(&mut rng, 0..{{ xml_safe_fields | length }}) {
+            {%- for union_field in xml_safe_fields %}
+            {{ loop.index0 }} => {{ union_enum_name }}::{{ union_field.name }}({{ union_field.random_value }}),
+            {%- endfor %}
+            _ => panic!("Invalid random index generated"),
+        }
+        {%- elif serde_annotation and unique_fields | length < union_fields | length %}
         // Only pick from variants with unique JSON structures to ensure round-trip works
         match rand::Rng::gen_range(&mut rng, 0..{{ unique_fields | length }}) {
             {%- for union_field in unique_fields %}

--- a/avrotize/avrotorust/dataclass_union.rs.jinja
+++ b/avrotize/avrotorust/dataclass_union.rs.jinja
@@ -1,4 +1,4 @@
-{%- if serde_annotation or avro_annotation %}
+{%- if serde_annotation or avro_annotation or xml_annotation %}
 use serde::{self, Serialize, Deserialize};
 {%- endif %}
 
@@ -16,7 +16,7 @@ impl Default for {{ union_enum_name }} {
     }
 }
 
-{% if serde_annotation or avro_annotation %}
+{% if serde_annotation or avro_annotation or xml_annotation %}
 impl Serialize for {{ union_enum_name }} {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -35,7 +35,13 @@ impl<'de> Deserialize<'de> for {{ union_enum_name }} {
     where
         D: serde::de::Deserializer<'de>
     {
+        {%- if xml_annotation %}
+        let is_xml = std::any::type_name::<D>().contains("quick_xml");
+        {%- endif %}
         let node = serde_json::Value::deserialize(deserializer)?;
+        {%- if xml_annotation %}
+        let node = if is_xml { normalize_xml_value(node) } else { node };
+        {%- endif %}
         {%- for union_field in union_fields %}
         if {{ union_field.json_match_predicate }} {
             {%- if union_field.type.startswith("Vec<") %}
@@ -53,6 +59,44 @@ impl<'de> Deserialize<'de> for {{ union_enum_name }} {
         Err(serde::de::Error::custom("No valid variant found"))
     }
 }
+
+{%- if xml_annotation %}
+fn normalize_xml_value(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(mut object) if object.len() == 1 && object.contains_key("$text") => {
+            normalize_xml_text(object.remove("$text").unwrap())
+        }
+        serde_json::Value::Object(object) => serde_json::Value::Object(
+            object.into_iter().map(|(key, value)| (key, normalize_xml_value(value))).collect()
+        ),
+        serde_json::Value::Array(values) => {
+            serde_json::Value::Array(values.into_iter().map(normalize_xml_value).collect())
+        }
+        other => other,
+    }
+}
+
+fn normalize_xml_text(value: serde_json::Value) -> serde_json::Value {
+    let serde_json::Value::String(text) = value else {
+        return normalize_xml_value(value);
+    };
+    if let Ok(value) = text.parse::<bool>() {
+        return serde_json::Value::Bool(value);
+    }
+    if let Ok(value) = text.parse::<i64>() {
+        return serde_json::Value::Number(value.into());
+    }
+    if let Ok(value) = text.parse::<u64>() {
+        return serde_json::Value::Number(value.into());
+    }
+    if let Ok(value) = text.parse::<f64>() {
+        if let Some(value) = serde_json::Number::from_f64(value) {
+            return serde_json::Value::Number(value);
+        }
+    }
+    serde_json::Value::String(text)
+}
+{%- endif %}
 
 impl {{ union_enum_name }} {
     pub fn is_json_match(node: &serde_json::Value) -> bool {

--- a/avrotize/commands.json
+++ b/avrotize/commands.json
@@ -3306,7 +3306,8 @@
         "structure_schema_path": "input_file_path",
         "rust_file_path": "output_file_path",
         "package_name": "args.package",
-        "serde_annotation": "args.json_annotation"
+        "serde_annotation": "args.json_annotation",
+        "xml_annotation": "args.xml_annotation"
       }
     },
     "extensions": [
@@ -3339,6 +3340,13 @@
         "help": "Use Serde JSON annotations",
         "default": false,
         "required": false
+      },
+      {
+        "name": "--xml-annotation",
+        "type": "bool",
+        "help": "Use quick-xml Serde annotations",
+        "default": false,
+        "required": false
       }
     ],
     "suggested_output_file_path": "{input_file_name}-rust",
@@ -3352,6 +3360,12 @@
       {
         "name": "--json-annotation",
         "message": "Use Serde JSON annotations?",
+        "type": "bool",
+        "default": false
+      },
+      {
+        "name": "--xml-annotation",
+        "message": "Use quick-xml Serde annotations?",
         "type": "bool",
         "default": false
       }
@@ -4027,7 +4041,8 @@
         "rust_file_path": "output_file_path",
         "package_name": "args.package",
         "avro_annotation": "args.avro_annotation",
-        "serde_annotation": "args.json_annotation"
+        "serde_annotation": "args.json_annotation",
+        "xml_annotation": "args.xml_annotation"
       }
     },
     "extensions": [
@@ -4072,6 +4087,13 @@
         "help": "Use JSON annotations",
         "default": false,
         "required": false
+      },
+      {
+        "name": "--xml-annotation",
+        "type": "bool",
+        "help": "Use quick-xml Serde annotations",
+        "default": false,
+        "required": false
       }
     ],
     "suggested_output_file_path": "{input_file_name}-rust",
@@ -4091,6 +4113,12 @@
       {
         "name": "--json-annotation",
         "message": "Use JSON annotations?",
+        "type": "bool",
+        "default": false
+      },
+      {
+        "name": "--xml-annotation",
+        "message": "Use quick-xml Serde annotations?",
         "type": "bool",
         "default": false
       }

--- a/avrotize/common.py
+++ b/avrotize/common.py
@@ -894,6 +894,26 @@ def json_enum_wire_value(value: Any, enum_schema: Any) -> str:
     return str(value)
 
 
+def xml_wire_name(name: str, schema_obj: Any) -> str:
+    """Resolve an XML local name, honoring ``altnames.xml``."""
+    if isinstance(schema_obj, dict):
+        altnames = schema_obj.get("altnames")
+        if isinstance(altnames, dict) and "xml" in altnames:
+            return altnames["xml"]
+    return name
+
+
+def xml_enum_wire_value(value: Any, enum_schema: Any) -> str:
+    """Resolve an XML enum value, honoring ``altenums.xml``."""
+    if isinstance(enum_schema, dict):
+        altenums = enum_schema.get("altenums")
+        if isinstance(altenums, dict):
+            xml_values = altenums.get("xml")
+            if isinstance(xml_values, dict) and str(value) in xml_values:
+                return xml_values[str(value)]
+    return str(value)
+
+
 def process_template(file_path: str, **kvargs) -> str:
     """
     Process a file as a Jinja2 template with the given object as input.

--- a/avrotize/common.py
+++ b/avrotize/common.py
@@ -894,26 +894,6 @@ def json_enum_wire_value(value: Any, enum_schema: Any) -> str:
     return str(value)
 
 
-def xml_wire_name(name: str, schema_obj: Any) -> str:
-    """Resolve an XML local name, honoring ``altnames.xml``."""
-    if isinstance(schema_obj, dict):
-        altnames = schema_obj.get("altnames")
-        if isinstance(altnames, dict) and "xml" in altnames:
-            return altnames["xml"]
-    return name
-
-
-def xml_enum_wire_value(value: Any, enum_schema: Any) -> str:
-    """Resolve an XML enum value, honoring ``altenums.xml``."""
-    if isinstance(enum_schema, dict):
-        altenums = enum_schema.get("altenums")
-        if isinstance(altenums, dict):
-            xml_values = altenums.get("xml")
-            if isinstance(xml_values, dict) and str(value) in xml_values:
-                return xml_values[str(value)]
-    return str(value)
-
-
 def process_template(file_path: str, **kvargs) -> str:
     """
     Process a file as a Jinja2 template with the given object as input.

--- a/avrotize/rust/xml_support.rs.jinja
+++ b/avrotize/rust/xml_support.rs.jinja
@@ -1,0 +1,326 @@
+use flate2::read::GzDecoder;
+use quick_xml::events::{BytesStart, Event};
+use quick_xml::name::ResolveResult;
+use quick_xml::reader::NsReader;
+use std::collections::HashSet;
+use std::io::Read;
+
+pub(crate) const MAX_XML_DATA_SIZE: usize = 16 * 1024 * 1024;
+const MAX_XML_DEPTH: usize = 128;
+
+fn invalid_data(message: impl Into<String>) -> Box<dyn std::error::Error> {
+    std::io::Error::new(std::io::ErrorKind::InvalidData, message.into()).into()
+}
+
+pub(crate) fn decode_data(
+    data: &[u8],
+    gzip: bool,
+    enforce_limit: bool,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    if enforce_limit && data.len() > MAX_XML_DATA_SIZE {
+        return Err(invalid_data("input exceeds the generated data size limit"));
+    }
+    if !gzip {
+        return Ok(data.to_vec());
+    }
+
+    let decoder = GzDecoder::new(data);
+    let mut decompressed = Vec::new();
+    if enforce_limit {
+        decoder
+            .take((MAX_XML_DATA_SIZE + 1) as u64)
+            .read_to_end(&mut decompressed)?;
+    } else {
+        decoder.take(u64::MAX).read_to_end(&mut decompressed)?;
+    }
+    if enforce_limit && decompressed.len() > MAX_XML_DATA_SIZE {
+        return Err(invalid_data("decompressed input exceeds the generated data size limit"));
+    }
+    Ok(decompressed)
+}
+
+fn validate_attributes(
+    start: &BytesStart<'_>,
+    allowed_attributes: &[&str],
+    owner: Option<&str>,
+    attribute_owners: &[(&str, &str)],
+) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    let raw_name = start.name();
+    let raw_name = std::str::from_utf8(raw_name.as_ref())?;
+    let namespace_attribute = raw_name
+        .split_once(':')
+        .map(|(prefix, _)| format!("xmlns:{prefix}"))
+        .unwrap_or_else(|| "xmlns".to_string());
+    let mut namespace = None;
+
+    for attribute in start.attributes().with_checks(true) {
+        let attribute = attribute?;
+        let key = std::str::from_utf8(attribute.key.as_ref())?;
+        let value = attribute.unescape_value()?.into_owned();
+        if key == namespace_attribute {
+            namespace = Some(value);
+        }
+        if key != "xmlns"
+            && !key.starts_with("xmlns:")
+            && (!allowed_attributes.contains(&key)
+                || owner.map_or(false, |owner| !attribute_owners.contains(&(owner, key))))
+        {
+            return Err(invalid_data(format!("unknown XML attribute: {key}")));
+        }
+    }
+    Ok(namespace)
+}
+
+fn validate_root(
+    start: &BytesStart<'_>,
+    namespace: &str,
+    expected_root: &str,
+    expected_namespace: &str,
+    allowed_attributes: &[&str],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let local_name = start.local_name();
+    let local_name = std::str::from_utf8(local_name.as_ref())?;
+    if local_name != expected_root {
+        return Err(invalid_data(format!(
+            "unexpected XML root: expected {expected_root}, found {local_name}"
+        )));
+    }
+    validate_attributes(start, allowed_attributes, None, &[])?;
+    if namespace != expected_namespace {
+        return Err(invalid_data(format!(
+            "unexpected XML namespace: expected {expected_namespace}, found {namespace}"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_root_child(
+    start: &BytesStart<'_>,
+    fields: &[(&str, bool, bool)],
+    seen: &mut HashSet<String>,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let local_name = start.local_name();
+    let local_name = std::str::from_utf8(local_name.as_ref())?;
+    let Some((_, repeatable, map)) = fields.iter().find(|(name, _, _)| *name == local_name) else {
+        return Err(invalid_data(format!("unknown XML element: {local_name}")));
+    };
+    if !repeatable && !seen.insert(local_name.to_string()) {
+        return Err(invalid_data(format!("duplicate XML element: {local_name}")));
+    }
+    Ok(*map)
+}
+
+fn validate_element_namespace(
+    parent: &str,
+    element: &str,
+    namespace: &str,
+    element_namespaces: &[(&str, &str, &str)],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut expected = element_namespaces
+        .iter()
+        .filter(|(expected_parent, expected_element, _)| {
+            *expected_parent == parent && *expected_element == element
+        })
+        .peekable();
+    if expected.peek().is_some() && !expected.any(|(_, _, expected_namespace)| *expected_namespace == namespace) {
+        return Err(invalid_data(format!(
+            "unexpected XML namespace for {element}: found {namespace}"
+        )));
+    }
+    Ok(())
+}
+
+fn resolved_namespace(
+    resolution: ResolveResult<'_>,
+) -> Result<String, Box<dyn std::error::Error>> {
+    match resolution {
+        ResolveResult::Unbound => Ok(String::new()),
+        ResolveResult::Bound(namespace) => {
+            Ok(std::str::from_utf8(namespace.as_ref())?.to_string())
+        }
+        ResolveResult::Unknown(prefix) => Err(invalid_data(format!(
+            "unknown XML namespace prefix: {}",
+            String::from_utf8_lossy(&prefix)
+        ))),
+    }
+}
+
+pub(crate) fn validate_xml_document(
+    data: &[u8],
+    expected_root: &str,
+    expected_namespace: &str,
+    fields: &[(&str, bool, bool)],
+    attributes: &[&str],
+    descendant_fields: &[&str],
+    descendant_attributes: &[&str],
+    map_fields: &[&str],
+    descendant_relationships: &[(&str, &str)],
+    element_namespaces: &[(&str, &str, &str)],
+    attribute_owners: &[(&str, &str)],
+) -> Result<(), Box<dyn std::error::Error>> {
+    if data.len() > MAX_XML_DATA_SIZE {
+        return Err(invalid_data("XML input exceeds the generated data size limit"));
+    }
+
+    let mut reader = NsReader::from_reader(data);
+    reader.config_mut().trim_text(false);
+    let mut depth = 0usize;
+    let mut root_seen = false;
+    let mut root_closed = false;
+    let mut seen_root_fields = HashSet::new();
+    let mut active_map_depth = None;
+    let mut map_keys = HashSet::new();
+    let mut element_stack: Vec<String> = Vec::new();
+
+    loop {
+        let (resolution, event) = reader.read_resolved_event()?;
+        let namespace = resolved_namespace(resolution)?;
+        match event {
+            Event::Start(start) => {
+                if depth == 0 {
+                    if root_seen || root_closed {
+                        return Err(invalid_data("XML must contain exactly one root element"));
+                    }
+                    validate_root(
+                        &start,
+                        &namespace,
+                        expected_root,
+                        expected_namespace,
+                        attributes,
+                    )?;
+                    root_seen = true;
+                    element_stack.push(expected_root.to_string());
+                } else {
+                    let local_name =
+                        std::str::from_utf8(start.local_name().as_ref())?.to_string();
+                    let parent = element_stack.last().cloned().unwrap_or_default();
+                    let attribute_owner =
+                        active_map_depth.is_none().then_some(local_name.as_str());
+                    validate_attributes(
+                        &start,
+                        descendant_attributes,
+                        attribute_owner,
+                        attribute_owners,
+                    )?;
+                    if depth == 1 {
+                        if validate_root_child(&start, fields, &mut seen_root_fields)? {
+                            active_map_depth = Some(depth + 1);
+                            map_keys.clear();
+                        }
+                    } else if active_map_depth == Some(depth) {
+                        if !map_keys.insert(local_name.clone()) {
+                            return Err(invalid_data(format!(
+                                "duplicate XML map key: {local_name}"
+                            )));
+                        }
+                    } else if active_map_depth.is_none() {
+                        if !descendant_fields.contains(&local_name.as_str())
+                            || !descendant_relationships
+                                .contains(&(parent.as_str(), local_name.as_str()))
+                        {
+                            return Err(invalid_data(format!(
+                                "unknown XML element: {local_name}"
+                            )));
+                        }
+                    }
+                    let namespace_parent = if depth == 1 { "" } else { parent.as_str() };
+                    validate_element_namespace(
+                        namespace_parent,
+                        &local_name,
+                        &namespace,
+                        element_namespaces,
+                    )?;
+                    if active_map_depth.is_none() && map_fields.contains(&local_name.as_str()) {
+                        active_map_depth = Some(depth + 1);
+                        map_keys.clear();
+                    }
+                    element_stack.push(local_name);
+                }
+                depth += 1;
+                if depth > MAX_XML_DEPTH {
+                    return Err(invalid_data("XML nesting depth exceeds the generated limit"));
+                }
+            }
+            Event::Empty(start) => {
+                if depth == 0 {
+                    if root_seen || root_closed {
+                        return Err(invalid_data("XML must contain exactly one root element"));
+                    }
+                    validate_root(
+                        &start,
+                        &namespace,
+                        expected_root,
+                        expected_namespace,
+                        attributes,
+                    )?;
+                    root_seen = true;
+                    root_closed = true;
+                } else {
+                    let local_name =
+                        std::str::from_utf8(start.local_name().as_ref())?.to_string();
+                    let parent = element_stack.last().cloned().unwrap_or_default();
+                    let attribute_owner =
+                        active_map_depth.is_none().then_some(local_name.as_str());
+                    validate_attributes(
+                        &start,
+                        descendant_attributes,
+                        attribute_owner,
+                        attribute_owners,
+                    )?;
+                    if depth == 1 {
+                        validate_root_child(&start, fields, &mut seen_root_fields)?;
+                    } else if active_map_depth == Some(depth) {
+                        if !map_keys.insert(local_name.clone()) {
+                            return Err(invalid_data(format!(
+                                "duplicate XML map key: {local_name}"
+                            )));
+                        }
+                    } else if active_map_depth.is_none() {
+                        if !descendant_fields.contains(&local_name.as_str())
+                            || !descendant_relationships
+                                .contains(&(parent.as_str(), local_name.as_str()))
+                        {
+                            return Err(invalid_data(format!(
+                                "unknown XML element: {local_name}"
+                            )));
+                        }
+                    }
+                    let namespace_parent = if depth == 1 { "" } else { parent.as_str() };
+                    validate_element_namespace(
+                        namespace_parent,
+                        &local_name,
+                        &namespace,
+                        element_namespaces,
+                    )?;
+                }
+            }
+            Event::End(_) => {
+                if depth == 0 {
+                    return Err(invalid_data("unexpected XML closing element"));
+                }
+                if active_map_depth == Some(depth) {
+                    active_map_depth = None;
+                    map_keys.clear();
+                }
+                element_stack.pop();
+                depth -= 1;
+                if depth == 0 {
+                    root_closed = true;
+                }
+            }
+            Event::DocType(_) => {
+                return Err(invalid_data("DOCTYPE declarations are not allowed"));
+            }
+            Event::Text(text) if depth == 0 && !text.as_ref().iter().all(u8::is_ascii_whitespace) => {
+                return Err(invalid_data("text outside the XML root is not allowed"));
+            }
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+
+    if !root_seen || !root_closed || depth != 0 {
+        return Err(invalid_data("XML document is incomplete"));
+    }
+    Ok(())
+}

--- a/avrotize/rust_xml.py
+++ b/avrotize/rust_xml.py
@@ -1,0 +1,21 @@
+from typing import Any
+
+
+def xml_wire_name(name: str, schema_obj: Any) -> str:
+    """Resolve an XML local name, honoring ``altnames.xml``."""
+    if isinstance(schema_obj, dict):
+        altnames = schema_obj.get("altnames")
+        if isinstance(altnames, dict) and "xml" in altnames:
+            return altnames["xml"]
+    return name
+
+
+def xml_enum_wire_value(value: Any, enum_schema: Any) -> str:
+    """Resolve an XML enum value, honoring ``altenums.xml``."""
+    if isinstance(enum_schema, dict):
+        altenums = enum_schema.get("altenums")
+        if isinstance(altenums, dict):
+            xml_values = altenums.get("xml")
+            if isinstance(xml_values, dict) and str(value) in xml_values:
+                return xml_values[str(value)]
+    return str(value)

--- a/avrotize/structuretorust.py
+++ b/avrotize/structuretorust.py
@@ -280,6 +280,134 @@ class StructureToRust:
             return self.generate_tuple(structure_schema, parent_namespace, write_file, explicit_name=explicit_name)
         return 'serde_json::Value'
 
+    def collect_xml_field_metadata(
+        self, structure_type
+    ) -> tuple[
+        set[str],
+        set[str],
+        set[str],
+        set[tuple[str, str]],
+        set[tuple[str, str, str]],
+        set[tuple[str, str]],
+    ]:
+        """Collects nested XML element, attribute, and map property names."""
+        elements: set[str] = set()
+        attributes: set[str] = set()
+        maps: set[str] = set()
+        relationships: set[tuple[str, str]] = set()
+        namespaces: set[tuple[str, str, str]] = set()
+        attribute_owners: set[tuple[str, str]] = set()
+        visited: set[tuple[int, str]] = set()
+
+        def nested_objects(node):
+            if isinstance(node, list):
+                return [record for item in node for record in nested_objects(item)]
+            if not isinstance(node, dict):
+                return []
+            if '$ref' in node:
+                resolved = self.resolve_ref(
+                    node['$ref'],
+                    self.schema_doc if isinstance(self.schema_doc, dict) else None,
+                )
+                return nested_objects(resolved)
+            node_type = node.get('type')
+            if node_type in ('object', 'tuple'):
+                return [node]
+            if node_type in ('array', 'set'):
+                return nested_objects(node.get('items'))
+            if node_type == 'choice':
+                return [
+                    record
+                    for choice in node.get('choices', {}).values()
+                    for record in nested_objects(choice)
+                ]
+            return []
+
+        def visit(node, parent_element=None, inherited_namespace=''):
+            if isinstance(node, list):
+                for item in node:
+                    visit(item, parent_element, inherited_namespace)
+            elif isinstance(node, dict):
+                if '$ref' in node:
+                    resolved = self.resolve_ref(
+                        node['$ref'],
+                        self.schema_doc if isinstance(self.schema_doc, dict) else None,
+                    )
+                    if resolved:
+                        visit(resolved, parent_element, inherited_namespace)
+                    return
+                node_type = node.get('type')
+                if node_type in ('object', 'tuple'):
+                    visit_key = (id(node), parent_element or '')
+                    if visit_key in visited:
+                        return
+                    visited.add(visit_key)
+                    record_namespace = node.get('xmlns', inherited_namespace)
+                    for prop_name, prop_schema in node.get('properties', {}).items():
+                        name = xml_wire_name(prop_name, prop_schema)
+                        if prop_schema.get('xmlkind', 'element') == 'attribute':
+                            attributes.add(name)
+                            attribute_owners.add((parent_element or '', name))
+                        else:
+                            elements.add(name)
+                            parent = parent_element or ''
+                            if parent_element:
+                                relationships.add((parent_element, name))
+                            if prop_schema.get('type') == 'map':
+                                maps.add(name)
+                            records = nested_objects(prop_schema)
+                            field_namespaces = {
+                                record.get('xmlns', record_namespace) for record in records
+                            } or {record_namespace}
+                            namespaces.update((parent, name, namespace) for namespace in field_namespaces)
+                        visit(prop_schema, name, record_namespace)
+                elif node_type in ('array', 'set'):
+                    visit(node.get('items'), parent_element, inherited_namespace)
+                elif node_type == 'map':
+                    visit(node.get('values'), parent_element, inherited_namespace)
+                elif node_type == 'choice':
+                    for choice in node.get('choices', {}).values():
+                        visit(choice, parent_element, inherited_namespace)
+
+        visit(structure_type)
+        return elements, attributes, maps, relationships, namespaces, attribute_owners
+
+    def add_xml_union_metadata(self, variants: list[dict]) -> dict[str, bool]:
+        """Marks union variants whose XML lexical forms cannot round-trip unambiguously."""
+        scalar_kinds = {
+            'String': 'string',
+            'bool': 'bool',
+            'i8': 'integer', 'i16': 'integer', 'i32': 'integer', 'i64': 'integer',
+            'u8': 'integer', 'u16': 'integer', 'u32': 'integer', 'u64': 'integer',
+            'isize': 'integer', 'usize': 'integer',
+            'f32': 'float', 'f64': 'float',
+        }
+        present_scalar_kinds = {scalar_kinds[variant['type']] for variant in variants if variant['type'] in scalar_kinds}
+        type_counts = {
+            rust_type: sum(1 for variant in variants if variant['type'] == rust_type)
+            for rust_type in {variant['type'] for variant in variants}
+        }
+        kind_counts = {
+            kind: sum(1 for variant in variants if scalar_kinds.get(variant['type']) == kind)
+            for kind in present_scalar_kinds
+        }
+        for variant in variants:
+            scalar_kind = scalar_kinds.get(variant['type'])
+            variant['xml_scalar_kind'] = scalar_kind or ''
+            variant['xml_guard_string'] = scalar_kind == 'string' and len(present_scalar_kinds) > 1
+            variant['xml_reject_value'] = (
+                type_counts[variant['type']] > 1
+                or (scalar_kind is not None and kind_counts[scalar_kind] > 1)
+                or (scalar_kind is not None and scalar_kind != 'string' and 'string' in present_scalar_kinds)
+                or (scalar_kind == 'integer' and 'float' in present_scalar_kinds)
+            )
+            variant['xml_safe_for_random'] = not variant['xml_reject_value']
+        return {
+            'bool': 'bool' in present_scalar_kinds,
+            'integer': 'integer' in present_scalar_kinds,
+            'float': 'float' in present_scalar_kinds,
+        }
+
     def generate_class(self, structure_schema: Dict, parent_namespace: str, write_file: bool, explicit_name: str = '') -> str:
         """ Generates a Rust struct from JSON Structure object type """
         # Get name and namespace
@@ -365,6 +493,14 @@ class StructureToRust:
 
         # Get docstring
         doc = structure_schema.get('description', structure_schema.get('doc', class_name))
+        (
+            descendant_elements,
+            descendant_attributes,
+            descendant_maps,
+            descendant_relationships,
+            element_namespaces,
+            attribute_owners,
+        ) = self.collect_xml_field_metadata(structure_schema)
 
         # Prepare context for template
         context = {
@@ -374,6 +510,12 @@ class StructureToRust:
             'struct_name': self.safe_identifier(class_name),
             'xml_name': xml_wire_name(explicit_name if explicit_name else structure_schema.get('name', 'UnnamedClass'), structure_schema),
             'xml_namespace': structure_schema.get('xmlns', ''),
+            'xml_descendant_elements': sorted(descendant_elements),
+            'xml_descendant_attributes': sorted(descendant_attributes),
+            'xml_descendant_maps': sorted(descendant_maps),
+            'xml_descendant_relationships': sorted(descendant_relationships),
+            'xml_element_namespaces': sorted(element_namespaces),
+            'xml_attribute_owners': sorted(attribute_owners),
             'fields': fields,
             'is_abstract': is_abstract,
         }
@@ -485,12 +627,14 @@ class StructureToRust:
                     })
 
         doc = structure_schema.get('description', structure_schema.get('doc', choice_name))
+        xml_string_guards = self.add_xml_union_metadata(choice_types)
 
         context = {
             'serde_annotation': self.serde_annotation,
             'xml_annotation': self.xml_annotation,
             'union_enum_name': self.safe_identifier(pascal(choice_name)),
             'variants': choice_types,
+            'xml_string_guards': xml_string_guards,
             'doc': doc,
         }
 
@@ -527,6 +671,7 @@ class StructureToRust:
                 'type': type_name,
                 'random_value': self.generate_random_value(type_name),
             })
+        xml_string_guards = self.add_xml_union_metadata(union_types)
         
         qualified_union_enum_name = self.safe_package(self.concat_package(ns, union_enum_name))
         
@@ -535,6 +680,7 @@ class StructureToRust:
             'xml_annotation': self.xml_annotation,
             'union_enum_name': union_enum_name,
             'variants': union_types,
+            'xml_string_guards': xml_string_guards,
             'doc': f'Union type for {field_name}',
         }
 
@@ -657,6 +803,8 @@ class StructureToRust:
         """Writes the lib.rs file for the Rust project"""
         modules = {name[(len('crate::')):].split('::')[0].replace('.', '_') for name in self.generated_types_rust_package if name.startswith('crate::')}
         mod_statements = '\n'.join(f'pub mod {self.escaped_identifier(module)};' for module in sorted(modules))
+        if self.xml_annotation:
+            mod_statements = 'pub(crate) mod xml_support;\n' + mod_statements
         
         lib_rs_content = f"""
 // This is the library entry point
@@ -668,6 +816,14 @@ class StructureToRust:
             os.makedirs(os.path.dirname(lib_rs_path), exist_ok=True)
         with open(lib_rs_path, 'w', encoding='utf-8') as file:
             file.write(lib_rs_content)
+
+    def write_xml_support_rs(self):
+        """Writes shared XML validation and bounded decompression helpers."""
+        if self.xml_annotation:
+            render_template(
+                'rust/xml_support.rs.jinja',
+                os.path.join(self.output_dir, "src", "xml_support.rs"),
+            )
 
     def process_definitions(self, definitions: Dict, namespace_path: str) -> None:
         """ Processes the definitions section recursively """
@@ -723,6 +879,7 @@ class StructureToRust:
                 self.process_definitions(self.definitions, '')
 
         self.write_cargo_toml()
+        self.write_xml_support_rs()
         self.write_lib_rs()
 
     def convert(self, structure_schema_path: str, output_dir: str):

--- a/avrotize/structuretorust.py
+++ b/avrotize/structuretorust.py
@@ -7,7 +7,15 @@ import os
 import re
 from typing import Any, Dict, List, Set, Tuple, Union, Optional
 
-from avrotize.common import pascal, snake, render_template, json_wire_name, json_enum_wire_value
+from avrotize.common import (
+    pascal,
+    snake,
+    render_template,
+    json_wire_name,
+    json_enum_wire_value,
+    xml_wire_name,
+    xml_enum_wire_value,
+)
 
 JsonNode = Dict[str, 'JsonNode'] | List['JsonNode'] | str | None
 
@@ -17,9 +25,10 @@ INDENT = '    '
 class StructureToRust:
     """ Converts JSON Structure schema to Rust structs """
 
-    def __init__(self, base_package: str = '', serde_annotation: bool = False) -> None:
+    def __init__(self, base_package: str = '', serde_annotation: bool = False, xml_annotation: bool = False) -> None:
         self.base_package = base_package.replace('.', '/').lower()
         self.serde_annotation = serde_annotation
+        self.xml_annotation = xml_annotation
         self.output_dir = os.getcwd()
         self.schema_doc: JsonNode = None
         self.generated_types_rust_package: Dict[str, str] = {}
@@ -307,7 +316,9 @@ class StructureToRust:
             if 'const' in prop_schema:
                 continue
             
-            original_field_name = json_wire_name(prop_name, prop_schema)
+            json_name = json_wire_name(prop_name, prop_schema)
+            xml_name = xml_wire_name(prop_name, prop_schema)
+            original_field_name = xml_name if self.xml_annotation else json_name
             field_name = self.safe_identifier(snake(prop_name))
             
             # Determine if required
@@ -322,7 +333,9 @@ class StructureToRust:
             if not is_required and not prop_type.startswith('Option<'):
                 prop_type = f'Option<{prop_type}>'
             
-            serde_rename = field_name != original_field_name
+            xml_kind = prop_schema.get('xmlkind', 'element')
+            serde_name = f"@{xml_name}" if self.xml_annotation and xml_kind == 'attribute' else original_field_name
+            serde_rename = field_name != serde_name
             
             # Get source type - handle nullable unions like ["int64", "null"]
             raw_type = prop_schema.get('type', 'string')
@@ -333,12 +346,20 @@ class StructureToRust:
                 source_type = non_null_types[0] if len(non_null_types) == 1 and isinstance(non_null_types[0], str) else 'object'
             else:
                 source_type = 'object'
+            is_generated_type = prop_type in self.generated_types_rust_package or '::' in prop_type
             fields.append({
                 'original_name': original_field_name,
+                'json_name': json_name,
+                'serde_name': serde_name,
+                'serde_alias': json_name if self.serde_annotation and self.xml_annotation and json_name != serde_name else '',
+                'xml_name': xml_name,
+                'xml_kind': xml_kind,
                 'name': field_name,
                 'type': prop_type,
+                'is_optional': prop_type.startswith('Option<'),
                 'source_type': source_type,
                 'serde_rename': serde_rename,
+                'is_generated_type': is_generated_type,
                 'random_value': self.generate_random_value(prop_type)
             })
 
@@ -348,8 +369,11 @@ class StructureToRust:
         # Prepare context for template
         context = {
             'serde_annotation': self.serde_annotation,
+            'xml_annotation': self.xml_annotation,
             'doc': doc,
             'struct_name': self.safe_identifier(class_name),
+            'xml_name': xml_wire_name(explicit_name if explicit_name else structure_schema.get('name', 'UnnamedClass'), structure_schema),
+            'xml_namespace': structure_schema.get('xmlns', ''),
             'fields': fields,
             'is_abstract': is_abstract,
         }
@@ -382,18 +406,29 @@ class StructureToRust:
         # Convert enum values to valid Rust identifiers
         symbols = []
         for value in enum_values:
-            wire = json_enum_wire_value(value, structure_schema)
+            wire = xml_enum_wire_value(value, structure_schema) if self.xml_annotation else json_enum_wire_value(value, structure_schema)
             if isinstance(value, str):
                 symbol = pascal(value.replace('-', '_').replace(' ', '_'))
-                symbols.append({'name': symbol, 'value': wire})
+                json_wire = json_enum_wire_value(value, structure_schema)
+                symbols.append({
+                    'name': symbol,
+                    'value': wire,
+                    'json_value': json_wire if symbol != json_wire else snake(symbol),
+                })
             else:
-                symbols.append({'name': f"Value{value}", 'value': str(value)})
+                symbols.append({
+                    'name': f"Value{value}",
+                    'value': str(value),
+                    'json_value': json_enum_wire_value(value, structure_schema),
+                })
 
         doc = structure_schema.get('description', structure_schema.get('doc', enum_name))
 
         context = {
             'serde_annotation': self.serde_annotation,
+            'xml_annotation': self.xml_annotation,
             'enum_name': self.safe_identifier(enum_name),
+            'xml_name': xml_wire_name(structure_schema.get('name', field_name + 'Enum'), structure_schema),
             'symbols': symbols,
             'doc': doc,
         }
@@ -436,7 +471,8 @@ class StructureToRust:
                         choice_types.append({
                             'variant_name': pascal(choice_key),
                             'type': type_name,
-                            'tag': choice_key
+                            'tag': choice_key,
+                            'random_value': self.generate_random_value(type_ref),
                         })
                 elif 'type' in choice_schema:
                     # Generate inline type
@@ -444,13 +480,15 @@ class StructureToRust:
                     choice_types.append({
                         'variant_name': pascal(choice_key),
                         'type': rust_type,
-                        'tag': choice_key
+                        'tag': choice_key,
+                        'random_value': self.generate_random_value(rust_type),
                     })
 
         doc = structure_schema.get('description', structure_schema.get('doc', choice_name))
 
         context = {
             'serde_annotation': self.serde_annotation,
+            'xml_annotation': self.xml_annotation,
             'union_enum_name': self.safe_identifier(pascal(choice_name)),
             'variants': choice_types,
             'doc': doc,
@@ -487,12 +525,14 @@ class StructureToRust:
             union_types.append({
                 'variant_name': variant_name,
                 'type': type_name,
+                'random_value': self.generate_random_value(type_name),
             })
         
         qualified_union_enum_name = self.safe_package(self.concat_package(ns, union_enum_name))
         
         context = {
             'serde_annotation': self.serde_annotation,
+            'xml_annotation': self.xml_annotation,
             'union_enum_name': union_enum_name,
             'variants': union_types,
             'doc': f'Union type for {field_name}',
@@ -593,9 +633,11 @@ class StructureToRust:
     def write_cargo_toml(self):
         """Writes the Cargo.toml file for the Rust project"""
         dependencies = []
-        if self.serde_annotation:
+        if self.serde_annotation or self.xml_annotation:
             dependencies.append('serde = { version = "1.0", features = ["derive"] }')
             dependencies.append('serde_json = "1.0"')
+        if self.xml_annotation:
+            dependencies.append('quick-xml = { version = "0.38", features = ["serialize"] }')
         dependencies.append('chrono = { version = "0.4", features = ["serde"] }')
         dependencies.append('uuid = { version = "1.11", features = ["serde", "v4"] }')
         dependencies.append('flate2 = "1.0"')
@@ -690,7 +732,7 @@ class StructureToRust:
         self.convert_schema(schema, output_dir)
 
 
-def convert_structure_to_rust(structure_schema_path: str, rust_file_path: str, package_name: str = '', serde_annotation: bool = False):
+def convert_structure_to_rust(structure_schema_path: str, rust_file_path: str, package_name: str = '', serde_annotation: bool = False, xml_annotation: bool = False):
     """Converts JSON Structure schema to Rust structs
 
     Args:
@@ -698,6 +740,7 @@ def convert_structure_to_rust(structure_schema_path: str, rust_file_path: str, p
         rust_file_path (str): Output Rust file path
         package_name (str): Base package name
         serde_annotation (bool): Include Serde annotations
+        xml_annotation (bool): Include quick-xml compatible Serde annotations
     """
     if not package_name:
         package_name = os.path.splitext(os.path.basename(structure_schema_path))[0].lower().replace('-', '_')
@@ -705,10 +748,11 @@ def convert_structure_to_rust(structure_schema_path: str, rust_file_path: str, p
     structtorust = StructureToRust()
     structtorust.base_package = package_name
     structtorust.serde_annotation = serde_annotation
+    structtorust.xml_annotation = xml_annotation
     structtorust.convert(structure_schema_path, rust_file_path)
 
 
-def convert_structure_schema_to_rust(structure_schema: JsonNode, output_dir: str, package_name: str = '', serde_annotation: bool = False):
+def convert_structure_schema_to_rust(structure_schema: JsonNode, output_dir: str, package_name: str = '', serde_annotation: bool = False, xml_annotation: bool = False):
     """Converts JSON Structure schema to Rust structs
 
     Args:
@@ -716,8 +760,10 @@ def convert_structure_schema_to_rust(structure_schema: JsonNode, output_dir: str
         output_dir (str): Output directory path
         package_name (str): Base package name
         serde_annotation (bool): Include Serde annotations
+        xml_annotation (bool): Include quick-xml compatible Serde annotations
     """
     structtorust = StructureToRust()
     structtorust.base_package = package_name
     structtorust.serde_annotation = serde_annotation
+    structtorust.xml_annotation = xml_annotation
     structtorust.convert_schema(structure_schema, output_dir)

--- a/avrotize/structuretorust.py
+++ b/avrotize/structuretorust.py
@@ -13,9 +13,8 @@ from avrotize.common import (
     render_template,
     json_wire_name,
     json_enum_wire_value,
-    xml_wire_name,
-    xml_enum_wire_value,
 )
+from avrotize.rust_xml import xml_wire_name, xml_enum_wire_value
 
 JsonNode = Dict[str, 'JsonNode'] | List['JsonNode'] | str | None
 

--- a/avrotize/structuretorust/dataclass_enum.rs.jinja
+++ b/avrotize/structuretorust/dataclass_enum.rs.jinja
@@ -1,25 +1,45 @@
-{%- if serde_annotation %}
+{%- if serde_annotation or xml_annotation %}
 use serde::{self, Serialize, Deserialize};
 {%- endif %}
 
 {% if doc %}
 /// {{ doc }}
 {%- endif %}
-#[derive(Debug{%- if serde_annotation %}, Serialize, Deserialize{%- endif %}, PartialEq, Clone, Default)]
-{%- if serde_annotation %}
+#[derive(Debug{%- if serde_annotation or xml_annotation %}{%- if not (serde_annotation and xml_annotation) %}, Serialize{%- endif %}, Deserialize{%- endif %}, PartialEq, Clone, Default)]
+{%- if xml_annotation %}
+#[serde(rename = "{{ xml_name }}")]
+{%- elif serde_annotation %}
 #[serde(rename_all = "snake_case")]
 {%- endif %}
 pub enum {{ enum_name }} {
     #[default]
 {%- for symbol in symbols %}
-    {%- if serde_annotation and symbol.name != symbol.value %}
-    #[serde(rename = "{{ symbol.value }}")]
+    {%- if (serde_annotation or xml_annotation) and (symbol.name != symbol.value or (serde_annotation and xml_annotation and symbol.json_value != symbol.value)) %}
+    #[serde(rename = "{{ symbol.value }}"{%- if serde_annotation and xml_annotation and symbol.json_value != symbol.value %}, alias = "{{ symbol.json_value }}"{%- endif %})]
     {%- endif %}
     {{ symbol.name }},
 {%- endfor %}
 }
 
-{%- if serde_annotation %}
+{%- if serde_annotation and xml_annotation %}
+impl Serialize for {{ enum_name }} {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let is_xml = std::any::type_name::<S>().contains("quick_xml");
+        match self {
+            {%- for symbol in symbols %}
+            {{ enum_name }}::{{ symbol.name }} => serializer.serialize_str(
+                if is_xml { "{{ symbol.value }}" } else { "{{ symbol.json_value }}" }
+            ),
+            {%- endfor %}
+        }
+    }
+}
+{%- endif %}
+
+{%- if serde_annotation or xml_annotation %}
 impl {{ enum_name }} {
     pub fn is_json_match(node: &serde_json::Value) -> bool {
         return node.is_string();
@@ -54,9 +74,9 @@ mod tests {
     fn test_enum_values_{{ enum_name.lower() }}() {
         {%- for symbol in symbols %}
         let instance = {{ enum_name }}::{{ symbol.name }};
-        {%- if serde_annotation %}
+        {%- if serde_annotation or xml_annotation %}
         let json = serde_json::to_string(&instance).unwrap();
-        assert!(json.contains("{{ symbol.value }}"));
+        assert!(json.contains("{% if serde_annotation %}{{ symbol.json_value }}{% else %}{{ symbol.value }}{% endif %}"));
         {%- endif %}
         {%- endfor %}
     }

--- a/avrotize/structuretorust/dataclass_struct.rs.jinja
+++ b/avrotize/structuretorust/dataclass_struct.rs.jinja
@@ -1,12 +1,15 @@
-{%- if serde_annotation %}
+{%- if serde_annotation or xml_annotation %}
 use serde::{Serialize, Deserialize};
+{%- if xml_annotation %}
+use serde::ser::SerializeStruct;
+{%- endif %}
 {%- endif %}
 use std::io::Write;
 use flate2::write::GzEncoder;
 use flate2::read::GzDecoder;
 
 {%- set needs_string_serde = fields | selectattr("source_type", "in", ['int64', 'uint64', 'int128', 'uint128', 'decimal']) | list | length > 0 %}
-{%- if serde_annotation and needs_string_serde %}
+{%- if (serde_annotation or xml_annotation) and needs_string_serde %}
 
 mod string_as_number {
     use serde::{self, Serializer, Deserializer, Deserialize};
@@ -45,16 +48,46 @@ mod option_string_as_number {
 }
 {%- endif %}
 
+{%- if xml_annotation and needs_string_serde %}
+
+struct StringAsNumberRef<'a, T>(&'a T);
+
+impl<T: std::fmt::Display> Serialize for StringAsNumberRef<'_, T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where S: serde::Serializer {
+        serializer.serialize_str(&self.0.to_string())
+    }
+}
+
+struct OptionStringAsNumberRef<'a, T>(&'a Option<T>);
+
+impl<T: std::fmt::Display> Serialize for OptionStringAsNumberRef<'_, T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where S: serde::Serializer {
+        match self.0 {
+            Some(value) => serializer.serialize_str(&value.to_string()),
+            None => serializer.serialize_none(),
+        }
+    }
+}
+{%- endif %}
+
 {% if doc %}
 /// {{ doc }}
 {%- endif %}
-#[derive(Debug{%- if serde_annotation %}, Serialize, Deserialize{%- endif %}, PartialEq, Clone, Default)]
+#[derive(Debug{%- if serde_annotation or xml_annotation %}{%- if not xml_annotation %}, Serialize{%- endif %}, Deserialize{%- endif %}, PartialEq, Clone, Default)]
+{%- if xml_annotation %}
+#[serde(rename = "{{ xml_name }}")]
+{%- endif %}
 pub struct {{ struct_name }} {
 {%- for field in fields %}
-    {%- if field.serde_rename and serde_annotation %}
-    #[serde(rename = "{{ field.original_name }}")]
+    {%- if field.serde_rename and (serde_annotation or xml_annotation) %}
+    #[serde(rename = "{{ field.serde_name }}"{%- if field.serde_alias %}, alias = "{{ field.serde_alias }}"{%- endif %})]
     {%- endif %}
-    {%- if serde_annotation and field.source_type in ['int64', 'uint64', 'int128', 'uint128', 'decimal'] %}
+    {%- if xml_annotation and field.is_optional %}
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    {%- endif %}
+    {%- if (serde_annotation or xml_annotation) and field.source_type in ['int64', 'uint64', 'int128', 'uint128', 'decimal'] %}
     {%- if field.type.startswith("Option<") %}
     #[serde(with = "option_string_as_number")]
     {%- else %}
@@ -65,6 +98,60 @@ pub struct {{ struct_name }} {
 {%- endfor %}
 }
 
+{% if xml_annotation %}
+impl Serialize for {{ struct_name }} {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let is_xml = std::any::type_name::<S>().contains("quick_xml");
+        let field_count = {{ fields | length }}
+            {%- if xml_namespace %}
+            + usize::from(is_xml)
+            {%- endif %}
+            {%- for field in fields %}
+            {%- if field.is_optional %}
+            - usize::from(is_xml && self.{{ field.name }}.is_none())
+            {%- endif %}
+            {%- endfor %};
+        let mut state = serializer.serialize_struct(
+            if is_xml { "{{ xml_name }}" } else { "{{ struct_name }}" },
+            field_count,
+        )?;
+        {%- if xml_namespace %}
+        if is_xml {
+            state.serialize_field("@xmlns", XML_NAMESPACE)?;
+        }
+        {%- endif %}
+        {%- for field in fields %}
+        {%- if field.is_optional %}
+        if !is_xml || self.{{ field.name }}.is_some() {
+        {%- endif %}
+            state.serialize_field(
+                if is_xml { "{{ field.serde_name }}" } else { "{{ field.json_name }}" },
+                {%- if field.source_type in ['int64', 'uint64', 'int128', 'uint128', 'decimal'] %}
+                {%- if field.is_optional %}
+                &OptionStringAsNumberRef(&self.{{ field.name }}),
+                {%- else %}
+                &StringAsNumberRef(&self.{{ field.name }}),
+                {%- endif %}
+                {%- else %}
+                &self.{{ field.name }},
+                {%- endif %}
+            )?;
+        {%- if field.is_optional %}
+        }
+        {%- endif %}
+        {%- endfor %}
+        state.end()
+    }
+}
+{%- endif %}
+
+{% if xml_annotation and xml_namespace %}
+const XML_NAMESPACE: &str = r#"{{ xml_namespace }}"#;
+{%- endif %}
+
 impl {{ struct_name }} {
    /// Serializes the struct to a byte array based on the provided content type
     pub fn to_byte_array(&self, content_type: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
@@ -73,6 +160,13 @@ impl {{ struct_name }} {
         {%- if serde_annotation %}
         if media_type.starts_with("application/json") {
             result = serde_json::to_vec(self)?;
+        }
+        else {% endif -%}
+        {%- if xml_annotation %}
+        if media_type.starts_with("application/xml") ||
+           media_type.starts_with("text/xml") {
+            let xml = quick_xml::se::to_string(self)?;
+            result = xml.into_bytes();
         }
         else {% endif -%}
         {
@@ -102,6 +196,13 @@ impl {{ struct_name }} {
         {%- if serde_annotation %}
         if media_type.starts_with("application/json") {
             let result = serde_json::from_slice(&data)?;
+            return Ok(result)
+        }
+        {%- endif %}
+        {%- if xml_annotation %}
+        if media_type.starts_with("application/xml") ||
+           media_type.starts_with("text/xml") {
+            let result = quick_xml::de::from_str(std::str::from_utf8(&data)?)?;
             return Ok(result)
         }
         {%- endif %}
@@ -145,16 +246,20 @@ mod tests {
         assert!(instance.{{ field.name }} != {{ field_type }}::default()); // Check that {{ field.name }} is not default
         {%- elif field.type.startswith("std::collections::HashMap<")%}
         assert!(instance.{{ field.name }}.len() >= 0); // Check that {{ field.name }} is not empty
+        {%- elif field.is_generated_type %}
+        // Skip default comparison for generated types (enums/unions) as random values may match default
+        let _ = &instance.{{ field.name }};
         {%- elif field.type != "bool" %}
         assert!(instance.{{ field.name }} != {{ field.type }}::default()); // Check that {{ field.name }} is not default
         {%- endif %}
         {%- endfor %}
     }
 
-    {%- if serde_annotation %}
+    {%- if serde_annotation or xml_annotation %}
     #[test]
     fn test_serialize_deserialize_{{ struct_name.lower() }}() {
         let instance = {{struct_name}}::generate_random_instance();
+        {%- if serde_annotation %}
         // Test JSON serialization and deserialization
         let json_bytes = instance.to_byte_array("application/json").unwrap();
         let deserialized_instance: {{ struct_name }} = {{ struct_name }}::from_data(&json_bytes, "application/json").unwrap();
@@ -163,6 +268,45 @@ mod tests {
         let json_gzip_bytes = instance.to_byte_array("application/json+gzip").unwrap();
         let deserialized_gzip_instance: {{ struct_name }} = {{ struct_name }}::from_data(&json_gzip_bytes, "application/json+gzip").unwrap();
         assert_eq!(instance, deserialized_gzip_instance);
+        {%- endif %}
+        {%- if xml_annotation %}
+        // Test XML serialization and deserialization
+        let xml_bytes = instance.to_byte_array("application/xml").unwrap();
+        let xml = String::from_utf8(xml_bytes.clone()).unwrap();
+        assert!(xml.starts_with("<{{ xml_name }}"), "unexpected XML root: {}", xml);
+        {%- if xml_namespace %}
+        assert!(xml.contains("xmlns=\"{{ xml_namespace }}\""), "missing XML namespace: {}", xml);
+        {%- endif %}
+        {%- for field in fields %}
+        {%- if field.xml_kind == "attribute" %}
+        assert!(xml.contains(" {{ field.xml_name }}=\""), "missing XML attribute {{ field.xml_name }}: {}", xml);
+        {%- else %}
+        assert!(xml.contains("<{{ field.xml_name }}"), "missing XML element {{ field.xml_name }}: {}", xml);
+        {%- endif %}
+        {%- endfor %}
+        let deserialized_xml_instance = {{ struct_name }}::from_data(&xml_bytes, "application/xml").unwrap();
+        assert_eq!(instance, deserialized_xml_instance);
+        let text_xml_bytes = instance.to_byte_array("text/xml").unwrap();
+        let deserialized_text_xml_instance = {{ struct_name }}::from_data(&text_xml_bytes, "text/xml").unwrap();
+        assert_eq!(instance, deserialized_text_xml_instance);
+        let xml_gzip_bytes = instance.to_byte_array("application/xml+gzip").unwrap();
+        let deserialized_xml_gzip_instance = {{ struct_name }}::from_data(&xml_gzip_bytes, "application/xml+gzip").unwrap();
+        assert_eq!(instance, deserialized_xml_gzip_instance);
+        let text_xml_gzip_bytes = instance.to_byte_array("text/xml+gzip").unwrap();
+        let deserialized_text_xml_gzip_instance = {{ struct_name }}::from_data(&text_xml_gzip_bytes, "text/xml+gzip").unwrap();
+        assert_eq!(instance, deserialized_text_xml_gzip_instance);
+        {%- if fields | selectattr("is_optional") | list | length > 0 %}
+        let mut optional_instance = {{ struct_name }}::generate_random_instance();
+        {%- for field in fields %}
+        {%- if field.is_optional %}
+        optional_instance.{{ field.name }} = None;
+        {%- endif %}
+        {%- endfor %}
+        let optional_xml_bytes = optional_instance.to_byte_array("application/xml").unwrap();
+        let deserialized_optional_instance = {{ struct_name }}::from_data(&optional_xml_bytes, "application/xml").unwrap();
+        assert_eq!(optional_instance, deserialized_optional_instance);
+        {%- endif %}
+        {%- endif %}
     }
     {%- endif %}
 }

--- a/avrotize/structuretorust/dataclass_struct.rs.jinja
+++ b/avrotize/structuretorust/dataclass_struct.rs.jinja
@@ -6,7 +6,9 @@ use serde::ser::SerializeStruct;
 {%- endif %}
 use std::io::Write;
 use flate2::write::GzEncoder;
+{%- if not xml_annotation %}
 use flate2::read::GzDecoder;
+{%- endif %}
 
 {%- set needs_string_serde = fields | selectattr("source_type", "in", ['int64', 'uint64', 'int128', 'uint128', 'decimal']) | list | length > 0 %}
 {%- if (serde_annotation or xml_annotation) and needs_string_serde %}
@@ -167,6 +169,9 @@ impl {{ struct_name }} {
            media_type.starts_with("text/xml") {
             let xml = quick_xml::se::to_string(self)?;
             result = xml.into_bytes();
+            if result.len() > crate::xml_support::MAX_XML_DATA_SIZE {
+                return Err("serialized XML exceeds the generated data size limit".into());
+            }
         }
         else {% endif -%}
         {
@@ -185,6 +190,15 @@ impl {{ struct_name }} {
     /// Deserializes the struct from a byte array based on the provided content type
     pub fn from_data(data: impl AsRef<[u8]>, content_type: &str) -> Result<Self, Box<dyn std::error::Error>> {
         let media_type = content_type.split(';').next().unwrap_or("");
+        {%- if xml_annotation %}
+        let is_xml = media_type.starts_with("application/xml") ||
+                     media_type.starts_with("text/xml");
+        let data = crate::xml_support::decode_data(
+            data.as_ref(),
+            media_type.ends_with("+gzip"),
+            is_xml,
+        )?;
+        {%- else %}
         let data = if media_type.ends_with("+gzip") {
             let mut decoder = GzDecoder::new(data.as_ref());
             let mut decompressed_data = Vec::new();
@@ -193,6 +207,7 @@ impl {{ struct_name }} {
         } else {
             data.as_ref().to_vec()
         };
+        {%- endif %}
         {%- if serde_annotation %}
         if media_type.starts_with("application/json") {
             let result = serde_json::from_slice(&data)?;
@@ -200,8 +215,60 @@ impl {{ struct_name }} {
         }
         {%- endif %}
         {%- if xml_annotation %}
-        if media_type.starts_with("application/xml") ||
-           media_type.starts_with("text/xml") {
+        if is_xml {
+            crate::xml_support::validate_xml_document(
+                &data,
+                "{{ xml_name }}",
+                r#"{{ xml_namespace }}"#,
+                &[
+                    {%- for field in fields %}
+                    {%- if field.xml_kind != "attribute" %}
+                    (
+                        "{{ field.xml_name }}",
+                        {{ "true" if field.type.startswith("Vec<") or field.type.startswith("std::collections::HashSet<") else "false" }},
+                        {{ "true" if "std::collections::HashMap<String, " in field.type else "false" }},
+                    ),
+                    {%- endif %}
+                    {%- endfor %}
+                ],
+                &[
+                    {%- for field in fields %}
+                    {%- if field.xml_kind == "attribute" %}
+                    "{{ field.xml_name }}",
+                    {%- endif %}
+                    {%- endfor %}
+                ],
+                &[
+                    {%- for name in xml_descendant_elements %}
+                    "{{ name }}",
+                    {%- endfor %}
+                ],
+                &[
+                    {%- for name in xml_descendant_attributes %}
+                    "{{ name }}",
+                    {%- endfor %}
+                ],
+                &[
+                    {%- for name in xml_descendant_maps %}
+                    "{{ name }}",
+                    {%- endfor %}
+                ],
+                &[
+                    {%- for parent, child in xml_descendant_relationships %}
+                    ("{{ parent }}", "{{ child }}"),
+                    {%- endfor %}
+                ],
+                &[
+                    {%- for parent, element, namespace in xml_element_namespaces %}
+                    ("{{ parent }}", "{{ element }}", r#"{{ namespace }}"#),
+                    {%- endfor %}
+                ],
+                &[
+                    {%- for owner, attribute in xml_attribute_owners %}
+                    ("{{ owner }}", "{{ attribute }}"),
+                    {%- endfor %}
+                ],
+            )?;
             let result = quick_xml::de::from_str(std::str::from_utf8(&data)?)?;
             return Ok(result)
         }

--- a/avrotize/structuretorust/dataclass_union.rs.jinja
+++ b/avrotize/structuretorust/dataclass_union.rs.jinja
@@ -25,9 +25,35 @@ impl Serialize for {{ union_enum_name }} {
     where
         S: serde::ser::Serializer
     {
+        {%- if xml_annotation %}
+        let is_xml = std::any::type_name::<S>().contains("quick_xml");
+        {%- endif %}
         match self {
             {%- for variant in variants %}
-            {{ union_enum_name }}::{{ variant.variant_name}}(value) => value.serialize(serializer),
+            {{ union_enum_name }}::{{ variant.variant_name}}(value) => {
+                {%- if xml_annotation and variant.xml_reject_value %}
+                if is_xml {
+                    return Err(serde::ser::Error::custom("ambiguous XML union value"));
+                }
+                {%- endif %}
+                {%- if xml_annotation and variant.xml_guard_string %}
+                if is_xml && (
+                    {%- if xml_string_guards.bool %}
+                    value.parse::<bool>().is_ok() ||
+                    {%- endif %}
+                    {%- if xml_string_guards.integer %}
+                    value.parse::<i128>().is_ok() ||
+                    {%- endif %}
+                    {%- if xml_string_guards.float %}
+                    value.parse::<f64>().is_ok() ||
+                    {%- endif %}
+                    false
+                ) {
+                    return Err(serde::ser::Error::custom("ambiguous XML union scalar"));
+                }
+                {%- endif %}
+                value.serialize(serializer)
+            },
             {%- endfor %}
         }
     }
@@ -43,7 +69,19 @@ impl<'de> Deserialize<'de> for {{ union_enum_name }} {
         {%- endif %}
         let node = serde_json::Value::deserialize(deserializer)?;
         {%- if xml_annotation %}
+        if is_xml && xml_scalar_match_count(&node) > 1 {
+            return Err(serde::de::Error::custom("ambiguous XML union scalar"));
+        }
         let node = if is_xml { normalize_xml_value(node) } else { node };
+        if is_xml {
+            let match_count = 0usize
+                {%- for variant in variants %}
+                + usize::from(serde_json::from_value::<{{ variant.type }}>(node.clone()).is_ok())
+                {%- endfor %};
+            if match_count > 1 {
+                return Err(serde::de::Error::custom("ambiguous XML union value"));
+            }
+        }
         {%- endif %}
         {%- for variant in variants %}
         {
@@ -58,6 +96,30 @@ impl<'de> Deserialize<'de> for {{ union_enum_name }} {
 {%- endif %}
 
 {%- if xml_annotation %}
+fn xml_scalar_match_count(value: &serde_json::Value) -> usize {
+    let serde_json::Value::Object(object) = value else {
+        return 0;
+    };
+    if object.len() != 1 {
+        return 0;
+    }
+    let Some(serde_json::Value::String(text)) = object.get("$text") else {
+        return 0;
+    };
+    0usize
+        {%- for variant in variants %}
+        {%- if variant.type == "String" %}
+        + 1
+        {%- elif variant.type == "bool" %}
+        + usize::from(text.parse::<bool>().is_ok())
+        {%- elif variant.type in ["i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64", "isize", "usize"] %}
+        + usize::from(text.parse::<i128>().is_ok())
+        {%- elif variant.type in ["f32", "f64"] %}
+        + usize::from(text.parse::<f64>().is_ok())
+        {%- endif %}
+        {%- endfor %}
+}
+
 fn normalize_xml_value(value: serde_json::Value) -> serde_json::Value {
     match value {
         serde_json::Value::Object(mut object) if object.len() == 1 && object.contains_key("$text") => {
@@ -97,14 +159,24 @@ fn normalize_xml_text(value: serde_json::Value) -> serde_json::Value {
 
 #[cfg(test)]
 impl {{ union_enum_name }} {
+{%- set xml_safe_variants = variants | selectattr('xml_safe_for_random') | list %}
     pub fn generate_random_instance() -> {{ union_enum_name }} {
         let mut rng = rand::thread_rng();
+        {%- if xml_annotation and xml_safe_variants | length > 0 %}
+        match rand::Rng::gen_range(&mut rng, 0..{{ xml_safe_variants | length }}) {
+            {%- for variant in xml_safe_variants %}
+            {{ loop.index0 }} => {{ union_enum_name }}::{{ variant.variant_name }}({{ variant.random_value }}),
+            {%- endfor %}
+            _ => panic!("Invalid random index generated"),
+        }
+        {%- else %}
         match rand::Rng::gen_range(&mut rng, 0..{{ variants | length }}) {
             {%- for variant in variants %}
             {{ loop.index0 }} => {{ union_enum_name }}::{{ variant.variant_name }}({{ variant.random_value }}),
             {%- endfor %}
             _ => panic!("Invalid random index generated"),
         }
+        {%- endif %}
     }
 }
 

--- a/avrotize/structuretorust/dataclass_union.rs.jinja
+++ b/avrotize/structuretorust/dataclass_union.rs.jinja
@@ -1,4 +1,4 @@
-{%- if serde_annotation %}
+{%- if serde_annotation or xml_annotation %}
 use serde::{self, Serialize, Deserialize};
 {%- endif %}
 
@@ -6,9 +6,6 @@ use serde::{self, Serialize, Deserialize};
 /// {{ doc }}
 {%- endif %}
 #[derive(Debug, PartialEq, Clone)]
-{%- if serde_annotation %}
-#[serde(untagged)]
-{%- endif %}
 pub enum {{ union_enum_name }} {
 {%- for variant in variants %}
     {{ variant.variant_name }}({{ variant.type -}})
@@ -22,7 +19,7 @@ impl Default for {{ union_enum_name }} {
     }
 }
 
-{%- if serde_annotation %}
+{%- if serde_annotation or xml_annotation %}
 impl Serialize for {{ union_enum_name }} {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -41,7 +38,13 @@ impl<'de> Deserialize<'de> for {{ union_enum_name }} {
     where
         D: serde::de::Deserializer<'de>
     {
+        {%- if xml_annotation %}
+        let is_xml = std::any::type_name::<D>().contains("quick_xml");
+        {%- endif %}
         let node = serde_json::Value::deserialize(deserializer)?;
+        {%- if xml_annotation %}
+        let node = if is_xml { normalize_xml_value(node) } else { node };
+        {%- endif %}
         {%- for variant in variants %}
         {
             if let Ok(value) = serde_json::from_value::<{{ variant.type }}>(node.clone()) {
@@ -54,13 +57,51 @@ impl<'de> Deserialize<'de> for {{ union_enum_name }} {
 }
 {%- endif %}
 
+{%- if xml_annotation %}
+fn normalize_xml_value(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(mut object) if object.len() == 1 && object.contains_key("$text") => {
+            normalize_xml_text(object.remove("$text").unwrap())
+        }
+        serde_json::Value::Object(object) => serde_json::Value::Object(
+            object.into_iter().map(|(key, value)| (key, normalize_xml_value(value))).collect()
+        ),
+        serde_json::Value::Array(values) => {
+            serde_json::Value::Array(values.into_iter().map(normalize_xml_value).collect())
+        }
+        other => other,
+    }
+}
+
+fn normalize_xml_text(value: serde_json::Value) -> serde_json::Value {
+    let serde_json::Value::String(text) = value else {
+        return normalize_xml_value(value);
+    };
+    if let Ok(value) = text.parse::<bool>() {
+        return serde_json::Value::Bool(value);
+    }
+    if let Ok(value) = text.parse::<i64>() {
+        return serde_json::Value::Number(value.into());
+    }
+    if let Ok(value) = text.parse::<u64>() {
+        return serde_json::Value::Number(value.into());
+    }
+    if let Ok(value) = text.parse::<f64>() {
+        if let Some(value) = serde_json::Number::from_f64(value) {
+            return serde_json::Value::Number(value);
+        }
+    }
+    serde_json::Value::String(text)
+}
+{%- endif %}
+
 #[cfg(test)]
 impl {{ union_enum_name }} {
     pub fn generate_random_instance() -> {{ union_enum_name }} {
         let mut rng = rand::thread_rng();
         match rand::Rng::gen_range(&mut rng, 0..{{ variants | length }}) {
             {%- for variant in variants %}
-            {{ loop.index0 }} => {{ union_enum_name }}::{{ variant.variant_name }}(Default::default()),
+            {{ loop.index0 }} => {{ union_enum_name }}::{{ variant.variant_name }}({{ variant.random_value }}),
             {%- endfor %}
             _ => panic!("Invalid random index generated"),
         }
@@ -73,8 +114,9 @@ mod tests {
 
     #[test]
     fn test_union_variants_{{ union_enum_name.lower() }}() {
+        let mut rng = rand::thread_rng();
         {%- for variant in variants %}
-        let instance = {{ union_enum_name }}::{{ variant.variant_name }}(Default::default());
+        let instance = {{ union_enum_name }}::{{ variant.variant_name }}({{ variant.random_value }});
         assert!(matches!(instance, {{ union_enum_name }}::{{ variant.variant_name }}(_)));
         {%- endfor %}
     }

--- a/test/test_rust_xml.py
+++ b/test/test_rust_xml.py
@@ -1,0 +1,229 @@
+"""Focused runtime tests for Rust XML generation."""
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+from avrotize.avrotorust import convert_avro_schema_to_rust
+from avrotize.structuretorust import convert_structure_schema_to_rust
+
+
+AVRO_SCHEMA = {
+    "type": "record",
+    "name": "Order",
+    "namespace": "xmlroot",
+    "xmlns": "urn:orders",
+    "altnames": {"xml": "purchase-order"},
+    "fields": [
+        {"name": "id", "type": "string", "xmlkind": "attribute", "altnames": {"xml": "order-id"}},
+        {"name": "display_name", "type": "string", "altnames": {"xml": "display-name"}},
+        {"name": "note", "type": ["null", "string"]},
+        {"name": "tags", "type": {"type": "array", "items": "string"}},
+        {"name": "properties", "type": {"type": "map", "values": "string"}},
+        {"name": "choice", "type": ["string", "int"]},
+        {
+            "name": "state",
+            "type": {
+                "type": "enum",
+                "name": "State",
+                "namespace": "xmlenum",
+                "symbols": ["OPEN", "CLOSED"],
+                "altenums": {"xml": {"OPEN": "open-state", "CLOSED": "closed-state"}},
+            },
+        },
+        {
+            "name": "child",
+            "type": {
+                "type": "record",
+                "name": "Child",
+                "namespace": "xmlchild",
+                "xmlns": "urn:child",
+                "fields": [
+                    {"name": "code", "type": "string", "xmlkind": "attribute"},
+                    {"name": "value", "type": "string"},
+                ],
+            },
+        },
+    ],
+}
+
+STRUCTURE_SCHEMA = {
+    "type": "object",
+    "name": "Order",
+    "namespace": "sxmlroot",
+    "xmlns": "urn:orders",
+    "altnames": {"xml": "purchase-order"},
+    "properties": {
+        "id": {
+            "type": "string",
+            "xmlkind": "attribute",
+            "altnames": {"json": "json-id", "xml": "order-id"},
+        },
+        "display_name": {
+            "type": "string",
+            "altnames": {"json": "displayName", "xml": "display-name"},
+        },
+        "note": {"type": "string"},
+        "tags": {"type": "array", "items": {"type": "string"}},
+        "properties": {"type": "map", "values": {"type": "string"}},
+        "choice": {"type": ["string", "int32"]},
+        "state": {
+            "type": "string",
+            "name": "State",
+            "namespace": "sxmlenum",
+            "enum": ["OPEN", "CLOSED"],
+            "altenums": {
+                "json": {"OPEN": "json-open", "CLOSED": "json-closed"},
+                "xml": {"OPEN": "open-state", "CLOSED": "closed-state"},
+            },
+        },
+        "child": {
+            "type": "object",
+            "name": "Child",
+            "namespace": "sxmlchild",
+            "xmlns": "urn:child",
+            "properties": {
+                "code": {"type": "string", "xmlkind": "attribute"},
+                "value": {"type": "string"},
+            },
+            "required": ["code", "value"],
+        },
+    },
+    "required": ["id", "display_name", "tags", "properties", "choice", "state", "child"],
+}
+
+
+class TestRustXml(unittest.TestCase):
+    """Generate and execute representative quick-xml crates."""
+
+    def setUp(self):
+        if not shutil.which("cargo"):
+            self.skipTest("cargo not found")
+        self.output_dir = tempfile.mkdtemp(prefix="avrotize-rust-xml-")
+        self.addCleanup(shutil.rmtree, self.output_dir, True)
+
+    def run_cargo_test(self, crate_dir):
+        result = subprocess.run(
+            ["cargo", "test", "--quiet"],
+            cwd=crate_dir,
+            capture_output=True,
+            text=True,
+            timeout=600,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def write_runtime_test(self, crate_dir, package, root_module, enum_module, child_module, json_id, json_display, json_enum):
+        tests_dir = os.path.join(crate_dir, "tests")
+        os.makedirs(tests_dir, exist_ok=True)
+        source = f"""
+use std::collections::HashMap;
+use {package}::{root_module}::order::Order;
+use {package}::{root_module}::choiceunion::ChoiceUnion;
+use {package}::{enum_module}::state::State;
+use {package}::{child_module}::child::Child;
+
+#[test]
+fn xml_and_json_wire_contracts_round_trip() {{
+    let value = Order {{
+        id: "42".into(),
+        display_name: "example".into(),
+        note: None,
+        tags: vec!["one".into(), "two".into()],
+        properties: HashMap::from([("key".into(), "value".into())]),
+        choice: ChoiceUnion::String("selected".into()),
+        state: State::OPEN,
+        child: Child {{ code: "C".into(), value: "nested".into() }},
+    }};
+
+    let json = String::from_utf8(value.to_byte_array("application/json").unwrap()).unwrap();
+    assert!(json.contains("\\\"{json_id}\\\":\\\"42\\\""), "{{json}}");
+    assert!(json.contains("\\\"{json_display}\\\":\\\"example\\\""), "{{json}}");
+    assert!(json.contains("\\\"state\\\":\\\"{json_enum}\\\""), "{{json}}");
+    assert!(json.contains("\\\"choice\\\":\\\"selected\\\""), "{{json}}");
+    assert!(!json.contains("@order-id"), "{{json}}");
+
+    let xml_bytes = value.to_byte_array("application/xml").unwrap();
+    let xml = String::from_utf8(xml_bytes.clone()).unwrap();
+    assert!(xml.starts_with("<purchase-order "), "{{xml}}");
+    assert!(xml.contains("xmlns=\\\"urn:orders\\\""), "{{xml}}");
+    assert!(xml.contains("order-id=\\\"42\\\""), "{{xml}}");
+    assert!(xml.contains("<display-name>example</display-name>"), "{{xml}}");
+    assert!(!xml.contains("<note"), "{{xml}}");
+    assert!(xml.contains("<tags>one</tags><tags>two</tags>"), "{{xml}}");
+    assert!(xml.contains("<properties><key>value</key></properties>"), "{{xml}}");
+    assert!(xml.contains("<choice>selected</choice>"), "{{xml}}");
+    assert!(xml.contains("<state>open-state</state>"), "{{xml}}");
+    assert!(xml.contains("<child xmlns=\\\"urn:child\\\" code=\\\"C\\\"><value>nested</value></child>"), "{{xml}}");
+    assert_eq!(value, Order::from_data(&xml_bytes, "application/xml").unwrap());
+
+    let text_xml = value.to_byte_array("text/xml").unwrap();
+    assert_eq!(value, Order::from_data(&text_xml, "text/xml").unwrap());
+    let gzip = value.to_byte_array("application/xml+gzip").unwrap();
+    assert_eq!(value, Order::from_data(&gzip, "application/xml+gzip").unwrap());
+    let text_gzip = value.to_byte_array("text/xml+gzip").unwrap();
+    assert_eq!(value, Order::from_data(&text_gzip, "text/xml+gzip").unwrap());
+}}
+"""
+        with open(os.path.join(tests_dir, "xml_runtime.rs"), "w", encoding="utf-8") as test_file:
+            test_file.write(source)
+
+    def assert_generated_metadata(self, crate_dir, root_module):
+        with open(os.path.join(crate_dir, "Cargo.toml"), encoding="utf-8") as cargo_file:
+            self.assertIn('quick-xml = { version = "0.38", features = ["serialize"] }', cargo_file.read())
+        with open(os.path.join(crate_dir, "src", root_module, "order.rs"), encoding="utf-8") as source_file:
+            source = source_file.read()
+        self.assertIn('#[serde(rename = "purchase-order")]', source)
+        self.assertIn('"@order-id"', source)
+        self.assertIn('media_type.starts_with("application/xml")', source)
+        self.assertIn('media_type.starts_with("text/xml")', source)
+
+    def test_avro_xml_runtime(self):
+        crate_dir = os.path.join(self.output_dir, "avro")
+        convert_avro_schema_to_rust(
+            AVRO_SCHEMA,
+            crate_dir,
+            package_name="avro_xml",
+            serde_annotation=True,
+            xml_annotation=True,
+        )
+        self.assert_generated_metadata(crate_dir, "xmlroot")
+        self.write_runtime_test(crate_dir, "avro_xml", "xmlroot", "xmlenum", "xmlchild", "id", "display_name", "OPEN")
+        self.run_cargo_test(crate_dir)
+
+    def test_structure_xml_runtime(self):
+        crate_dir = os.path.join(self.output_dir, "structure")
+        convert_structure_schema_to_rust(
+            STRUCTURE_SCHEMA,
+            crate_dir,
+            package_name="structure_xml",
+            serde_annotation=True,
+            xml_annotation=True,
+        )
+        self.assert_generated_metadata(crate_dir, "sxmlroot")
+        self.write_runtime_test(
+            crate_dir,
+            "structure_xml",
+            "sxmlroot",
+            "sxmlenum",
+            "sxmlchild",
+            "json-id",
+            "displayName",
+            "json-open",
+        )
+        self.run_cargo_test(crate_dir)
+
+
+class TestRustXmlCli(unittest.TestCase):
+    """The public CLI surface exposes the same XML flag for both converters."""
+
+    def test_rust_commands_expose_xml_annotation(self):
+        commands_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "avrotize", "commands.json")
+        with open(commands_path, encoding="utf-8") as commands_file:
+            commands = {command["command"]: command for command in json.load(commands_file)}
+        for command_name in ("a2rust", "s2rust"):
+            command = commands[command_name]
+            self.assertEqual(command["function"]["args"]["xml_annotation"], "args.xml_annotation")
+            self.assertIn("--xml-annotation", [argument["name"] for argument in command["args"]])

--- a/test/test_rust_xml.py
+++ b/test/test_rust_xml.py
@@ -20,6 +20,7 @@ AVRO_SCHEMA = {
     "fields": [
         {"name": "id", "type": "string", "xmlkind": "attribute", "altnames": {"xml": "order-id"}},
         {"name": "display_name", "type": "string", "altnames": {"xml": "display-name"}},
+        {"name": "count", "type": "int"},
         {"name": "note", "type": ["null", "string"]},
         {"name": "tags", "type": {"type": "array", "items": "string"}},
         {"name": "properties", "type": {"type": "map", "values": "string"}},
@@ -66,6 +67,7 @@ STRUCTURE_SCHEMA = {
             "type": "string",
             "altnames": {"json": "displayName", "xml": "display-name"},
         },
+        "count": {"type": "int32"},
         "note": {"type": "string"},
         "tags": {"type": "array", "items": {"type": "string"}},
         "properties": {"type": "map", "values": {"type": "string"}},
@@ -92,7 +94,7 @@ STRUCTURE_SCHEMA = {
             "required": ["code", "value"],
         },
     },
-    "required": ["id", "display_name", "tags", "properties", "choice", "state", "child"],
+    "required": ["id", "display_name", "count", "tags", "properties", "choice", "state", "child"],
 }
 
 
@@ -120,6 +122,8 @@ class TestRustXml(unittest.TestCase):
         os.makedirs(tests_dir, exist_ok=True)
         source = f"""
 use std::collections::HashMap;
+use std::io::Write;
+use flate2::write::GzEncoder;
 use {package}::{root_module}::order::Order;
 use {package}::{root_module}::choiceunion::ChoiceUnion;
 use {package}::{enum_module}::state::State;
@@ -130,6 +134,7 @@ fn xml_and_json_wire_contracts_round_trip() {{
     let value = Order {{
         id: "42".into(),
         display_name: "example".into(),
+        count: 7,
         note: None,
         tags: vec!["one".into(), "two".into()],
         properties: HashMap::from([("key".into(), "value".into())]),
@@ -141,6 +146,7 @@ fn xml_and_json_wire_contracts_round_trip() {{
     let json = String::from_utf8(value.to_byte_array("application/json").unwrap()).unwrap();
     assert!(json.contains("\\\"{json_id}\\\":\\\"42\\\""), "{{json}}");
     assert!(json.contains("\\\"{json_display}\\\":\\\"example\\\""), "{{json}}");
+    assert!(json.contains("\\\"count\\\":7"), "{{json}}");
     assert!(json.contains("\\\"state\\\":\\\"{json_enum}\\\""), "{{json}}");
     assert!(json.contains("\\\"choice\\\":\\\"selected\\\""), "{{json}}");
     assert!(!json.contains("@order-id"), "{{json}}");
@@ -151,6 +157,7 @@ fn xml_and_json_wire_contracts_round_trip() {{
     assert!(xml.contains("xmlns=\\\"urn:orders\\\""), "{{xml}}");
     assert!(xml.contains("order-id=\\\"42\\\""), "{{xml}}");
     assert!(xml.contains("<display-name>example</display-name>"), "{{xml}}");
+    assert!(xml.contains("<count>7</count>"), "{{xml}}");
     assert!(!xml.contains("<note"), "{{xml}}");
     assert!(xml.contains("<tags>one</tags><tags>two</tags>"), "{{xml}}");
     assert!(xml.contains("<properties><key>value</key></properties>"), "{{xml}}");
@@ -165,6 +172,140 @@ fn xml_and_json_wire_contracts_round_trip() {{
     assert_eq!(value, Order::from_data(&gzip, "application/xml+gzip").unwrap());
     let text_gzip = value.to_byte_array("text/xml+gzip").unwrap();
     assert_eq!(value, Order::from_data(&text_gzip, "text/xml+gzip").unwrap());
+
+    let mut large_json = value.clone();
+    large_json.display_name = "x".repeat(17 * 1024 * 1024);
+    let large_json_gzip = large_json.to_byte_array("application/json+gzip").unwrap();
+    assert_eq!(
+        large_json,
+        Order::from_data(&large_json_gzip, "application/json+gzip").unwrap()
+    );
+
+    let mut ambiguous = value.clone();
+    ambiguous.choice = ChoiceUnion::I32(42);
+    let result = std::panic::catch_unwind(|| ambiguous.to_byte_array("application/xml"));
+    assert!(result.is_ok(), "to_byte_array panicked");
+    assert!(result.unwrap().is_err(), "ambiguous union was silently serialized");
+}}
+
+fn valid_xml() -> String {{
+    concat!(
+        "<purchase-order xmlns=\\"urn:orders\\" order-id=\\"42\\">",
+        "<display-name>example</display-name><count>7</count>",
+        "<tags>one</tags><properties><key>value</key></properties>",
+        "<choice>selected</choice><state>open-state</state>",
+        "<child xmlns=\\"urn:child\\" code=\\"C\\"><value>nested</value></child>",
+        "</purchase-order>"
+    ).to_string()
+}}
+
+fn assert_xml_error(data: &[u8], content_type: &str) {{
+    let result = std::panic::catch_unwind(|| Order::from_data(data, content_type));
+    assert!(result.is_ok(), "from_data panicked");
+    assert!(result.unwrap().is_err(), "invalid XML was silently accepted");
+}}
+
+#[test]
+fn adversarial_xml_is_rejected_without_panics() {{
+    let valid = valid_xml();
+
+    assert_xml_error(b"<purchase-order", "application/xml");
+    assert_xml_error(valid[..valid.len() - 9].as_bytes(), "application/xml");
+    assert_xml_error(&[0x1f, 0x8b, 0x08, 0x00, 0xff], "application/xml+gzip");
+
+    let doctype = valid.replace(
+        "<purchase-order",
+        "<!DOCTYPE purchase-order [<!ENTITY xxe SYSTEM \\"file:///etc/passwd\\">]><purchase-order",
+    ).replace("example", "&xxe;");
+    assert_xml_error(doctype.as_bytes(), "application/xml");
+
+    let entity_bomb = valid.replace(
+        "<purchase-order",
+        "<!DOCTYPE purchase-order [<!ENTITY a \\"aaaaaaaaaa\\"><!ENTITY b \\"&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;\\">]><purchase-order",
+    ).replace("example", "&b;");
+    assert_xml_error(entity_bomb.as_bytes(), "application/xml");
+
+    assert_xml_error(valid.replace("urn:orders", "urn:wrong").as_bytes(), "application/xml");
+    assert_xml_error(
+        valid.replace("<display-name>example</display-name>", "").as_bytes(),
+        "application/xml",
+    );
+    assert_xml_error(
+        valid.replace(
+            "</display-name>",
+            "</display-name><display-name>duplicate</display-name>",
+        ).as_bytes(),
+        "application/xml",
+    );
+    assert_xml_error(
+        valid.replace("<count>7</count>", "<count>not-a-number</count>").as_bytes(),
+        "application/xml",
+    );
+    assert_xml_error(
+        valid.replace("<state>open-state</state>", "<state>invalid</state>").as_bytes(),
+        "application/xml",
+    );
+    assert_xml_error(
+        valid.replace("</count>", "</count><unknown>value</unknown>").as_bytes(),
+        "application/xml",
+    );
+    assert_xml_error(
+        valid.replace(
+            "<value>nested</value>",
+            "<display-name>ignored</display-name><value>nested</value>",
+        ).as_bytes(),
+        "application/xml",
+    );
+    assert_xml_error(valid.replace("urn:child", "urn:wrong-child").as_bytes(), "application/xml");
+    assert_xml_error(
+        valid.replace("<display-name>", "<display-name code=\\"unexpected\\">").as_bytes(),
+        "application/xml",
+    );
+    assert_xml_error(
+        valid.replace("order-id=\\"42\\"", "order-id=\\"42\\" unexpected=\\"x\\"").as_bytes(),
+        "application/xml",
+    );
+    assert_xml_error(
+        valid.replace("order-id=\\"42\\"", "order-id=\\"42\\" order-id=\\"43\\"").as_bytes(),
+        "application/xml",
+    );
+
+    let nested = format!(
+        "<purchase-order xmlns=\\"urn:orders\\" order-id=\\"42\\"><display-name>{{}}{{}}example{{}}{{}}</display-name></purchase-order>",
+        "<x>".repeat(140),
+        "<y>",
+        "</y>",
+        "</x>".repeat(140),
+    );
+    assert_xml_error(nested.as_bytes(), "application/xml");
+
+    let oversized = format!(
+        "<purchase-order xmlns=\\"urn:orders\\" order-id=\\"42\\"><display-name>{{}}</display-name></purchase-order>",
+        "x".repeat(17 * 1024 * 1024),
+    );
+    assert_xml_error(oversized.as_bytes(), "application/xml");
+    let mut encoder = GzEncoder::new(Vec::new(), flate2::Compression::default());
+    encoder.write_all(oversized.as_bytes()).unwrap();
+    assert_xml_error(&encoder.finish().unwrap(), "application/xml+gzip");
+
+    assert_xml_error(
+        valid.replace("<choice>selected</choice>", "<choice>42</choice>").as_bytes(),
+        "application/xml",
+    );
+    assert_xml_error(
+        valid.replace(
+            "<properties><key>value</key></properties>",
+            "<properties><key>value</key><key>duplicate</key></properties>",
+        ).as_bytes(),
+        "application/xml",
+    );
+    assert_xml_error(
+        valid.replace(
+            "<properties><key>value</key></properties>",
+            "<properties><key><nested>invalid</nested></key></properties>",
+        ).as_bytes(),
+        "application/xml",
+    );
 }}
 """
         with open(os.path.join(tests_dir, "xml_runtime.rs"), "w", encoding="utf-8") as test_file:
@@ -179,6 +320,7 @@ fn xml_and_json_wire_contracts_round_trip() {{
         self.assertIn('"@order-id"', source)
         self.assertIn('media_type.starts_with("application/xml")', source)
         self.assertIn('media_type.starts_with("text/xml")', source)
+        self.assertTrue(os.path.exists(os.path.join(crate_dir, "src", "xml_support.rs")))
 
     def test_avro_xml_runtime(self):
         crate_dir = os.path.join(self.output_dir, "avro")


### PR DESCRIPTION
Closes #413

Adds quick-xml/Serde XML support to both Rust generators while preserving independent JSON/Avro naming. Includes namespaces, attributes/elements, maps/unions, XML media types, gzip, panic removal, and adversarial validation.