### PR TITLE
TypeScript: add XML serialization support

### DIFF
--- a/avrotize/avrotots.py
+++ b/avrotize/avrotots.py
@@ -23,10 +23,11 @@ def is_typescript_reserved_word(word: str) -> bool:
 class AvroToTypeScript:
     """Converts Avro schema to TypeScript classes using templates with namespace support."""
 
-    def __init__(self, base_package: str = '', typed_json_annotation=False, avro_annotation=False) -> None:
+    def __init__(self, base_package: str = '', typed_json_annotation=False, avro_annotation=False, xml_annotation=False) -> None:
         self.base_package = base_package
         self.typed_json_annotation = typed_json_annotation
         self.avro_annotation = avro_annotation
+        self.xml_annotation = xml_annotation
         self.output_dir = os.getcwd()
         self.src_dir = os.path.join(self.output_dir, "src")
         self.generated_types: Dict[str, str] = {}
@@ -86,6 +87,60 @@ class AvroToTypeScript:
         if is_typescript_reserved_word(name):
             return name + "_"
         return name
+
+    @staticmethod
+    def xml_name(default_name: str, schema: Dict) -> str:
+        """Resolve an XML local name from an ``altnames.xml`` annotation."""
+        altnames = schema.get("altnames", {})
+        return str(altnames.get("xml", default_name)) if isinstance(altnames, dict) else default_name
+
+    def xml_enum_values(self, schema: Dict) -> Dict[str, str]:
+        """Build runtime-enum-value to XML-wire-value mappings."""
+        alternates = schema.get("altenums", {})
+        xml_alternates = alternates.get("xml", {}) if isinstance(alternates, dict) else {}
+        return {str(symbol): str(xml_alternates.get(str(symbol), symbol)) for symbol in schema.get("symbols", [])}
+
+    def xml_type_mapping(self, avro_type: Union[str, Dict, List], parent_namespace: str, wrapper_type: str = '') -> str:
+        """Render a typed XML value mapping for a generated field."""
+        if isinstance(avro_type, list):
+            non_null = [item for item in avro_type if item != "null"]
+            if len(non_null) == 1:
+                return self.xml_type_mapping(non_null[0], parent_namespace)
+            variants = ", ".join(self.xml_type_mapping(item, parent_namespace) for item in non_null)
+            if wrapper_type:
+                return f"{{ kind: 'union', variants: {wrapper_type}.XmlVariants, unwrap: (value) => (value as any).value, wrap: (value) => new {wrapper_type}(value as any) }}"
+            return f"{{ kind: 'union', variants: [{variants}] }}"
+        if isinstance(avro_type, str):
+            primitive_kinds = {
+                "boolean": "boolean", "int": "number", "long": "number",
+                "float": "number", "double": "number", "bytes": "string",
+                "string": "string", "null": "any",
+            }
+            if avro_type in primitive_kinds:
+                return f"{{ kind: '{primitive_kinds[avro_type]}' }}"
+            type_name = fullname(avro_type, parent_namespace)
+            named_schema = self.type_dict.get(type_name) if self.type_dict else None
+            if isinstance(named_schema, dict) and named_schema.get("type") == "enum":
+                values = json.dumps(self.xml_enum_values(named_schema))
+                return f"{{ kind: 'enum', enumValues: {values} }}"
+            class_name = pascal(avro_type.split(".")[-1])
+            return f"{{ kind: 'record', record: () => {class_name}.XmlMapping }}"
+        if isinstance(avro_type, dict):
+            logical_type = avro_type.get("logicalType")
+            if logical_type in ["date", "time-millis", "time-micros", "timestamp-millis", "timestamp-micros"]:
+                return "{ kind: 'date' }"
+            schema_type = avro_type.get("type")
+            if schema_type == "record":
+                return f"{{ kind: 'record', record: () => {pascal(avro_type['name'])}.XmlMapping }}"
+            if schema_type == "enum":
+                values = json.dumps(self.xml_enum_values(avro_type))
+                return f"{{ kind: 'enum', enumValues: {values} }}"
+            if schema_type == "array":
+                return f"{{ kind: 'array', item: {self.xml_type_mapping(avro_type['items'], parent_namespace)} }}"
+            if schema_type == "map":
+                return f"{{ kind: 'map', value: {self.xml_type_mapping(avro_type['values'], parent_namespace)} }}"
+            return self.xml_type_mapping(schema_type, parent_namespace)
+        return "{ kind: 'any' }"
 
     def convert_avro_type_to_typescript(self, avro_type: Union[str, Dict, List], parent_namespace: str, import_types: Set[str], class_name: str = '', field_name: str = '') -> str:
         """Convert Avro type to TypeScript type with namespace support."""
@@ -151,6 +206,7 @@ class AvroToTypeScript:
 
         fields = [{
             'definition': self.generate_field(field, avro_schema.get('namespace', parent_namespace), import_types, class_name),
+            'schema': field,
             'docstring': field.get('doc', '')
         } for field in avro_schema.get('fields', [])]
 
@@ -165,6 +221,9 @@ class AvroToTypeScript:
             'is_union': field['definition']['is_union'],
             'docstring': field['docstring'],
             'test_value': self.generate_test_value(field['definition']['type'], field['definition']['is_enum']),
+            'xml_name': self.xml_name(field['schema']['name'], field['schema']),
+            'xml_kind': 'attribute' if field['schema'].get('xmlkind') == 'attribute' else 'element',
+            'xml_type_mapping': self.xml_type_mapping(field['schema']['type'], avro_schema.get('namespace', parent_namespace), field['definition']['type'] if field['definition']['is_union'] else ''),
         } for field in fields]
 
         imports_with_paths: Dict[str, str] = {}
@@ -199,6 +258,10 @@ class AvroToTypeScript:
             base_package=self.base_package,
             avro_annotation=self.avro_annotation,
             typed_json_annotation=self.typed_json_annotation,
+            xml_annotation=self.xml_annotation,
+            xml_root_name=self.xml_name(avro_schema['name'], avro_schema),
+            xml_namespace=avro_schema.get('xmlns'),
+            xml_runtime_import=('../' * len(namespace.split('.')) if namespace else './') + 'xml.js',
             avro_schema_json=avro_schema_json,
             get_is_json_match_clause=self.get_is_json_match_clause,
         )
@@ -248,7 +311,7 @@ class AvroToTypeScript:
             'type': field_type,
             'is_primitive': self.is_typescript_primitive(field_type.replace('[]', '')),
             'is_array': field_type.endswith('[]'),
-            'is_union': self.generated_types.get(import_name, '') == 'union',
+            'is_union': any(kind == 'union' and name.endswith('.' + self.strip_nullable(field_type)) for name, kind in self.generated_types.items()),
             'is_enum': self.generated_types.get(import_name, '') == 'enum',
         }
 
@@ -266,7 +329,8 @@ class AvroToTypeScript:
         
         # Handle map/dict types
         if field_type.startswith('{ [key: string]:'):
-            return "{ 'key': 'value' }"
+            value_type = field_type[len('{ [key: string]:'):].rsplit('}', 1)[0].strip()
+            return f"{{ 'key': {self.generate_test_value(value_type)} }}"
         
         # Handle union types (pipe-separated)
         if '|' in field_type:
@@ -323,7 +387,7 @@ class AvroToTypeScript:
             elif field_type.endswith('[]'):
                 clause += f"Array.isArray(element['{field_name_js}'])"
             else:
-                clause += f"{field_type}.isJsonMatch(element['{field_name_js}'])"
+                clause += f"({field_type} as any).isJsonMatch(element['{field_name_js}'])"
 
         if is_optional:
             clause += f") || element['{field_name_js}'] === null"
@@ -355,10 +419,13 @@ class AvroToTypeScript:
             
         if self.typed_json_annotation:
             class_definition += "import 'reflect-metadata';\n"
-            class_definition += "import { CustomDeserializerParams, CustomSerializerParams } from 'typedjson/lib/types/metadata.js';\n"
+        class_definition += "import type { CustomDeserializerParams, CustomSerializerParams } from 'typedjson/lib/types/metadata.js';\n"
             
 
         class_definition += f"\nexport class {union_class_name} {{\n"
+        if self.xml_annotation:
+            xml_variants = ', '.join(self.xml_type_mapping(item, parent_namespace) for item in avro_type if item != 'null')
+            class_definition += f"{self.INDENT}public static readonly XmlVariants = [{xml_variants}] as const;\n\n"
 
         class_definition += f"{self.INDENT}private value: any;\n\n"
 
@@ -397,8 +464,8 @@ class AvroToTypeScript:
         class_definition += f"{self.INDENT}public static fromData(element: any, contentTypeString: string): {union_class_name} {{\n"
         class_definition += f"{self.INDENT*2}const unionTypes = [{', '.join([t.strip() for t in union_types if not self.is_typescript_primitive(t.strip())])}];\n"
         class_definition += f"{self.INDENT*2}for (const type of unionTypes) {{\n"
-        class_definition += f"{self.INDENT*3}if (type.isJsonMatch(element)) {{\n"
-        class_definition += f"{self.INDENT*4}return new {union_class_name}(type.fromData(element, contentTypeString));\n"
+        class_definition += f"{self.INDENT*3}if ((type as any).isJsonMatch(element)) {{\n"
+        class_definition += f"{self.INDENT*4}return new {union_class_name}((type as any).fromData(element, contentTypeString));\n"
         class_definition += f"{self.INDENT*3}}}\n"
         class_definition += f"{self.INDENT*2}}}\n"
         class_definition += f"{self.INDENT*2}throw new Error('No matching type for union');\n"
@@ -423,6 +490,10 @@ class AvroToTypeScript:
         class_definition += f"{self.INDENT*2}}}\n"
         class_definition += f"{self.INDENT}}}\n\n"
 
+        sample_value = self.generate_test_value(union_types[0])
+        class_definition += f"{self.INDENT}public static createInstance(): {union_class_name} {{\n"
+        class_definition += f"{self.INDENT*2}return new {union_class_name}({sample_value});\n"
+        class_definition += f"{self.INDENT}}}\n"
         class_definition += "}\n"
 
         if write_file:
@@ -502,6 +573,10 @@ class AvroToTypeScript:
         # Generate TypeScript type definitions for avro-js when using Avro annotations
         if self.avro_annotation:
             self.generate_avro_js_types(output_dir)
+        if self.xml_annotation:
+            xml_runtime = process_template("avrotots/xml_runtime.ts.jinja")
+            with open(os.path.join(self.src_dir, 'xml.ts'), 'w', encoding='utf-8') as file:
+                file.write(xml_runtime)
 
     def generate_avro_js_types(self, output_dir: str):
         """Generate TypeScript type declaration file for avro-js module."""
@@ -743,19 +818,19 @@ class AvroToTypeScript:
         self.generate_project_files(output_dir)
 
 
-def convert_avro_to_typescript(avro_schema_path, js_dir_path, package_name='', typedjson_annotation=False, avro_annotation=False):
+def convert_avro_to_typescript(avro_schema_path, js_dir_path, package_name='', typedjson_annotation=False, avro_annotation=False, xml_annotation=False):
     """Convert Avro schema to TypeScript classes."""
     if not package_name:
         package_name = os.path.splitext(os.path.basename(avro_schema_path))[0].lower().replace('-', '_')
 
     converter = AvroToTypeScript(package_name, typed_json_annotation=typedjson_annotation,
-                                 avro_annotation=avro_annotation)
+                                 avro_annotation=avro_annotation, xml_annotation=xml_annotation)
     converter.convert(avro_schema_path, js_dir_path)
 
 
-def convert_avro_schema_to_typescript(avro_schema, js_dir_path, package_name='', typedjson_annotation=False, avro_annotation=False):
+def convert_avro_schema_to_typescript(avro_schema, js_dir_path, package_name='', typedjson_annotation=False, avro_annotation=False, xml_annotation=False):
     """Convert Avro schema to TypeScript classes."""
     converter = AvroToTypeScript(package_name, typed_json_annotation=typedjson_annotation,
-                                 avro_annotation=avro_annotation)
+                                 avro_annotation=avro_annotation, xml_annotation=xml_annotation)
     converter.convert_schema(avro_schema, js_dir_path)
     converter.generate_project_files(js_dir_path)

--- a/avrotize/avrotots/class_core.ts.jinja
+++ b/avrotize/avrotots/class_core.ts.jinja
@@ -108,7 +108,16 @@ export class {{ class_name }} {
         const contentType = contentTypeString.split(';')[0].trim();
         const isGzip = contentType.endsWith('+gzip');
         const mediaType = isGzip ? contentType.slice(0, -5) : contentType;
-        if (isGzip) data = pako.ungzip(data);
+        if (isGzip) {
+            if ((mediaType === 'application/xml' || mediaType === 'text/xml') && data.byteLength > 1024 * 1024) {
+                throw new Error('Compressed XML payload exceeds the input limit');
+            }
+            try {
+                data = pako.ungzip(data);
+            } catch (error) {
+                throw new Error(`Invalid gzip data: ${error instanceof Error ? error.message : String(error)}`);
+            }
+        }
 
         {%- if avro_annotation %}
         if (mediaType === 'avro/binary' || mediaType === 'application/vnd.apache.avro+avro') {

--- a/avrotize/avrotots/class_core.ts.jinja
+++ b/avrotize/avrotots/class_core.ts.jinja
@@ -13,8 +13,11 @@ import avro, { type Type } from 'avro-js';
 {%- for import_type, import_path in imports.items() %}
 import { {{ import_type }} } from '{{ import_path }}';
 {%- endfor %}
-{%- if avro_annotation or typed_json_annotation %}
+{%- if avro_annotation or typed_json_annotation or xml_annotation %}
 import pako from 'pako';
+{%- endif %}
+{%- if xml_annotation %}
+import { deserializeXml, serializeXml, type XmlRecordMapping } from '{{ xml_runtime_import }}';
 {%- endif %}
 
 {%- if typed_json_annotation %}
@@ -23,6 +26,21 @@ import pako from 'pako';
 export class {{ class_name }} {
     {%- if avro_annotation %}
     public static AvroType: Type = avro.parse({{ avro_schema_json }});
+    {%- endif %}
+    {%- if xml_annotation %}
+    public static readonly XmlMapping: XmlRecordMapping<{{ class_name }}> = {
+        rootName: {{ xml_root_name | tojson }},
+        {%- if xml_namespace %}
+        namespace: {{ xml_namespace | tojson }},
+        {%- endif %}
+        assignMissing: true,
+        fields: [
+            {%- for field in fields %}
+            { property: {{ field.name | tojson }}, name: {{ field.xml_name | tojson }}, kind: '{{ field.xml_kind }}',{% if field.type.endswith('?') %} optional: true,{% endif %} type: {{ field.xml_type_mapping }} }{% if not loop.last %},{% endif %}
+            {%- endfor %}
+        ],
+        create: (values) => Object.assign(Object.create({{ class_name }}.prototype) as {{ class_name }}, values),
+    };
     {%- endif %}
 
     {%- for field in fields %}
@@ -52,63 +70,68 @@ export class {{ class_name }} {
         {%- endfor %}
     }
 
-    {%- if avro_annotation or typed_json_annotation %}
+    {%- if avro_annotation or typed_json_annotation or xml_annotation %}
     public toByteArray(contentTypeString: string): Uint8Array {
         const contentType = contentTypeString.split(';')[0].trim();
+        const isGzip = contentType.endsWith('+gzip');
+        const mediaType = isGzip ? contentType.slice(0, -5) : contentType;
         let result: Uint8Array | null = null;
 
         {%- if avro_annotation %}
-        if (contentType.startsWith('avro/binary') || contentType.startsWith('application/vnd.apache.avro+avro')) {
+        if (mediaType === 'avro/binary' || mediaType === 'application/vnd.apache.avro+avro') {
             result = ({{ class_name }}.AvroType.toBuffer(this) as unknown) as Uint8Array;
         }
         {%- endif %}
 
         {%- if typed_json_annotation %}
-        if (contentType.startsWith('application/json')) {
+        if (mediaType === 'application/json') {
             const serializer = new TypedJSON({{ class_name }});
             const jsonString = serializer.stringify(this);
             result = new TextEncoder().encode(jsonString);
         }
         {%- endif %}
 
-        if (result && contentTypeString.endsWith('+gzip')) {
+        {%- if xml_annotation %}
+        if (mediaType === 'application/xml' || mediaType === 'text/xml') {
+            result = new TextEncoder().encode(serializeXml(this, {{ class_name }}.XmlMapping));
+        }
+        {%- endif %}
+
+        if (result && isGzip) {
             result = pako.gzip(result);
         }
-
-        if (result) {
-            return result;
-        } else {
-            throw new Error(`Unsupported media type: ${contentTypeString}`);
-        }
+        if (!result) throw new Error(`Unsupported media type: ${contentTypeString}`);
+        return result;
     }
 
     public static fromData(data: any, contentTypeString: string): {{ class_name }} {
         const contentType = contentTypeString.split(';')[0].trim();
-
-        if (contentTypeString.endsWith('+gzip')) {
-            data = pako.ungzip(data);
-        }
+        const isGzip = contentType.endsWith('+gzip');
+        const mediaType = isGzip ? contentType.slice(0, -5) : contentType;
+        if (isGzip) data = pako.ungzip(data);
 
         {%- if avro_annotation %}
-        if (contentType.startsWith('avro/binary') || contentType.startsWith('application/vnd.apache.avro+avro')) {
+        if (mediaType === 'avro/binary' || mediaType === 'application/vnd.apache.avro+avro') {
             return {{ class_name }}.AvroType.fromBuffer(data);
         }
         {%- endif %}
 
         {%- if typed_json_annotation %}
-        if (contentType.startsWith('application/json')) {
+        if (mediaType === 'application/json') {
             const serializer = new TypedJSON({{ class_name }});
             const retval = serializer.parse(new TextDecoder().decode(data));
-            if (!(retval instanceof {{ class_name }})) {
-                throw new Error(`Deserialized object is not an instance of {{ class_name }}`);
-            }
+            if (!(retval instanceof {{ class_name }})) throw new Error(`Deserialized object is not an instance of {{ class_name }}`);
             return retval;
         }
         {%- endif %}
 
+        {%- if xml_annotation %}
+        if (mediaType === 'application/xml' || mediaType === 'text/xml') {
+            return deserializeXml(new TextDecoder().decode(data), {{ class_name }}.XmlMapping);
+        }
+        {%- endif %}
         throw new Error(`Unsupported media type: ${contentTypeString}`);
     }
-
 
     {%- if typed_json_annotation %}
     public static isJsonMatch(element: any): boolean {

--- a/avrotize/avrotots/package.json.jinja
+++ b/avrotize/avrotots/package.json.jinja
@@ -10,6 +10,7 @@
     },
     "dependencies": {
         "avro-js": "^1.12.0",
+        "fast-xml-parser": "^5.2.5",
         "typedjson": "^1.8.0",
         "pako": "^2.1.0",
         "reflect-metadata": "^0.2.2",

--- a/avrotize/avrotots/xml_runtime.ts.jinja
+++ b/avrotize/avrotots/xml_runtime.ts.jinja
@@ -1,4 +1,4 @@
-import { XMLBuilder, XMLParser } from 'fast-xml-parser';
+import { XMLBuilder, XMLParser, XMLValidator } from 'fast-xml-parser';
 
 export type XmlValueKind = 'string' | 'number' | 'boolean' | 'date' | 'enum' | 'record' | 'array' | 'set' | 'map' | 'union' | 'any';
 
@@ -29,28 +29,92 @@ export interface XmlRecordMapping<T = unknown> {
     readonly create: (values: Record<string, unknown>) => T;
 }
 
+const MAX_XML_SIZE = 1024 * 1024;
+const MAX_XML_DEPTH = 64;
+const XML_NAME = /^[A-Za-z_][A-Za-z0-9._-]*$/;
+
+function isObject(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isMapObject(value: unknown): value is Record<string, unknown> {
+    return isObject(value) && !(value instanceof Date) && !(value instanceof Set);
+}
+
+function canSerialize(value: unknown, mapping: XmlTypeMapping): boolean {
+    switch (mapping.kind) {
+        case 'string': return typeof value === 'string';
+        case 'number': return typeof value === 'number' && Number.isFinite(value);
+        case 'boolean': return typeof value === 'boolean';
+        case 'date': return value instanceof Date && !Number.isNaN(value.getTime());
+        case 'enum': return typeof value === 'string' && Object.prototype.hasOwnProperty.call(mapping.enumValues ?? {}, value);
+        case 'record': return isMapObject(value);
+        case 'array': return Array.isArray(value);
+        case 'set': return value instanceof Set;
+        case 'map': return isMapObject(value);
+        case 'any': return true;
+        case 'union': return (mapping.variants ?? []).filter((variant) => canSerialize(value, variant)).length === 1;
+    }
+}
+
 function selectVariant(value: unknown, variants: readonly XmlTypeMapping[]): XmlTypeMapping {
-    if (Array.isArray(value)) return variants.find((v) => v.kind === 'array') ?? variants[0];
-    if (value instanceof Set) return variants.find((v) => v.kind === 'set') ?? variants[0];
-    if (value instanceof Date) return variants.find((v) => v.kind === 'date') ?? variants[0];
-    if (value !== null && typeof value === 'object') return variants.find((v) => v.kind === 'record' || v.kind === 'map') ?? variants[0];
-    return variants.find((v) => v.kind === typeof value) ?? variants.find((v) => v.kind === 'enum' && typeof value === 'string') ?? variants[0];
+    const matches = variants.filter((variant) => canSerialize(value, variant));
+    if (matches.length !== 1) {
+        throw new Error(`XML union value matches ${matches.length} variants; exactly one is required`);
+    }
+    return matches[0];
+}
+
+function emptyCollection(): Record<string, string> {
+    return { '@_empty': 'true' };
+}
+
+function isEmptyCollection(value: unknown): boolean {
+    return isObject(value) && value['@_empty'] === 'true' && Object.keys(value).length === 1;
 }
 
 function toXmlValue(value: unknown, mapping: XmlTypeMapping): unknown {
     if (value === undefined || value === null) return undefined;
     switch (mapping.kind) {
-        case 'date': return value instanceof Date ? value.toISOString() : String(value);
-        case 'enum': return mapping.enumValues?.[String(value)] ?? String(value);
+        case 'string':
+            if (typeof value !== 'string') throw new Error('Expected XML string value');
+            return value;
+        case 'number':
+            if (typeof value !== 'number' || !Number.isFinite(value)) throw new Error('Expected finite XML number value');
+            return value;
+        case 'boolean':
+            if (typeof value !== 'boolean') throw new Error('Expected XML boolean value');
+            return value;
+        case 'date':
+            if (!(value instanceof Date) || Number.isNaN(value.getTime())) throw new Error('Expected valid XML date value');
+            return value.toISOString();
+        case 'enum': {
+            const enumValue = mapping.enumValues?.[String(value)];
+            if (enumValue === undefined) throw new Error(`Invalid XML enum value: ${String(value)}`);
+            return enumValue;
+        }
         case 'record': {
+            if (!isMapObject(value)) throw new Error('Expected XML record value');
             const recordMapping = mapping.record!();
-            const fields = toXmlFields(value as Record<string, unknown>, recordMapping);
+            const fields = toXmlFields(value, recordMapping);
             if (recordMapping.namespace) fields['@_xmlns'] = recordMapping.namespace;
             return fields;
         }
-        case 'array': return (value as unknown[]).map((item) => toXmlValue(item, mapping.item!));
-        case 'set': return Array.from(value as Set<unknown>, (item) => toXmlValue(item, mapping.item!));
-        case 'map': return Object.fromEntries(Object.entries(value as Record<string, unknown>).map(([key, item]) => [key, toXmlValue(item, mapping.value!)]));
+        case 'array': {
+            if (!Array.isArray(value)) throw new Error('Expected XML array value');
+            return value.length === 0 ? emptyCollection() : value.map((item) => toXmlValue(item, mapping.item!));
+        }
+        case 'set': {
+            if (!(value instanceof Set)) throw new Error('Expected XML set value');
+            return value.size === 0 ? emptyCollection() : Array.from(value, (item) => toXmlValue(item, mapping.item!));
+        }
+        case 'map': {
+            if (!isMapObject(value)) throw new Error('Expected XML map value');
+            return Object.fromEntries(Object.entries(value).map(([key, item]) => {
+                if (!XML_NAME.test(key)) throw new Error(`Invalid XML map key: ${key}`);
+                return [key, toXmlValue(item, mapping.value!)];
+            }));
+        }
         case 'union': {
             const unwrapped = mapping.unwrap ? mapping.unwrap(value) : value;
             return toXmlValue(unwrapped, selectVariant(unwrapped, mapping.variants!));
@@ -59,74 +123,167 @@ function toXmlValue(value: unknown, mapping: XmlTypeMapping): unknown {
     }
 }
 
+function scalarText(value: unknown, type: string): string {
+    if (typeof value !== 'string') throw new Error(`Expected scalar XML ${type} value`);
+    return value.trim();
+}
+
 function fromXmlValue(value: unknown, mapping: XmlTypeMapping): unknown {
     if (value === undefined || value === null) return undefined;
     switch (mapping.kind) {
-        case 'number': return Number(value);
-        case 'boolean': return value === true || value === 'true' || value === '1';
-        case 'date': return new Date(String(value));
-        case 'enum': {
-            const wireValue = String(value);
-            const entry = Object.entries(mapping.enumValues ?? {}).find(([, xmlValue]) => xmlValue === wireValue);
-            return entry?.[0] ?? wireValue;
+        case 'string':
+            if (typeof value !== 'string') throw new Error('Expected scalar XML string value');
+            return value;
+        case 'number': {
+            const text = scalarText(value, 'number');
+            if (!/^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/.test(text)) throw new Error(`Invalid XML number: ${text}`);
+            const numberValue = Number(text);
+            if (!Number.isFinite(numberValue)) throw new Error(`Invalid XML number: ${text}`);
+            return numberValue;
         }
-        case 'record': return fromXmlFields(value as Record<string, unknown>, mapping.record!());
-        case 'array': return (Array.isArray(value) ? value : [value]).map((item) => fromXmlValue(item, mapping.item!));
-        case 'set': return new Set((Array.isArray(value) ? value : [value]).map((item) => fromXmlValue(item, mapping.item!)));
-        case 'map': return Object.fromEntries(Object.entries(value as Record<string, unknown>).filter(([key]) => key !== '#text' && key !== '@_xmlns').map(([key, item]) => [key, fromXmlValue(item, mapping.value!)]));
+        case 'boolean': {
+            const text = scalarText(value, 'boolean');
+            if (text === 'true' || text === '1') return true;
+            if (text === 'false' || text === '0') return false;
+            throw new Error(`Invalid XML boolean: ${text}`);
+        }
+        case 'date': {
+            const text = scalarText(value, 'date');
+            const date = new Date(text);
+            if (Number.isNaN(date.getTime())) throw new Error(`Invalid XML date: ${text}`);
+            return date;
+        }
+        case 'enum': {
+            const wireValue = scalarText(value, 'enum');
+            const entry = Object.entries(mapping.enumValues ?? {}).find(([, xmlValue]) => xmlValue === wireValue);
+            if (!entry) throw new Error(`Invalid XML enum value: ${wireValue}`);
+            return entry[0];
+        }
+        case 'record':
+            if (!isObject(value)) throw new Error('Expected XML record element');
+            validateNamespace(value, mapping.record!());
+            return fromXmlFields(value, mapping.record!());
+        case 'array': {
+            if (isEmptyCollection(value)) return [];
+            const values = Array.isArray(value) ? value : [value];
+            return values.map((item) => fromXmlValue(item, mapping.item!));
+        }
+        case 'set': {
+            if (isEmptyCollection(value)) return new Set();
+            const values = Array.isArray(value) ? value : [value];
+            return new Set(values.map((item) => fromXmlValue(item, mapping.item!)));
+        }
+        case 'map': {
+            if (value === '') return {};
+            if (!isObject(value)) throw new Error('Expected XML map element');
+            const text = value['#text'];
+            if (text !== undefined && text !== 0 && String(text).trim() !== '') throw new Error('XML map cannot contain text content');
+            const entries = Object.entries(value).filter(([key]) => key !== '#text' && !key.startsWith('@_xmlns'));
+            return Object.fromEntries(entries.map(([key, item]) => {
+                if (key.startsWith('@_')) throw new Error(`Unexpected XML map attribute: ${key.slice(2)}`);
+                if (Array.isArray(item)) throw new Error(`Duplicate XML map key: ${key}`);
+                return [key, fromXmlValue(item, mapping.value!)];
+            }));
+        }
         case 'union': {
-            const variants = mapping.variants!;
-            const selected = value !== null && typeof value === 'object'
-                ? variants.find((v) => v.kind === 'record' || v.kind === 'map' || v.kind === 'array')
-                : variants.find((v) => v.kind === 'string' || v.kind === 'enum') ?? variants[0];
-            const converted = fromXmlValue(value, selected ?? variants[0]);
-            return mapping.wrap ? mapping.wrap(converted) : converted;
+            const matches: unknown[] = [];
+            for (const variant of mapping.variants ?? []) {
+                try {
+                    matches.push(fromXmlValue(value, variant));
+                } catch {
+                    // A variant that rejects the wire value is not a match.
+                }
+            }
+            if (matches.length !== 1) throw new Error(`XML union value matches ${matches.length} variants; exactly one is required`);
+            return mapping.wrap ? mapping.wrap(matches[0]) : matches[0];
         }
         default: return value;
     }
 }
 
+function acceptsRepeatedValues(mapping: XmlTypeMapping): boolean {
+    return mapping.kind === 'array' || mapping.kind === 'set' ||
+        (mapping.kind === 'union' && (mapping.variants ?? []).some((variant) => acceptsRepeatedValues(variant)));
+}
+
 function toXmlFields<T>(value: T, mapping: XmlRecordMapping<T>): Record<string, unknown> {
     const result: Record<string, unknown> = {};
     for (const field of mapping.fields) {
-        const converted = toXmlValue(value[field.property], field.type);
-        if (converted !== undefined) {
-            result[field.kind === 'attribute' ? '@_' + field.name : field.name] = converted;
+        const fieldValue = value[field.property];
+        if ((fieldValue === undefined || fieldValue === null) && !field.optional) {
+            throw new Error(`Missing required XML field: ${field.name}`);
         }
+        const converted = toXmlValue(fieldValue, field.type);
+        if (converted !== undefined) result[field.kind === 'attribute' ? '@_' + field.name : field.name] = converted;
     }
     return result;
 }
 
 function fromXmlFields<T>(value: Record<string, unknown>, mapping: XmlRecordMapping<T>): T {
     const fields: Record<string, unknown> = {};
+    const expectedKeys = new Map(mapping.fields.map((field) => [field.kind === 'attribute' ? '@_' + field.name : field.name, field]));
+    for (const key of Object.keys(value)) {
+        if (key === '#text' || key.startsWith('@_xmlns')) continue;
+        if (!expectedKeys.has(key)) throw new Error(`Unknown XML field or attribute: ${key.startsWith('@_') ? key.slice(2) : key}`);
+    }
+    const mixedText = value['#text'];
+    if (mixedText !== undefined && mixedText !== 0 && String(mixedText).trim() !== '') throw new Error('Unexpected XML text content in record');
     for (const field of mapping.fields) {
         if (mapping.assignMissing) fields[field.property] = undefined;
         const key = field.kind === 'attribute' ? '@_' + field.name : field.name;
-        if (Object.prototype.hasOwnProperty.call(value, key)) {
-            fields[field.property] = fromXmlValue(value[key], field.type);
-        } else if (!field.optional && field.type.kind === 'array') {
-            fields[field.property] = [];
-        } else if (!field.optional && field.type.kind === 'set') {
-            fields[field.property] = new Set();
-        } else if (!field.optional && field.type.kind === 'map') {
-            fields[field.property] = {};
+        if (!Object.prototype.hasOwnProperty.call(value, key)) {
+            if (!field.optional) throw new Error(`Missing required XML field: ${field.name}`);
+            continue;
         }
+        const rawValue = value[key];
+        if (Array.isArray(rawValue) && !acceptsRepeatedValues(field.type)) throw new Error(`Duplicate singleton XML field: ${field.name}`);
+        fields[field.property] = fromXmlValue(rawValue, field.type);
     }
     return mapping.create(fields);
+}
+
+function validateNamespace<T>(value: Record<string, unknown>, mapping: XmlRecordMapping<T>, prefix = ''): void {
+    if (!mapping.namespace) return;
+    const namespaceKey = prefix ? `@_xmlns:${prefix}` : '@_xmlns';
+    if (value[namespaceKey] !== mapping.namespace) {
+        throw new Error(`XML namespace mismatch for ${mapping.rootName}: expected ${mapping.namespace}`);
+    }
+}
+
+function assertDepth(value: unknown, depth = 0): void {
+    if (depth > MAX_XML_DEPTH) throw new Error(`XML nesting exceeds ${MAX_XML_DEPTH} levels`);
+    if (Array.isArray(value)) {
+        for (const item of value) assertDepth(item, depth);
+    } else if (isObject(value)) {
+        for (const child of Object.values(value)) assertDepth(child, depth + 1);
+    }
+}
+
+function assertSafeXml(xml: string): void {
+    if (xml.length > MAX_XML_SIZE || new TextEncoder().encode(xml).byteLength > MAX_XML_SIZE) {
+        throw new Error(`XML payload exceeds ${MAX_XML_SIZE} bytes`);
+    }
+    if (/<!DOCTYPE|<!ENTITY/i.test(xml)) throw new Error('DOCTYPE and ENTITY declarations are not allowed in XML');
+    const validation = XMLValidator.validate(xml, { allowBooleanAttributes: false });
+    if (validation !== true) {
+        const message = (validation as { err?: { msg?: string } }).err?.msg ?? 'invalid XML';
+        throw new Error(`Malformed XML: ${message}`);
+    }
 }
 
 export function serializeXml<T>(value: T, mapping: XmlRecordMapping<T>): string {
     const body = toXmlFields(value, mapping);
     if (mapping.namespace) body['@_xmlns'] = mapping.namespace;
-    const builder = new XMLBuilder({
-        ignoreAttributes: false,
-        attributeNamePrefix: '@_',
-        suppressEmptyNode: false,
-    });
-    return builder.build({ [mapping.rootName]: body });
+    const builder = new XMLBuilder({ ignoreAttributes: false, attributeNamePrefix: '@_', suppressEmptyNode: false });
+    const xml = builder.build({ [mapping.rootName]: body });
+    if (xml.length > MAX_XML_SIZE || new TextEncoder().encode(xml).byteLength > MAX_XML_SIZE) {
+        throw new Error(`XML payload exceeds ${MAX_XML_SIZE} bytes`);
+    }
+    return xml;
 }
 
 export function deserializeXml<T>(xml: string, mapping: XmlRecordMapping<T>): T {
+    assertSafeXml(xml);
     const parser = new XMLParser({
         ignoreAttributes: false,
         attributeNamePrefix: '@_',
@@ -135,14 +292,23 @@ export function deserializeXml<T>(xml: string, mapping: XmlRecordMapping<T>): T 
         processEntities: false,
         trimValues: false,
     });
-    const document = parser.parse(xml) as Record<string, unknown>;
-    let root = document[mapping.rootName];
+    let document: Record<string, unknown>;
+    try {
+        document = parser.parse(xml) as Record<string, unknown>;
+    } catch (error) {
+        throw new Error(`Malformed XML: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    assertDepth(document);
+    let rootKey = mapping.rootName;
+    let root = document[rootKey];
     if (root === undefined) {
-        const rootKey = Object.keys(document).find((key) => key.split(':').pop() === mapping.rootName);
-        if (rootKey) root = document[rootKey];
+        const match = Object.keys(document).filter((key) => key.split(':').pop() === mapping.rootName);
+        if (match.length !== 1) throw new Error(`Expected exactly one XML root element ${mapping.rootName}`);
+        rootKey = match[0];
+        root = document[rootKey];
     }
-    if (root === undefined || root === null || typeof root !== 'object') {
-        throw new Error(`Expected XML root element ${mapping.rootName}`);
-    }
-    return fromXmlFields(root as Record<string, unknown>, mapping);
+    if (!isObject(root)) throw new Error(`Expected XML root element ${mapping.rootName}`);
+    const prefix = rootKey.includes(':') ? rootKey.split(':', 1)[0] : '';
+    validateNamespace(root, mapping, prefix);
+    return fromXmlFields(root, mapping);
 }

--- a/avrotize/avrotots/xml_runtime.ts.jinja
+++ b/avrotize/avrotots/xml_runtime.ts.jinja
@@ -1,0 +1,148 @@
+import { XMLBuilder, XMLParser } from 'fast-xml-parser';
+
+export type XmlValueKind = 'string' | 'number' | 'boolean' | 'date' | 'enum' | 'record' | 'array' | 'set' | 'map' | 'union' | 'any';
+
+export interface XmlTypeMapping {
+    readonly kind: XmlValueKind;
+    readonly item?: XmlTypeMapping;
+    readonly value?: XmlTypeMapping;
+    readonly variants?: readonly XmlTypeMapping[];
+    readonly enumValues?: Readonly<Record<string, string>>;
+    readonly record?: () => XmlRecordMapping<any>;
+    readonly unwrap?: (value: unknown) => unknown;
+    readonly wrap?: (value: unknown) => unknown;
+}
+
+export interface XmlFieldMapping<T> {
+    readonly property: keyof T & string;
+    readonly name: string;
+    readonly kind: 'element' | 'attribute';
+    readonly optional?: boolean;
+    readonly type: XmlTypeMapping;
+}
+
+export interface XmlRecordMapping<T = unknown> {
+    readonly rootName: string;
+    readonly namespace?: string;
+    readonly fields: readonly XmlFieldMapping<T>[];
+    readonly assignMissing?: boolean;
+    readonly create: (values: Record<string, unknown>) => T;
+}
+
+function selectVariant(value: unknown, variants: readonly XmlTypeMapping[]): XmlTypeMapping {
+    if (Array.isArray(value)) return variants.find((v) => v.kind === 'array') ?? variants[0];
+    if (value instanceof Set) return variants.find((v) => v.kind === 'set') ?? variants[0];
+    if (value instanceof Date) return variants.find((v) => v.kind === 'date') ?? variants[0];
+    if (value !== null && typeof value === 'object') return variants.find((v) => v.kind === 'record' || v.kind === 'map') ?? variants[0];
+    return variants.find((v) => v.kind === typeof value) ?? variants.find((v) => v.kind === 'enum' && typeof value === 'string') ?? variants[0];
+}
+
+function toXmlValue(value: unknown, mapping: XmlTypeMapping): unknown {
+    if (value === undefined || value === null) return undefined;
+    switch (mapping.kind) {
+        case 'date': return value instanceof Date ? value.toISOString() : String(value);
+        case 'enum': return mapping.enumValues?.[String(value)] ?? String(value);
+        case 'record': {
+            const recordMapping = mapping.record!();
+            const fields = toXmlFields(value as Record<string, unknown>, recordMapping);
+            if (recordMapping.namespace) fields['@_xmlns'] = recordMapping.namespace;
+            return fields;
+        }
+        case 'array': return (value as unknown[]).map((item) => toXmlValue(item, mapping.item!));
+        case 'set': return Array.from(value as Set<unknown>, (item) => toXmlValue(item, mapping.item!));
+        case 'map': return Object.fromEntries(Object.entries(value as Record<string, unknown>).map(([key, item]) => [key, toXmlValue(item, mapping.value!)]));
+        case 'union': {
+            const unwrapped = mapping.unwrap ? mapping.unwrap(value) : value;
+            return toXmlValue(unwrapped, selectVariant(unwrapped, mapping.variants!));
+        }
+        default: return value;
+    }
+}
+
+function fromXmlValue(value: unknown, mapping: XmlTypeMapping): unknown {
+    if (value === undefined || value === null) return undefined;
+    switch (mapping.kind) {
+        case 'number': return Number(value);
+        case 'boolean': return value === true || value === 'true' || value === '1';
+        case 'date': return new Date(String(value));
+        case 'enum': {
+            const wireValue = String(value);
+            const entry = Object.entries(mapping.enumValues ?? {}).find(([, xmlValue]) => xmlValue === wireValue);
+            return entry?.[0] ?? wireValue;
+        }
+        case 'record': return fromXmlFields(value as Record<string, unknown>, mapping.record!());
+        case 'array': return (Array.isArray(value) ? value : [value]).map((item) => fromXmlValue(item, mapping.item!));
+        case 'set': return new Set((Array.isArray(value) ? value : [value]).map((item) => fromXmlValue(item, mapping.item!)));
+        case 'map': return Object.fromEntries(Object.entries(value as Record<string, unknown>).filter(([key]) => key !== '#text' && key !== '@_xmlns').map(([key, item]) => [key, fromXmlValue(item, mapping.value!)]));
+        case 'union': {
+            const variants = mapping.variants!;
+            const selected = value !== null && typeof value === 'object'
+                ? variants.find((v) => v.kind === 'record' || v.kind === 'map' || v.kind === 'array')
+                : variants.find((v) => v.kind === 'string' || v.kind === 'enum') ?? variants[0];
+            const converted = fromXmlValue(value, selected ?? variants[0]);
+            return mapping.wrap ? mapping.wrap(converted) : converted;
+        }
+        default: return value;
+    }
+}
+
+function toXmlFields<T>(value: T, mapping: XmlRecordMapping<T>): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+    for (const field of mapping.fields) {
+        const converted = toXmlValue(value[field.property], field.type);
+        if (converted !== undefined) {
+            result[field.kind === 'attribute' ? '@_' + field.name : field.name] = converted;
+        }
+    }
+    return result;
+}
+
+function fromXmlFields<T>(value: Record<string, unknown>, mapping: XmlRecordMapping<T>): T {
+    const fields: Record<string, unknown> = {};
+    for (const field of mapping.fields) {
+        if (mapping.assignMissing) fields[field.property] = undefined;
+        const key = field.kind === 'attribute' ? '@_' + field.name : field.name;
+        if (Object.prototype.hasOwnProperty.call(value, key)) {
+            fields[field.property] = fromXmlValue(value[key], field.type);
+        } else if (!field.optional && field.type.kind === 'array') {
+            fields[field.property] = [];
+        } else if (!field.optional && field.type.kind === 'set') {
+            fields[field.property] = new Set();
+        } else if (!field.optional && field.type.kind === 'map') {
+            fields[field.property] = {};
+        }
+    }
+    return mapping.create(fields);
+}
+
+export function serializeXml<T>(value: T, mapping: XmlRecordMapping<T>): string {
+    const body = toXmlFields(value, mapping);
+    if (mapping.namespace) body['@_xmlns'] = mapping.namespace;
+    const builder = new XMLBuilder({
+        ignoreAttributes: false,
+        attributeNamePrefix: '@_',
+        suppressEmptyNode: false,
+    });
+    return builder.build({ [mapping.rootName]: body });
+}
+
+export function deserializeXml<T>(xml: string, mapping: XmlRecordMapping<T>): T {
+    const parser = new XMLParser({
+        ignoreAttributes: false,
+        attributeNamePrefix: '@_',
+        parseAttributeValue: false,
+        parseTagValue: false,
+        processEntities: false,
+        trimValues: false,
+    });
+    const document = parser.parse(xml) as Record<string, unknown>;
+    let root = document[mapping.rootName];
+    if (root === undefined) {
+        const rootKey = Object.keys(document).find((key) => key.split(':').pop() === mapping.rootName);
+        if (rootKey) root = document[rootKey];
+    }
+    if (root === undefined || root === null || typeof root !== 'object') {
+        throw new Error(`Expected XML root element ${mapping.rootName}`);
+    }
+    return fromXmlFields(root as Record<string, unknown>, mapping);
+}

--- a/avrotize/commands.json
+++ b/avrotize/commands.json
@@ -3368,7 +3368,8 @@
         "ts_file_path": "output_file_path",
         "package_name": "args.package",
         "typedjson_annotation": "args.typedjson_annotation",
-        "avro_annotation": "args.avro_annotation"
+        "avro_annotation": "args.avro_annotation",
+        "xml_annotation": "args.xml_annotation"
       }
     },
     "extensions": [
@@ -3408,6 +3409,13 @@
         "help": "Add Avro binary serialization support with embedded Structure schema",
         "default": false,
         "required": false
+      },
+      {
+        "name": "--xml-annotation",
+        "type": "bool",
+        "help": "Generate XML mappings and serialization support",
+        "default": false,
+        "required": false
       }
     ],
     "suggested_output_file_path": "{input_file_name}-ts",
@@ -3415,6 +3423,12 @@
       {
         "name": "--typedjson-annotation",
         "message": "Use TypedJSON annotations?",
+        "type": "bool",
+        "default": false
+      },
+      {
+        "name": "--xml-annotation",
+        "message": "Generate XML serialization support?",
         "type": "bool",
         "default": false
       }
@@ -3706,7 +3720,8 @@
         "js_dir_path": "output_file_path",
         "package_name": "args.package",
         "avro_annotation": "args.avro_annotation",
-        "typedjson_annotation": "args.typedjson_annotation"
+        "typedjson_annotation": "args.typedjson_annotation",
+        "xml_annotation": "args.xml_annotation"
       }
     },
     "extensions": [
@@ -3751,6 +3766,13 @@
         "help": "Use TypedJSON annotations",
         "default": false,
         "required": false
+      },
+      {
+        "name": "--xml-annotation",
+        "type": "bool",
+        "help": "Generate XML mappings and serialization support",
+        "default": false,
+        "required": false
       }
     ],
     "suggested_output_file_path": "{input_file_name}-ts",
@@ -3764,6 +3786,12 @@
       {
         "name": "--typedjson-annotation",
         "message": "Use TypedJSON annotations?",
+        "type": "bool",
+        "default": false
+      },
+      {
+        "name": "--xml-annotation",
+        "message": "Generate XML serialization support?",
         "type": "bool",
         "default": false
       }

--- a/avrotize/structuretots.py
+++ b/avrotize/structuretots.py
@@ -31,10 +31,11 @@ def is_typescript_reserved_word(word: str) -> bool:
 class StructureToTypeScript:
     """ Converts JSON Structure schema to TypeScript classes """
 
-    def __init__(self, base_package: str = '', typedjson_annotation=False, avro_annotation=False) -> None:
+    def __init__(self, base_package: str = '', typedjson_annotation=False, avro_annotation=False, xml_annotation=False) -> None:
         self.base_package = base_package or ''
         self.typedjson_annotation = typedjson_annotation
         self.avro_annotation = avro_annotation
+        self.xml_annotation = xml_annotation
         self.output_dir = os.getcwd()
         self.schema_doc: JsonNode = None
         self.generated_types: Dict[str, str] = {}
@@ -110,6 +111,68 @@ class StructureToTypeScript:
             return name + "_"
         return name
 
+    @staticmethod
+    def xml_name(default_name: str, schema: Dict) -> str:
+        """Resolve an XML local name from an ``altnames.xml`` annotation."""
+        altnames = schema.get("altnames", {})
+        return str(altnames.get("xml", default_name)) if isinstance(altnames, dict) else default_name
+
+    @staticmethod
+    def xml_enum_values(schema: Dict) -> Dict[str, str]:
+        """Map generated enum values to their XML wire values."""
+        json_values = schema.get("altenums", {}).get("json", {}) if isinstance(schema.get("altenums"), dict) else {}
+        xml_values = schema.get("altenums", {}).get("xml", {}) if isinstance(schema.get("altenums"), dict) else {}
+        return {str(json_values.get(str(value), value)): str(xml_values.get(str(value), value)) for value in schema.get("enum", [])}
+
+    def xml_type_mapping(self, structure_type: JsonNode, parent_namespace: str) -> str:
+        """Render a typed XML value mapping for a JSON Structure property."""
+        if isinstance(structure_type, list):
+            non_null = [item for item in structure_type if item != "null"]
+            if len(non_null) == 1:
+                return self.xml_type_mapping(non_null[0], parent_namespace)
+            variants = ", ".join(self.xml_type_mapping(item, parent_namespace) for item in non_null)
+            return f"{{ kind: 'union', variants: [{variants}] }}"
+        if isinstance(structure_type, str):
+            if structure_type in ["boolean"]:
+                return "{ kind: 'boolean' }"
+            if structure_type in ["integer", "number", "int8", "uint8", "int16", "uint16", "int32", "uint32", "int64", "uint64", "float8", "float", "double", "binary32", "binary64"]:
+                return "{ kind: 'number' }"
+            if structure_type in ["int128", "uint128", "decimal", "string", "binary", "bytes", "duration", "uuid", "uri", "jsonpointer"]:
+                return "{ kind: 'string' }"
+            if structure_type in ["date", "time", "datetime", "timestamp"]:
+                return "{ kind: 'date' }"
+            return "{ kind: 'any' }"
+        if isinstance(structure_type, dict):
+            if "$ref" in structure_type:
+                ref_schema = self.resolve_ref(structure_type["$ref"])
+                if isinstance(ref_schema, dict) and "enum" in ref_schema:
+                    return f"{{ kind: 'enum', enumValues: {json.dumps(self.xml_enum_values(ref_schema))} }}"
+                ref_name = pascal(structure_type["$ref"].split("/")[-1])
+                return f"{{ kind: 'record', record: () => {ref_name}.XmlMapping }}"
+            if "enum" in structure_type:
+                return f"{{ kind: 'enum', enumValues: {json.dumps(self.xml_enum_values(structure_type))} }}"
+            schema_type = structure_type.get("type", "any")
+            if isinstance(schema_type, list):
+                return self.xml_type_mapping(schema_type, parent_namespace)
+            if schema_type == "object":
+                class_name = pascal(structure_type.get("name", "UnnamedClass"))
+                return f"{{ kind: 'record', record: () => {class_name}.XmlMapping }}"
+            if schema_type in ["array", "tuple"]:
+                items = structure_type.get("items", {"type": "any"})
+                if isinstance(items, list):
+                    variants = ", ".join(self.xml_type_mapping(item, parent_namespace) for item in items)
+                    return f"{{ kind: 'array', item: {{ kind: 'union', variants: [{variants}] }} }}"
+                return f"{{ kind: 'array', item: {self.xml_type_mapping(items, parent_namespace)} }}"
+            if schema_type == "set":
+                return f"{{ kind: 'set', item: {self.xml_type_mapping(structure_type.get('items', {'type': 'any'}), parent_namespace)} }}"
+            if schema_type == "map":
+                return f"{{ kind: 'map', value: {self.xml_type_mapping(structure_type.get('values', {'type': 'any'}), parent_namespace)} }}"
+            if schema_type == "choice":
+                variants = ", ".join(self.xml_type_mapping(item, parent_namespace) for item in structure_type.get("choices", {}).values())
+                return f"{{ kind: 'union', variants: [{variants}] }}"
+            return self.xml_type_mapping(schema_type, parent_namespace)
+        return "{ kind: 'any' }"
+
     def pascal_type_name(self, ref: str) -> str:
         """Converts a reference to a type name"""
         return '_'.join([pascal(part) for part in ref.split('.')[-1].split('_')])
@@ -158,6 +221,8 @@ class StructureToTypeScript:
 
         path = ref[2:].split('/')
         schema = context_schema if context_schema else self.schema_doc
+        if isinstance(schema, list) and len(schema) == 1:
+            schema = schema[0]
         for part in path:
             if not isinstance(schema, dict) or part not in schema:
                 return None
@@ -364,6 +429,9 @@ class StructureToTypeScript:
                 'is_optional': is_optional,
                 'is_primitive': self.is_typescript_primitive(field_type_no_null.replace('[]', '')),
                 'is_enum': is_enum,
+                'xml_name': self.xml_name(prop_name, prop_schema) if isinstance(prop_schema, dict) else prop_name,
+                'xml_kind': 'attribute' if isinstance(prop_schema, dict) and prop_schema.get('xmlkind') == 'attribute' else 'element',
+                'xml_type_mapping': self.xml_type_mapping(prop_schema, schema_namespace),
                 'docstring': prop_schema.get('description', '') if isinstance(prop_schema, dict) else ''
             })
 
@@ -399,6 +467,10 @@ class StructureToTypeScript:
             required_fields=required_fields,
             imports=imports_with_paths,
             typedjson_annotation=self.typedjson_annotation,
+            xml_annotation=self.xml_annotation,
+            xml_root_name=self.xml_name(explicit_name if explicit_name else structure_schema.get('name', 'UnnamedClass'), structure_schema),
+            xml_namespace=structure_schema.get('xmlns'),
+            xml_runtime_import=('../' * len(namespace.split('.')) if namespace else './') + 'xml.js',
         )
 
         if write_file:
@@ -718,12 +790,16 @@ class StructureToTypeScript:
         self.generate_package_json(package_name)
         self.generate_tsconfig()
         self.generate_gitignore()
+        if self.xml_annotation:
+            xml_runtime = process_template("structuretots/xml_runtime.ts.jinja")
+            with open(os.path.join(self.output_dir, 'src', 'xml.ts'), 'w', encoding='utf-8') as f:
+                f.write(xml_runtime)
         self.generate_index()
 
 
 def convert_structure_to_typescript(structure_schema_path: str, ts_file_path: str, 
                                    package_name: str = '', typedjson_annotation: bool = False, 
-                                   avro_annotation: bool = False) -> None:
+                                   avro_annotation: bool = False, xml_annotation: bool = False) -> None:
     """
     Converts a JSON Structure schema to TypeScript classes.
     
@@ -733,14 +809,15 @@ def convert_structure_to_typescript(structure_schema_path: str, ts_file_path: st
         package_name: Package name for the generated TypeScript project
         typedjson_annotation: Whether to include TypedJSON annotations
         avro_annotation: Whether to include Avro annotations
+        xml_annotation: Whether to generate XML mappings and serialization
     """
-    converter = StructureToTypeScript(package_name, typedjson_annotation, avro_annotation)
+    converter = StructureToTypeScript(package_name, typedjson_annotation, avro_annotation, xml_annotation)
     converter.convert(structure_schema_path, ts_file_path, package_name)
 
 
 def convert_structure_schema_to_typescript(structure_schema: JsonNode, output_dir: str, 
                                           package_name: str = '', typedjson_annotation: bool = False, 
-                                          avro_annotation: bool = False) -> None:
+                                          avro_annotation: bool = False, xml_annotation: bool = False) -> None:
     """
     Converts a JSON Structure schema to TypeScript classes.
     
@@ -750,6 +827,7 @@ def convert_structure_schema_to_typescript(structure_schema: JsonNode, output_di
         package_name: Package name for the generated TypeScript project
         typedjson_annotation: Whether to include TypedJSON annotations
         avro_annotation: Whether to include Avro annotations
+        xml_annotation: Whether to generate XML mappings and serialization
     """
-    converter = StructureToTypeScript(package_name, typedjson_annotation, avro_annotation)
+    converter = StructureToTypeScript(package_name, typedjson_annotation, avro_annotation, xml_annotation)
     converter.convert_schema(structure_schema, output_dir, package_name)

--- a/avrotize/structuretots.py
+++ b/avrotize/structuretots.py
@@ -606,6 +606,13 @@ class StructureToTypeScript:
             'null': 'null'
         }
         
+        # Use the first variant to create a valid sample for union fields.
+        if ' | ' in field_type:
+            union_field = dict(field)
+            union_field['type_no_null'] = field_type.split(' | ', 1)[0].strip()
+            union_field['is_enum'] = False
+            return self.generate_test_value(union_field)
+
         # Handle arrays
         if field_type.endswith('[]'):
             inner_type = field_type[:-2]

--- a/avrotize/structuretots/class_core.ts.jinja
+++ b/avrotize/structuretots/class_core.ts.jinja
@@ -10,11 +10,31 @@ import { jsonObject, jsonMember, TypedJSON } from 'typedjson';
 {%- for import_type, import_path in imports.items() %}
 import { {{ import_type }} } from '{{ import_path }}';
 {%- endfor %}
+{%- if typedjson_annotation or xml_annotation %}
+import pako from 'pako';
+{%- endif %}
+{%- if xml_annotation %}
+import { deserializeXml, serializeXml, type XmlRecordMapping } from '{{ xml_runtime_import }}';
+{%- endif %}
 
 {%- if typedjson_annotation %}
 @jsonObject
 {%- endif %}
 export {% if is_abstract %}abstract {% endif %}class {{ class_name }}{% if base_class %} extends {{ base_class }}{% endif %} {
+    {%- if xml_annotation %}
+    public static readonly XmlMapping: XmlRecordMapping<{{ class_name }}> = {
+        rootName: {{ xml_root_name | tojson }},
+        {%- if xml_namespace %}
+        namespace: {{ xml_namespace | tojson }},
+        {%- endif %}
+        fields: [
+            {%- for field in fields %}
+            { property: {{ field.name | tojson }}, name: {{ field.xml_name | tojson }}, kind: '{{ field.xml_kind }}',{% if field.is_optional %} optional: true,{% endif %} type: {{ field.xml_type_mapping }} }{% if not loop.last %},{% endif %}
+            {%- endfor %}
+        ],
+        create: (values) => Object.assign(Object.create({{ class_name }}.prototype) as {{ class_name }}, values),
+    };
+    {%- endif %}
     {%- for field in fields %}
     /** {{ field.docstring }} */
     {%- if typedjson_annotation %}
@@ -66,6 +86,43 @@ export {% if is_abstract %}abstract {% endif %}class {{ class_name }}{% if base_
             throw new Error('Failed to deserialize {{ class_name }}');
         }
         return result;
+    }
+    {%- endif %}
+
+    {%- if typedjson_annotation or xml_annotation %}
+    public toByteArray(contentTypeString: string): Uint8Array {
+        const contentType = contentTypeString.split(';')[0].trim();
+        const isGzip = contentType.endsWith('+gzip');
+        const mediaType = isGzip ? contentType.slice(0, -5) : contentType;
+        let result: Uint8Array | null = null;
+        {%- if typedjson_annotation %}
+        if (mediaType === 'application/json') result = new TextEncoder().encode(this.toJSON());
+        {%- endif %}
+        {%- if xml_annotation %}
+        if (mediaType === 'application/xml' || mediaType === 'text/xml') {
+            result = new TextEncoder().encode(serializeXml(this, {{ class_name }}.XmlMapping));
+        }
+        {%- endif %}
+        if (result && isGzip) result = pako.gzip(result);
+        if (!result) throw new Error(`Unsupported media type: ${contentTypeString}`);
+        return result;
+    }
+
+    public static fromData(data: Uint8Array, contentTypeString: string): {{ class_name }} {
+        const contentType = contentTypeString.split(';')[0].trim();
+        const isGzip = contentType.endsWith('+gzip');
+        const mediaType = isGzip ? contentType.slice(0, -5) : contentType;
+        if (isGzip) data = pako.ungzip(data);
+        const text = new TextDecoder().decode(data);
+        {%- if typedjson_annotation %}
+        if (mediaType === 'application/json') return {{ class_name }}.fromJSON(text);
+        {%- endif %}
+        {%- if xml_annotation %}
+        if (mediaType === 'application/xml' || mediaType === 'text/xml') {
+            return deserializeXml(text, {{ class_name }}.XmlMapping);
+        }
+        {%- endif %}
+        throw new Error(`Unsupported media type: ${contentTypeString}`);
     }
     {%- endif %}
 

--- a/avrotize/structuretots/class_core.ts.jinja
+++ b/avrotize/structuretots/class_core.ts.jinja
@@ -112,7 +112,16 @@ export {% if is_abstract %}abstract {% endif %}class {{ class_name }}{% if base_
         const contentType = contentTypeString.split(';')[0].trim();
         const isGzip = contentType.endsWith('+gzip');
         const mediaType = isGzip ? contentType.slice(0, -5) : contentType;
-        if (isGzip) data = pako.ungzip(data);
+        if (isGzip) {
+            if ((mediaType === 'application/xml' || mediaType === 'text/xml') && data.byteLength > 1024 * 1024) {
+                throw new Error('Compressed XML payload exceeds the input limit');
+            }
+            try {
+                data = pako.ungzip(data);
+            } catch (error) {
+                throw new Error(`Invalid gzip data: ${error instanceof Error ? error.message : String(error)}`);
+            }
+        }
         const text = new TextDecoder().decode(data);
         {%- if typedjson_annotation %}
         if (mediaType === 'application/json') return {{ class_name }}.fromJSON(text);

--- a/avrotize/structuretots/package.json.jinja
+++ b/avrotize/structuretots/package.json.jinja
@@ -16,10 +16,13 @@
     "typescript": "^5.0.0",
     "@types/node": "^20.0.0",
     "@types/jest": "^29.5.0",
+    "@types/pako": "^2.0.3",
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0"
   },
   "dependencies": {
+    "fast-xml-parser": "^5.2.5",
+    "pako": "^2.1.0",
     "typedjson": "^1.8.0",
     "reflect-metadata": "^0.1.13"
   },

--- a/avrotize/structuretots/xml_runtime.ts.jinja
+++ b/avrotize/structuretots/xml_runtime.ts.jinja
@@ -1,4 +1,4 @@
-import { XMLBuilder, XMLParser } from 'fast-xml-parser';
+import { XMLBuilder, XMLParser, XMLValidator } from 'fast-xml-parser';
 
 export type XmlValueKind = 'string' | 'number' | 'boolean' | 'date' | 'enum' | 'record' | 'array' | 'set' | 'map' | 'union' | 'any';
 
@@ -29,28 +29,92 @@ export interface XmlRecordMapping<T = unknown> {
     readonly create: (values: Record<string, unknown>) => T;
 }
 
+const MAX_XML_SIZE = 1024 * 1024;
+const MAX_XML_DEPTH = 64;
+const XML_NAME = /^[A-Za-z_][A-Za-z0-9._-]*$/;
+
+function isObject(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isMapObject(value: unknown): value is Record<string, unknown> {
+    return isObject(value) && !(value instanceof Date) && !(value instanceof Set);
+}
+
+function canSerialize(value: unknown, mapping: XmlTypeMapping): boolean {
+    switch (mapping.kind) {
+        case 'string': return typeof value === 'string';
+        case 'number': return typeof value === 'number' && Number.isFinite(value);
+        case 'boolean': return typeof value === 'boolean';
+        case 'date': return value instanceof Date && !Number.isNaN(value.getTime());
+        case 'enum': return typeof value === 'string' && Object.prototype.hasOwnProperty.call(mapping.enumValues ?? {}, value);
+        case 'record': return isMapObject(value);
+        case 'array': return Array.isArray(value);
+        case 'set': return value instanceof Set;
+        case 'map': return isMapObject(value);
+        case 'any': return true;
+        case 'union': return (mapping.variants ?? []).filter((variant) => canSerialize(value, variant)).length === 1;
+    }
+}
+
 function selectVariant(value: unknown, variants: readonly XmlTypeMapping[]): XmlTypeMapping {
-    if (Array.isArray(value)) return variants.find((v) => v.kind === 'array') ?? variants[0];
-    if (value instanceof Set) return variants.find((v) => v.kind === 'set') ?? variants[0];
-    if (value instanceof Date) return variants.find((v) => v.kind === 'date') ?? variants[0];
-    if (value !== null && typeof value === 'object') return variants.find((v) => v.kind === 'record' || v.kind === 'map') ?? variants[0];
-    return variants.find((v) => v.kind === typeof value) ?? variants.find((v) => v.kind === 'enum' && typeof value === 'string') ?? variants[0];
+    const matches = variants.filter((variant) => canSerialize(value, variant));
+    if (matches.length !== 1) {
+        throw new Error(`XML union value matches ${matches.length} variants; exactly one is required`);
+    }
+    return matches[0];
+}
+
+function emptyCollection(): Record<string, string> {
+    return { '@_empty': 'true' };
+}
+
+function isEmptyCollection(value: unknown): boolean {
+    return isObject(value) && value['@_empty'] === 'true' && Object.keys(value).length === 1;
 }
 
 function toXmlValue(value: unknown, mapping: XmlTypeMapping): unknown {
     if (value === undefined || value === null) return undefined;
     switch (mapping.kind) {
-        case 'date': return value instanceof Date ? value.toISOString() : String(value);
-        case 'enum': return mapping.enumValues?.[String(value)] ?? String(value);
+        case 'string':
+            if (typeof value !== 'string') throw new Error('Expected XML string value');
+            return value;
+        case 'number':
+            if (typeof value !== 'number' || !Number.isFinite(value)) throw new Error('Expected finite XML number value');
+            return value;
+        case 'boolean':
+            if (typeof value !== 'boolean') throw new Error('Expected XML boolean value');
+            return value;
+        case 'date':
+            if (!(value instanceof Date) || Number.isNaN(value.getTime())) throw new Error('Expected valid XML date value');
+            return value.toISOString();
+        case 'enum': {
+            const enumValue = mapping.enumValues?.[String(value)];
+            if (enumValue === undefined) throw new Error(`Invalid XML enum value: ${String(value)}`);
+            return enumValue;
+        }
         case 'record': {
+            if (!isMapObject(value)) throw new Error('Expected XML record value');
             const recordMapping = mapping.record!();
-            const fields = toXmlFields(value as Record<string, unknown>, recordMapping);
+            const fields = toXmlFields(value, recordMapping);
             if (recordMapping.namespace) fields['@_xmlns'] = recordMapping.namespace;
             return fields;
         }
-        case 'array': return (value as unknown[]).map((item) => toXmlValue(item, mapping.item!));
-        case 'set': return Array.from(value as Set<unknown>, (item) => toXmlValue(item, mapping.item!));
-        case 'map': return Object.fromEntries(Object.entries(value as Record<string, unknown>).map(([key, item]) => [key, toXmlValue(item, mapping.value!)]));
+        case 'array': {
+            if (!Array.isArray(value)) throw new Error('Expected XML array value');
+            return value.length === 0 ? emptyCollection() : value.map((item) => toXmlValue(item, mapping.item!));
+        }
+        case 'set': {
+            if (!(value instanceof Set)) throw new Error('Expected XML set value');
+            return value.size === 0 ? emptyCollection() : Array.from(value, (item) => toXmlValue(item, mapping.item!));
+        }
+        case 'map': {
+            if (!isMapObject(value)) throw new Error('Expected XML map value');
+            return Object.fromEntries(Object.entries(value).map(([key, item]) => {
+                if (!XML_NAME.test(key)) throw new Error(`Invalid XML map key: ${key}`);
+                return [key, toXmlValue(item, mapping.value!)];
+            }));
+        }
         case 'union': {
             const unwrapped = mapping.unwrap ? mapping.unwrap(value) : value;
             return toXmlValue(unwrapped, selectVariant(unwrapped, mapping.variants!));
@@ -59,74 +123,167 @@ function toXmlValue(value: unknown, mapping: XmlTypeMapping): unknown {
     }
 }
 
+function scalarText(value: unknown, type: string): string {
+    if (typeof value !== 'string') throw new Error(`Expected scalar XML ${type} value`);
+    return value.trim();
+}
+
 function fromXmlValue(value: unknown, mapping: XmlTypeMapping): unknown {
     if (value === undefined || value === null) return undefined;
     switch (mapping.kind) {
-        case 'number': return Number(value);
-        case 'boolean': return value === true || value === 'true' || value === '1';
-        case 'date': return new Date(String(value));
-        case 'enum': {
-            const wireValue = String(value);
-            const entry = Object.entries(mapping.enumValues ?? {}).find(([, xmlValue]) => xmlValue === wireValue);
-            return entry?.[0] ?? wireValue;
+        case 'string':
+            if (typeof value !== 'string') throw new Error('Expected scalar XML string value');
+            return value;
+        case 'number': {
+            const text = scalarText(value, 'number');
+            if (!/^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/.test(text)) throw new Error(`Invalid XML number: ${text}`);
+            const numberValue = Number(text);
+            if (!Number.isFinite(numberValue)) throw new Error(`Invalid XML number: ${text}`);
+            return numberValue;
         }
-        case 'record': return fromXmlFields(value as Record<string, unknown>, mapping.record!());
-        case 'array': return (Array.isArray(value) ? value : [value]).map((item) => fromXmlValue(item, mapping.item!));
-        case 'set': return new Set((Array.isArray(value) ? value : [value]).map((item) => fromXmlValue(item, mapping.item!)));
-        case 'map': return Object.fromEntries(Object.entries(value as Record<string, unknown>).filter(([key]) => key !== '#text' && key !== '@_xmlns').map(([key, item]) => [key, fromXmlValue(item, mapping.value!)]));
+        case 'boolean': {
+            const text = scalarText(value, 'boolean');
+            if (text === 'true' || text === '1') return true;
+            if (text === 'false' || text === '0') return false;
+            throw new Error(`Invalid XML boolean: ${text}`);
+        }
+        case 'date': {
+            const text = scalarText(value, 'date');
+            const date = new Date(text);
+            if (Number.isNaN(date.getTime())) throw new Error(`Invalid XML date: ${text}`);
+            return date;
+        }
+        case 'enum': {
+            const wireValue = scalarText(value, 'enum');
+            const entry = Object.entries(mapping.enumValues ?? {}).find(([, xmlValue]) => xmlValue === wireValue);
+            if (!entry) throw new Error(`Invalid XML enum value: ${wireValue}`);
+            return entry[0];
+        }
+        case 'record':
+            if (!isObject(value)) throw new Error('Expected XML record element');
+            validateNamespace(value, mapping.record!());
+            return fromXmlFields(value, mapping.record!());
+        case 'array': {
+            if (isEmptyCollection(value)) return [];
+            const values = Array.isArray(value) ? value : [value];
+            return values.map((item) => fromXmlValue(item, mapping.item!));
+        }
+        case 'set': {
+            if (isEmptyCollection(value)) return new Set();
+            const values = Array.isArray(value) ? value : [value];
+            return new Set(values.map((item) => fromXmlValue(item, mapping.item!)));
+        }
+        case 'map': {
+            if (value === '') return {};
+            if (!isObject(value)) throw new Error('Expected XML map element');
+            const text = value['#text'];
+            if (text !== undefined && text !== 0 && String(text).trim() !== '') throw new Error('XML map cannot contain text content');
+            const entries = Object.entries(value).filter(([key]) => key !== '#text' && !key.startsWith('@_xmlns'));
+            return Object.fromEntries(entries.map(([key, item]) => {
+                if (key.startsWith('@_')) throw new Error(`Unexpected XML map attribute: ${key.slice(2)}`);
+                if (Array.isArray(item)) throw new Error(`Duplicate XML map key: ${key}`);
+                return [key, fromXmlValue(item, mapping.value!)];
+            }));
+        }
         case 'union': {
-            const variants = mapping.variants!;
-            const selected = value !== null && typeof value === 'object'
-                ? variants.find((v) => v.kind === 'record' || v.kind === 'map' || v.kind === 'array')
-                : variants.find((v) => v.kind === 'string' || v.kind === 'enum') ?? variants[0];
-            const converted = fromXmlValue(value, selected ?? variants[0]);
-            return mapping.wrap ? mapping.wrap(converted) : converted;
+            const matches: unknown[] = [];
+            for (const variant of mapping.variants ?? []) {
+                try {
+                    matches.push(fromXmlValue(value, variant));
+                } catch {
+                    // A variant that rejects the wire value is not a match.
+                }
+            }
+            if (matches.length !== 1) throw new Error(`XML union value matches ${matches.length} variants; exactly one is required`);
+            return mapping.wrap ? mapping.wrap(matches[0]) : matches[0];
         }
         default: return value;
     }
 }
 
+function acceptsRepeatedValues(mapping: XmlTypeMapping): boolean {
+    return mapping.kind === 'array' || mapping.kind === 'set' ||
+        (mapping.kind === 'union' && (mapping.variants ?? []).some((variant) => acceptsRepeatedValues(variant)));
+}
+
 function toXmlFields<T>(value: T, mapping: XmlRecordMapping<T>): Record<string, unknown> {
     const result: Record<string, unknown> = {};
     for (const field of mapping.fields) {
-        const converted = toXmlValue(value[field.property], field.type);
-        if (converted !== undefined) {
-            result[field.kind === 'attribute' ? '@_' + field.name : field.name] = converted;
+        const fieldValue = value[field.property];
+        if ((fieldValue === undefined || fieldValue === null) && !field.optional) {
+            throw new Error(`Missing required XML field: ${field.name}`);
         }
+        const converted = toXmlValue(fieldValue, field.type);
+        if (converted !== undefined) result[field.kind === 'attribute' ? '@_' + field.name : field.name] = converted;
     }
     return result;
 }
 
 function fromXmlFields<T>(value: Record<string, unknown>, mapping: XmlRecordMapping<T>): T {
     const fields: Record<string, unknown> = {};
+    const expectedKeys = new Map(mapping.fields.map((field) => [field.kind === 'attribute' ? '@_' + field.name : field.name, field]));
+    for (const key of Object.keys(value)) {
+        if (key === '#text' || key.startsWith('@_xmlns')) continue;
+        if (!expectedKeys.has(key)) throw new Error(`Unknown XML field or attribute: ${key.startsWith('@_') ? key.slice(2) : key}`);
+    }
+    const mixedText = value['#text'];
+    if (mixedText !== undefined && mixedText !== 0 && String(mixedText).trim() !== '') throw new Error('Unexpected XML text content in record');
     for (const field of mapping.fields) {
         if (mapping.assignMissing) fields[field.property] = undefined;
         const key = field.kind === 'attribute' ? '@_' + field.name : field.name;
-        if (Object.prototype.hasOwnProperty.call(value, key)) {
-            fields[field.property] = fromXmlValue(value[key], field.type);
-        } else if (!field.optional && field.type.kind === 'array') {
-            fields[field.property] = [];
-        } else if (!field.optional && field.type.kind === 'set') {
-            fields[field.property] = new Set();
-        } else if (!field.optional && field.type.kind === 'map') {
-            fields[field.property] = {};
+        if (!Object.prototype.hasOwnProperty.call(value, key)) {
+            if (!field.optional) throw new Error(`Missing required XML field: ${field.name}`);
+            continue;
         }
+        const rawValue = value[key];
+        if (Array.isArray(rawValue) && !acceptsRepeatedValues(field.type)) throw new Error(`Duplicate singleton XML field: ${field.name}`);
+        fields[field.property] = fromXmlValue(rawValue, field.type);
     }
     return mapping.create(fields);
+}
+
+function validateNamespace<T>(value: Record<string, unknown>, mapping: XmlRecordMapping<T>, prefix = ''): void {
+    if (!mapping.namespace) return;
+    const namespaceKey = prefix ? `@_xmlns:${prefix}` : '@_xmlns';
+    if (value[namespaceKey] !== mapping.namespace) {
+        throw new Error(`XML namespace mismatch for ${mapping.rootName}: expected ${mapping.namespace}`);
+    }
+}
+
+function assertDepth(value: unknown, depth = 0): void {
+    if (depth > MAX_XML_DEPTH) throw new Error(`XML nesting exceeds ${MAX_XML_DEPTH} levels`);
+    if (Array.isArray(value)) {
+        for (const item of value) assertDepth(item, depth);
+    } else if (isObject(value)) {
+        for (const child of Object.values(value)) assertDepth(child, depth + 1);
+    }
+}
+
+function assertSafeXml(xml: string): void {
+    if (xml.length > MAX_XML_SIZE || new TextEncoder().encode(xml).byteLength > MAX_XML_SIZE) {
+        throw new Error(`XML payload exceeds ${MAX_XML_SIZE} bytes`);
+    }
+    if (/<!DOCTYPE|<!ENTITY/i.test(xml)) throw new Error('DOCTYPE and ENTITY declarations are not allowed in XML');
+    const validation = XMLValidator.validate(xml, { allowBooleanAttributes: false });
+    if (validation !== true) {
+        const message = (validation as { err?: { msg?: string } }).err?.msg ?? 'invalid XML';
+        throw new Error(`Malformed XML: ${message}`);
+    }
 }
 
 export function serializeXml<T>(value: T, mapping: XmlRecordMapping<T>): string {
     const body = toXmlFields(value, mapping);
     if (mapping.namespace) body['@_xmlns'] = mapping.namespace;
-    const builder = new XMLBuilder({
-        ignoreAttributes: false,
-        attributeNamePrefix: '@_',
-        suppressEmptyNode: false,
-    });
-    return builder.build({ [mapping.rootName]: body });
+    const builder = new XMLBuilder({ ignoreAttributes: false, attributeNamePrefix: '@_', suppressEmptyNode: false });
+    const xml = builder.build({ [mapping.rootName]: body });
+    if (xml.length > MAX_XML_SIZE || new TextEncoder().encode(xml).byteLength > MAX_XML_SIZE) {
+        throw new Error(`XML payload exceeds ${MAX_XML_SIZE} bytes`);
+    }
+    return xml;
 }
 
 export function deserializeXml<T>(xml: string, mapping: XmlRecordMapping<T>): T {
+    assertSafeXml(xml);
     const parser = new XMLParser({
         ignoreAttributes: false,
         attributeNamePrefix: '@_',
@@ -135,14 +292,23 @@ export function deserializeXml<T>(xml: string, mapping: XmlRecordMapping<T>): T 
         processEntities: false,
         trimValues: false,
     });
-    const document = parser.parse(xml) as Record<string, unknown>;
-    let root = document[mapping.rootName];
+    let document: Record<string, unknown>;
+    try {
+        document = parser.parse(xml) as Record<string, unknown>;
+    } catch (error) {
+        throw new Error(`Malformed XML: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    assertDepth(document);
+    let rootKey = mapping.rootName;
+    let root = document[rootKey];
     if (root === undefined) {
-        const rootKey = Object.keys(document).find((key) => key.split(':').pop() === mapping.rootName);
-        if (rootKey) root = document[rootKey];
+        const match = Object.keys(document).filter((key) => key.split(':').pop() === mapping.rootName);
+        if (match.length !== 1) throw new Error(`Expected exactly one XML root element ${mapping.rootName}`);
+        rootKey = match[0];
+        root = document[rootKey];
     }
-    if (root === undefined || root === null || typeof root !== 'object') {
-        throw new Error(`Expected XML root element ${mapping.rootName}`);
-    }
-    return fromXmlFields(root as Record<string, unknown>, mapping);
+    if (!isObject(root)) throw new Error(`Expected XML root element ${mapping.rootName}`);
+    const prefix = rootKey.includes(':') ? rootKey.split(':', 1)[0] : '';
+    validateNamespace(root, mapping, prefix);
+    return fromXmlFields(root, mapping);
 }

--- a/avrotize/structuretots/xml_runtime.ts.jinja
+++ b/avrotize/structuretots/xml_runtime.ts.jinja
@@ -1,0 +1,148 @@
+import { XMLBuilder, XMLParser } from 'fast-xml-parser';
+
+export type XmlValueKind = 'string' | 'number' | 'boolean' | 'date' | 'enum' | 'record' | 'array' | 'set' | 'map' | 'union' | 'any';
+
+export interface XmlTypeMapping {
+    readonly kind: XmlValueKind;
+    readonly item?: XmlTypeMapping;
+    readonly value?: XmlTypeMapping;
+    readonly variants?: readonly XmlTypeMapping[];
+    readonly enumValues?: Readonly<Record<string, string>>;
+    readonly record?: () => XmlRecordMapping<any>;
+    readonly unwrap?: (value: unknown) => unknown;
+    readonly wrap?: (value: unknown) => unknown;
+}
+
+export interface XmlFieldMapping<T> {
+    readonly property: keyof T & string;
+    readonly name: string;
+    readonly kind: 'element' | 'attribute';
+    readonly optional?: boolean;
+    readonly type: XmlTypeMapping;
+}
+
+export interface XmlRecordMapping<T = unknown> {
+    readonly rootName: string;
+    readonly namespace?: string;
+    readonly fields: readonly XmlFieldMapping<T>[];
+    readonly assignMissing?: boolean;
+    readonly create: (values: Record<string, unknown>) => T;
+}
+
+function selectVariant(value: unknown, variants: readonly XmlTypeMapping[]): XmlTypeMapping {
+    if (Array.isArray(value)) return variants.find((v) => v.kind === 'array') ?? variants[0];
+    if (value instanceof Set) return variants.find((v) => v.kind === 'set') ?? variants[0];
+    if (value instanceof Date) return variants.find((v) => v.kind === 'date') ?? variants[0];
+    if (value !== null && typeof value === 'object') return variants.find((v) => v.kind === 'record' || v.kind === 'map') ?? variants[0];
+    return variants.find((v) => v.kind === typeof value) ?? variants.find((v) => v.kind === 'enum' && typeof value === 'string') ?? variants[0];
+}
+
+function toXmlValue(value: unknown, mapping: XmlTypeMapping): unknown {
+    if (value === undefined || value === null) return undefined;
+    switch (mapping.kind) {
+        case 'date': return value instanceof Date ? value.toISOString() : String(value);
+        case 'enum': return mapping.enumValues?.[String(value)] ?? String(value);
+        case 'record': {
+            const recordMapping = mapping.record!();
+            const fields = toXmlFields(value as Record<string, unknown>, recordMapping);
+            if (recordMapping.namespace) fields['@_xmlns'] = recordMapping.namespace;
+            return fields;
+        }
+        case 'array': return (value as unknown[]).map((item) => toXmlValue(item, mapping.item!));
+        case 'set': return Array.from(value as Set<unknown>, (item) => toXmlValue(item, mapping.item!));
+        case 'map': return Object.fromEntries(Object.entries(value as Record<string, unknown>).map(([key, item]) => [key, toXmlValue(item, mapping.value!)]));
+        case 'union': {
+            const unwrapped = mapping.unwrap ? mapping.unwrap(value) : value;
+            return toXmlValue(unwrapped, selectVariant(unwrapped, mapping.variants!));
+        }
+        default: return value;
+    }
+}
+
+function fromXmlValue(value: unknown, mapping: XmlTypeMapping): unknown {
+    if (value === undefined || value === null) return undefined;
+    switch (mapping.kind) {
+        case 'number': return Number(value);
+        case 'boolean': return value === true || value === 'true' || value === '1';
+        case 'date': return new Date(String(value));
+        case 'enum': {
+            const wireValue = String(value);
+            const entry = Object.entries(mapping.enumValues ?? {}).find(([, xmlValue]) => xmlValue === wireValue);
+            return entry?.[0] ?? wireValue;
+        }
+        case 'record': return fromXmlFields(value as Record<string, unknown>, mapping.record!());
+        case 'array': return (Array.isArray(value) ? value : [value]).map((item) => fromXmlValue(item, mapping.item!));
+        case 'set': return new Set((Array.isArray(value) ? value : [value]).map((item) => fromXmlValue(item, mapping.item!)));
+        case 'map': return Object.fromEntries(Object.entries(value as Record<string, unknown>).filter(([key]) => key !== '#text' && key !== '@_xmlns').map(([key, item]) => [key, fromXmlValue(item, mapping.value!)]));
+        case 'union': {
+            const variants = mapping.variants!;
+            const selected = value !== null && typeof value === 'object'
+                ? variants.find((v) => v.kind === 'record' || v.kind === 'map' || v.kind === 'array')
+                : variants.find((v) => v.kind === 'string' || v.kind === 'enum') ?? variants[0];
+            const converted = fromXmlValue(value, selected ?? variants[0]);
+            return mapping.wrap ? mapping.wrap(converted) : converted;
+        }
+        default: return value;
+    }
+}
+
+function toXmlFields<T>(value: T, mapping: XmlRecordMapping<T>): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+    for (const field of mapping.fields) {
+        const converted = toXmlValue(value[field.property], field.type);
+        if (converted !== undefined) {
+            result[field.kind === 'attribute' ? '@_' + field.name : field.name] = converted;
+        }
+    }
+    return result;
+}
+
+function fromXmlFields<T>(value: Record<string, unknown>, mapping: XmlRecordMapping<T>): T {
+    const fields: Record<string, unknown> = {};
+    for (const field of mapping.fields) {
+        if (mapping.assignMissing) fields[field.property] = undefined;
+        const key = field.kind === 'attribute' ? '@_' + field.name : field.name;
+        if (Object.prototype.hasOwnProperty.call(value, key)) {
+            fields[field.property] = fromXmlValue(value[key], field.type);
+        } else if (!field.optional && field.type.kind === 'array') {
+            fields[field.property] = [];
+        } else if (!field.optional && field.type.kind === 'set') {
+            fields[field.property] = new Set();
+        } else if (!field.optional && field.type.kind === 'map') {
+            fields[field.property] = {};
+        }
+    }
+    return mapping.create(fields);
+}
+
+export function serializeXml<T>(value: T, mapping: XmlRecordMapping<T>): string {
+    const body = toXmlFields(value, mapping);
+    if (mapping.namespace) body['@_xmlns'] = mapping.namespace;
+    const builder = new XMLBuilder({
+        ignoreAttributes: false,
+        attributeNamePrefix: '@_',
+        suppressEmptyNode: false,
+    });
+    return builder.build({ [mapping.rootName]: body });
+}
+
+export function deserializeXml<T>(xml: string, mapping: XmlRecordMapping<T>): T {
+    const parser = new XMLParser({
+        ignoreAttributes: false,
+        attributeNamePrefix: '@_',
+        parseAttributeValue: false,
+        parseTagValue: false,
+        processEntities: false,
+        trimValues: false,
+    });
+    const document = parser.parse(xml) as Record<string, unknown>;
+    let root = document[mapping.rootName];
+    if (root === undefined) {
+        const rootKey = Object.keys(document).find((key) => key.split(':').pop() === mapping.rootName);
+        if (rootKey) root = document[rootKey];
+    }
+    if (root === undefined || root === null || typeof root !== 'object') {
+        throw new Error(`Expected XML root element ${mapping.rootName}`);
+    }
+    return fromXmlFields(root as Record<string, unknown>, mapping);
+}

--- a/test/test_typescript_xml.py
+++ b/test/test_typescript_xml.py
@@ -1,0 +1,136 @@
+'Focused generation and runtime tests for TypeScript XML support.'
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+
+import pytest
+
+from avrotize.avrotots import convert_avro_schema_to_typescript
+from avrotize.structuretots import convert_structure_schema_to_typescript
+
+
+AVRO_SCHEMA = {
+    "type": "record", "name": "Order", "namespace": "example", "xmlns": "urn:orders",
+    "altnames": {"xml": "purchase"},
+    "fields": [
+        {"name": "id", "type": "string", "xmlkind": "attribute", "altnames": {"xml": "order-id"}},
+        {"name": "count", "type": "int"},
+        {"name": "note", "type": ["null", "string"]},
+        {"name": "child", "type": {"type": "record", "name": "Child", "fields": [
+            {"name": "active", "type": "boolean"}
+        ]}},
+        {"name": "tags", "type": {"type": "array", "items": "string"}},
+        {"name": "state", "type": {"type": "enum", "name": "State", "symbols": ["OPEN", "CLOSED"],
+                                            "altenums": {"xml": {"OPEN": "open-order"}}}},
+        {"name": "scores", "type": {"type": "map", "values": "double"}},
+        {"name": "choice", "type": ["string", {"type": "record", "name": "ChoiceDetail", "fields": [
+            {"name": "code", "type": "int"}
+        ]}]},
+    ],
+}
+
+STRUCTURE_SCHEMA = {
+    "type": "object", "name": "Order", "namespace": "example", "xmlns": "urn:orders",
+    "altnames": {"xml": "purchase"},
+    "properties": {
+        "id": {"type": "string", "xmlkind": "attribute", "altnames": {"xml": "order-id"}},
+        "count": {"type": "int32"},
+        "note": {"type": ["string", "null"]},
+        "child": {"type": "object", "name": "Child", "properties": {"active": {"type": "boolean"}},
+                  "required": ["active"]},
+        "tags": {"type": "array", "items": {"type": "string"}},
+        "state": {"type": "string", "name": "State", "enum": ["OPEN", "CLOSED"],
+                  "altenums": {"json": {"OPEN": "open"}, "xml": {"OPEN": "open-order"}}},
+        "scores": {"type": "map", "values": {"type": "double"}},
+    },
+    "required": ["id", "count", "child", "tags", "state", "scores"],
+}
+
+
+def _run(command, cwd):
+    return subprocess.run(command, cwd=cwd, capture_output=True, text=True,
+                          shell=os.name == "nt", timeout=300)
+
+
+def _build_and_run(output_dir, script):
+    install = _run(["npm", "install", "--ignore-scripts"], output_dir)
+    assert install.returncode == 0, install.stderr
+    build = _run(["npm", "run", "build"], output_dir)
+    assert build.returncode == 0, build.stderr
+    script_path = os.path.join(output_dir, "xml-runtime.mjs")
+    with open(script_path, "w", encoding="utf-8") as handle:
+        handle.write(script)
+    runtime = _run(["node", "xml-runtime.mjs"], output_dir)
+    assert runtime.returncode == 0, runtime.stderr
+
+
+def test_avrotots_xml_generation_and_runtime():
+    if not shutil.which("npm") or not shutil.which("node"):
+        pytest.skip("Node.js toolchain is unavailable")
+    output = os.path.join(tempfile.gettempdir(), "avrotize", "avrotots-xml")
+    shutil.rmtree(output, ignore_errors=True)
+    convert_avro_schema_to_typescript(AVRO_SCHEMA, output, "xmltypes", xml_annotation=True)
+
+    source = os.path.join(output, "src", "xmltypes", "example", "Order.ts")
+    with open(source, encoding="utf-8") as handle:
+        generated = handle.read()
+    with open(os.path.join(output, "package.json"), encoding="utf-8") as handle:
+        package = json.load(handle)
+    assert 'rootName: "purchase"' in generated
+    assert 'name: "order-id", kind: \'attribute\'' in generated
+    assert "application/xml" in generated and "text/xml" in generated
+    assert package["dependencies"]["fast-xml-parser"]
+
+    _build_and_run(output, r'''
+import assert from "node:assert/strict";
+import { Order } from "./dist/xmltypes/example/Order.js";
+import { Child } from "./dist/xmltypes/example/Child.js";
+import { State } from "./dist/xmltypes/example/State.js";
+import { ChoiceDetail } from "./dist/xmltypes/example/ChoiceDetail.js";
+import { ChoiceUnion } from "./dist/xmltypes/example/ChoiceUnion.js";
+const value = new Order("A-1", 3, undefined, new Child(true), ["one", "two"], State.OPEN,
+    {speed: 42.5}, new ChoiceUnion(new ChoiceDetail(9)));
+const bytes = value.toByteArray("application/xml");
+const xml = new TextDecoder().decode(bytes);
+assert.match(xml, /<purchase[^>]*xmlns="urn:orders"[^>]*>/);
+assert.match(xml, /<purchase[^>]*order-id="A-1"[^>]*>/);
+assert.match(xml, /<state>open-order<\/state>/);
+assert.deepStrictEqual(Order.fromData(bytes, "text/xml"), value);
+const gzip = value.toByteArray("application/xml+gzip");
+assert.deepStrictEqual(Order.fromData(gzip, "application/xml+gzip"), value);
+''')
+
+
+def test_structuretots_xml_generation_and_runtime():
+    if not shutil.which("npm") or not shutil.which("node"):
+        pytest.skip("Node.js toolchain is unavailable")
+    output = os.path.join(tempfile.gettempdir(), "avrotize", "structuretots-xml")
+    shutil.rmtree(output, ignore_errors=True)
+    convert_structure_schema_to_typescript(STRUCTURE_SCHEMA, output, "xmltypes", xml_annotation=True)
+
+    source = os.path.join(output, "src", "xmltypes", "example", "Order.ts")
+    with open(source, encoding="utf-8") as handle:
+        generated = handle.read()
+    with open(os.path.join(output, "package.json"), encoding="utf-8") as handle:
+        package = json.load(handle)
+    assert 'namespace: "urn:orders"' in generated
+    assert "XmlRecordMapping<Order>" in generated
+    assert package["dependencies"]["fast-xml-parser"]
+
+    _build_and_run(output, r'''
+import assert from "node:assert/strict";
+import { Order } from "./dist/xmltypes/example/Order.js";
+import { Child } from "./dist/xmltypes/example/Child.js";
+import { State } from "./dist/xmltypes/example/State.js";
+const value = new Order("S-1", 5, new Child(false), ["one", "two"], State.OPEN, {speed: 7.5});
+const bytes = value.toByteArray("application/xml");
+const xml = new TextDecoder().decode(bytes);
+assert.match(xml, /<purchase[^>]*xmlns="urn:orders"[^>]*>/);
+assert.match(xml, /<state>open-order<\/state>/);
+assert.deepStrictEqual(Order.fromData(bytes, "text/xml"), value);
+const gzip = value.toByteArray("text/xml+gzip");
+assert.deepStrictEqual(Order.fromData(gzip, "text/xml+gzip"), value);
+''')

--- a/test/test_typescript_xml.py
+++ b/test/test_typescript_xml.py
@@ -29,6 +29,8 @@ AVRO_SCHEMA = {
         {"name": "choice", "type": ["string", {"type": "record", "name": "ChoiceDetail", "fields": [
             {"name": "code", "type": "int"}
         ]}]},
+        {"name": "ambiguous", "type": ["string", "int"]},
+        {"name": "stringOrList", "type": ["string", {"type": "array", "items": "string"}]},
     ],
 }
 
@@ -45,8 +47,10 @@ STRUCTURE_SCHEMA = {
         "state": {"type": "string", "name": "State", "enum": ["OPEN", "CLOSED"],
                   "altenums": {"json": {"OPEN": "open"}, "xml": {"OPEN": "open-order"}}},
         "scores": {"type": "map", "values": {"type": "double"}},
+        "ambiguous": {"type": ["string", "int32"]},
+        "stringOrList": {"type": ["string", {"type": "array", "items": {"type": "string"}}]},
     },
-    "required": ["id", "count", "child", "tags", "state", "scores"],
+    "required": ["id", "count", "child", "tags", "state", "scores", "ambiguous", "stringOrList"],
 }
 
 
@@ -92,7 +96,7 @@ import { State } from "./dist/xmltypes/example/State.js";
 import { ChoiceDetail } from "./dist/xmltypes/example/ChoiceDetail.js";
 import { ChoiceUnion } from "./dist/xmltypes/example/ChoiceUnion.js";
 const value = new Order("A-1", 3, undefined, new Child(true), ["one", "two"], State.OPEN,
-    {speed: 42.5}, new ChoiceUnion(new ChoiceDetail(9)));
+    {speed: 42.5}, new ChoiceUnion(new ChoiceDetail(9)), "plain", ["left", "right"]);
 const bytes = value.toByteArray("application/xml");
 const xml = new TextDecoder().decode(bytes);
 assert.match(xml, /<purchase[^>]*xmlns="urn:orders"[^>]*>/);
@@ -101,6 +105,35 @@ assert.match(xml, /<state>open-order<\/state>/);
 assert.deepStrictEqual(Order.fromData(bytes, "text/xml"), value);
 const gzip = value.toByteArray("application/xml+gzip");
 assert.deepStrictEqual(Order.fromData(gzip, "application/xml+gzip"), value);
+
+const encode = (text) => new TextEncoder().encode(text);
+const rejectXml = (text, pattern) => assert.throws(() => Order.fromData(encode(text), "application/xml"), pattern);
+const validXml = '<purchase order-id="A-1" xmlns="urn:orders"><count>3</count><child><active>true</active></child>' +
+    '<tags>solo</tags><state>open-order</state><scores><speed>1.5</speed></scores>' +
+    '<choice><code>9</code></choice><ambiguous>plain</ambiguous>' +
+    '<stringOrList>left</stringOrList><stringOrList>right</stringOrList></purchase>';
+const parsedSingletonList = Order.fromData(encode(validXml), "application/xml");
+assert.deepStrictEqual(parsedSingletonList.tags, ["solo"]);
+assert.deepStrictEqual(parsedSingletonList.stringOrList, ["left", "right"]);
+
+rejectXml(validXml.slice(0, -5), /Malformed XML/);                                      // truncated
+rejectXml(validXml.replace('<count>3</count>', '<count>3</counts>'), /Malformed XML/);         // malformed
+assert.throws(() => Order.fromData(new Uint8Array([1, 2, 3]), "application/xml+gzip"), /Invalid gzip data/);
+rejectXml('<!DOCTYPE purchase [<!ENTITY x "boom">]>' + validXml, /DOCTYPE and ENTITY/);
+rejectXml(validXml.replace('urn:orders', 'urn:wrong'), /namespace mismatch/);
+rejectXml(validXml.replace(' order-id="A-1"', ''), /Missing required XML field: order-id/);
+rejectXml(validXml.replace('<count>3</count>', '<count>3</count><count>4</count>'), /Duplicate singleton/);
+rejectXml(validXml.replace('</purchase>', '<unknown>value</unknown></purchase>'), /Unknown XML field/);
+rejectXml(validXml.replace('open-order', 'INVALID'), /Invalid XML enum/);
+rejectXml(validXml.replace('<count>3</count>', '<count>NaN</count>'), /Invalid XML number/);
+const nested = '<deep>' + '<x>'.repeat(70) + 'v' + '</x>'.repeat(70) + '</deep>';
+rejectXml(validXml.replace('</purchase>', nested + '</purchase>'), /nesting exceeds/);
+rejectXml(validXml.replace('</purchase>', '<note>' + 'x'.repeat(1024 * 1024) + '</note></purchase>'), /payload exceeds/);
+rejectXml(validXml.replace('<ambiguous>plain</ambiguous>', '<ambiguous>1</ambiguous>'), /union value matches 2 variants/);
+rejectXml(validXml.replace('<scores><speed>1.5</speed></scores>', '<scores>bad</scores>'), /Expected XML map/);
+rejectXml(validXml.replace('<speed>1.5</speed>', '<speed>1.5</speed><speed>2</speed>'), /Duplicate XML map key/);
+rejectXml(validXml.replace('<stringOrList>left</stringOrList><stringOrList>right</stringOrList>',
+    '<stringOrList>left</stringOrList>'), /union value matches 2 variants/);
 ''')
 
 
@@ -125,7 +158,8 @@ import assert from "node:assert/strict";
 import { Order } from "./dist/xmltypes/example/Order.js";
 import { Child } from "./dist/xmltypes/example/Child.js";
 import { State } from "./dist/xmltypes/example/State.js";
-const value = new Order("S-1", 5, new Child(false), ["one", "two"], State.OPEN, {speed: 7.5});
+const value = new Order("S-1", 5, new Child(false), ["one", "two"], State.OPEN, {speed: 7.5},
+    "plain", ["left", "right"]);
 const bytes = value.toByteArray("application/xml");
 const xml = new TextDecoder().decode(bytes);
 assert.match(xml, /<purchase[^>]*xmlns="urn:orders"[^>]*>/);
@@ -133,4 +167,32 @@ assert.match(xml, /<state>open-order<\/state>/);
 assert.deepStrictEqual(Order.fromData(bytes, "text/xml"), value);
 const gzip = value.toByteArray("text/xml+gzip");
 assert.deepStrictEqual(Order.fromData(gzip, "text/xml+gzip"), value);
+
+const encode = (text) => new TextEncoder().encode(text);
+const rejectXml = (text, pattern) => assert.throws(() => Order.fromData(encode(text), "application/xml"), pattern);
+const validXml = '<purchase order-id="S-1" xmlns="urn:orders"><count>5</count><child><active>false</active></child>' +
+    '<tags>solo</tags><state>open-order</state><scores><speed>1.5</speed></scores>' +
+    '<ambiguous>plain</ambiguous><stringOrList>left</stringOrList><stringOrList>right</stringOrList></purchase>';
+const parsedSingletonList = Order.fromData(encode(validXml), "application/xml");
+assert.deepStrictEqual(parsedSingletonList.tags, ["solo"]);
+assert.deepStrictEqual(parsedSingletonList.stringOrList, ["left", "right"]);
+
+rejectXml(validXml.slice(0, -5), /Malformed XML/);
+rejectXml(validXml.replace('<count>5</count>', '<count>5</counts>'), /Malformed XML/);
+assert.throws(() => Order.fromData(new Uint8Array([1, 2, 3]), "text/xml+gzip"), /Invalid gzip data/);
+rejectXml('<!DOCTYPE purchase [<!ENTITY x "boom">]>' + validXml, /DOCTYPE and ENTITY/);
+rejectXml(validXml.replace('urn:orders', 'urn:wrong'), /namespace mismatch/);
+rejectXml(validXml.replace(' order-id="S-1"', ''), /Missing required XML field: order-id/);
+rejectXml(validXml.replace('<count>5</count>', '<count>5</count><count>6</count>'), /Duplicate singleton/);
+rejectXml(validXml.replace('</purchase>', '<unknown>value</unknown></purchase>'), /Unknown XML field/);
+rejectXml(validXml.replace('open-order', 'INVALID'), /Invalid XML enum/);
+rejectXml(validXml.replace('<count>5</count>', '<count>NaN</count>'), /Invalid XML number/);
+const nested = '<deep>' + '<x>'.repeat(70) + 'v' + '</x>'.repeat(70) + '</deep>';
+rejectXml(validXml.replace('</purchase>', nested + '</purchase>'), /nesting exceeds/);
+rejectXml(validXml.replace('</purchase>', '<note>' + 'x'.repeat(1024 * 1024) + '</note></purchase>'), /payload exceeds/);
+rejectXml(validXml.replace('<ambiguous>plain</ambiguous>', '<ambiguous>1</ambiguous>'), /union value matches 2 variants/);
+rejectXml(validXml.replace('<scores><speed>1.5</speed></scores>', '<scores>bad</scores>'), /Expected XML map/);
+rejectXml(validXml.replace('<speed>1.5</speed>', '<speed>1.5</speed><speed>2</speed>'), /Duplicate XML map key/);
+rejectXml(validXml.replace('<stringOrList>left</stringOrList><stringOrList>right</stringOrList>',
+    '<stringOrList>left</stringOrList>'), /union value matches 2 variants/);
 ''')


### PR DESCRIPTION
Closes #411

Adds typed fast-xml-parser mapping and shared runtime support to both TypeScript generators. Includes namespaces, attributes/elements, collections, maps/unions, XML media types, gzip, and bounded strict adversarial validation.