### PR TITLE
Fix Rust Avro annotations for enums and unions

### DIFF
--- a/avrotize/avrotorust.py
+++ b/avrotize/avrotorust.py
@@ -31,6 +31,7 @@ class AvroToRust:
         self.avro_short_names: Dict[str, List[str]] = {}
         self.avro_type_fullnames: Dict[int, str] = {}
         self.union_path_identities: Dict[str, str] = {}
+        self.union_alias_candidates: Dict[tuple[str, str], List[str]] = {}
         self.avro_annotation = False
         self.serde_annotation = False
         self.xml_annotation = False
@@ -114,6 +115,11 @@ class AvroToRust:
             else:
                 named_type = self.resolve_avro_named_type(avro_type, namespace)
                 if named_type and named_type.get('type') in ('record', 'enum', 'fixed'):
+                    if named_type.get('type') == 'fixed':
+                        if named_type.get('logicalType') == 'decimal':
+                            return 'f64'
+                        if 'logicalType' not in named_type:
+                            return 'Vec<u8>'
                     named_fullname = self.avro_type_fullnames[id(named_type)]
                     named_namespace = named_fullname.rpartition('.')[0]
                     rust_namespace = named_namespace.replace('.', '::').lower()
@@ -152,8 +158,6 @@ class AvroToRust:
                     namespace,
                     path=path,
                 )
-                if self.avro_annotation and 'null' in avro_type:
-                    type_name = f'Option<{type_name}>'
         elif isinstance(avro_type, dict):
             if avro_type['type'] in ['record', 'enum']:
                 type_name = self.generate_class_or_enum(
@@ -161,8 +165,13 @@ class AvroToRust:
                     namespace,
                     path=path,
                 )
-            elif avro_type['type'] == 'fixed' or avro_type['type'] == 'bytes' and 'logicalType' in avro_type:
-                if avro_type['logicalType'] == 'decimal':
+            elif avro_type['type'] == 'fixed':
+                if avro_type.get('logicalType') == 'decimal':
+                    return 'f64'
+                if 'logicalType' not in avro_type:
+                    return 'Vec<u8>'
+            elif avro_type['type'] == 'bytes' and 'logicalType' in avro_type:
+                if avro_type.get('logicalType') == 'decimal':
                     return 'f64'
             elif avro_type['type'] == 'array':
                 item_type = self.convert_avro_type_to_rust(
@@ -211,7 +220,6 @@ class AvroToRust:
             avro_schema['name'],
             avro_schema.get('namespace', parent_namespace),
         )
-        namespace = namespace.lower()
         type_path = path or [('record', fullname)]
         if avro_schema['type'] == 'record':
             return self.generate_struct(avro_schema, namespace, type_path)
@@ -236,9 +244,6 @@ class AvroToRust:
         contextual_name = f'{namespace}.{name}' if namespace else name
         if contextual_name in self.avro_named_types:
             return self.avro_named_types[contextual_name]
-        candidates = self.avro_short_names.get(name, [])
-        if len(candidates) == 1:
-            return self.avro_named_types[candidates[0]]
         return None
 
     def union_name_from_path(self, path) -> str:
@@ -613,7 +618,11 @@ class AvroToRust:
                 'type': field_type,
                 'serde_rename': serde_rename,
                 'is_optional': field_type.startswith('Option<'),
-                'random_value': self.generate_random_value(field_type),
+                'random_value': self.generate_random_value_for_avro(
+                    field_type,
+                    field['type'],
+                    parent_namespace,
+                ),
                 'is_generated_type': is_generated_type,
                 'is_avro_union': bool(avro_union_fields),
                 'avro_union_type': base_field_type,
@@ -726,15 +735,9 @@ class AvroToRust:
                 )
                 values = []
                 union_fields = self.generated_union_fields.get(union_type, [])
-                union_avro_types = [
-                    item for item in avro_type if item != 'null'
-                ]
-                for field, branch_type in zip(
-                    union_fields,
-                    union_avro_types,
-                ):
+                for field in union_fields:
                     branch_values = self.generate_avro_test_values(
-                        branch_type,
+                        field['avro_type'],
                         field['type'],
                         namespace,
                     ) or [field['random_value']]
@@ -742,10 +745,6 @@ class AvroToRust:
                         f'{union_type}::{field["name"]}({value})'
                         for value in branch_values
                     )
-                if rust_type.startswith('Option<'):
-                    values = [f'Some({value})' for value in values]
-                    if 'null' in avro_type:
-                        values.insert(0, 'None')
                 return values
             if len(non_null_types) == 1 and rust_type.startswith('Option<'):
                 inner_type = rust_type[7:-1]
@@ -826,38 +825,16 @@ class AvroToRust:
                     if rust_type.startswith('Option<') else rust_type
                 )
                 union_fields = self.generated_union_fields.get(union_type, [])
-                branch_types = [item for item in avro_type if item != 'null']
                 arms = []
-                for union_field, branch_type in zip(
-                    union_fields,
-                    branch_types,
-                ):
-                    inner_encode = self.render_avro_encode_value(
-                        branch_type,
-                        union_field['type'],
-                        namespace,
-                        'value',
-                        counter,
-                    )
+                for union_field in union_fields:
                     arms.append(
                         f'''{union_type}::{union_field["name"]}(value) =>
                             apache_avro::types::Value::Union(
                                 {union_field["source_avro_index"]},
-                                Box::new({inner_encode}),
+                                Box::new({union_field["avro_encode"]}),
                             )'''
                     )
                 arms_text = ',\n'.join(arms)
-                if rust_type.startswith('Option<'):
-                    null_index = avro_type.index('null')
-                    return f'''match {value_expression} {{
-                        None => apache_avro::types::Value::Union(
-                            {null_index},
-                            Box::new(apache_avro::types::Value::Null),
-                        ),
-                        Some(value) => match value {{
-                            {arms_text},
-                        }},
-                    }}'''
                 return f'''match {value_expression} {{
                     {arms_text},
                 }}'''
@@ -911,10 +888,16 @@ class AvroToRust:
                     'apache_avro::types::Value::Bytes('
                     f'({value_expression}).clone())'
                 )
-            if node_type == 'fixed':
+            if node_type == 'fixed' and 'logicalType' not in resolved_type:
                 return (
-                    'apache_avro::types::Value::Fixed('
-                    f'{resolved_type["size"]}, ({value_expression}).clone())'
+                    '{\n'
+                    f'    let bytes = ({value_expression}).clone();\n'
+                    f'    if bytes.len() != {resolved_type["size"]} {{\n'
+                    '        return Err("invalid Avro fixed size".into());\n'
+                    '    }\n'
+                    '    apache_avro::types::Value::Fixed('
+                    f'{resolved_type["size"]}, bytes)\n'
+                    '}'
                 )
             if node_type == 'record':
                 return f'({value_expression}).to_avro_value()?'
@@ -1085,9 +1068,12 @@ class AvroToRust:
                     apache_avro::types::Value::Bytes(bytes) => bytes.clone(),
                     _ => return Err("expected an Avro bytes value".into()),
                 }}'''
-            if node_type == 'fixed':
+            if node_type == 'fixed' and 'logicalType' not in resolved_type:
                 return f'''match {value_expression} {{
-                    apache_avro::types::Value::Fixed(_, bytes) => bytes.clone(),
+                    apache_avro::types::Value::Fixed(size, bytes)
+                        if *size == {resolved_type["size"]}
+                            && bytes.len() == {resolved_type["size"]} =>
+                        bytes.clone(),
                     _ => return Err("expected an Avro fixed value".into()),
                 }}'''
             if node_type == 'record':
@@ -1249,17 +1235,21 @@ class AvroToRust:
         union_avro_branches = [
             (source_index, avro_branch)
             for source_index, avro_branch in enumerate(avro_type)
-            if avro_branch != 'null'
+            if self.avro_annotation or avro_branch != 'null'
         ]
         union_avro_types = [
             avro_branch for _, avro_branch in union_avro_branches
         ]
         union_types = [
-            self.convert_avro_type_to_rust(
-                field_name + "Option" + str(i),
-                avro_branch,
-                namespace,
-                path=(path or []) + [('branch', str(source_index))],
+            (
+                '()'
+                if avro_branch == 'null'
+                else self.convert_avro_type_to_rust(
+                    field_name + "Option" + str(i),
+                    avro_branch,
+                    namespace,
+                    path=(path or []) + [('branch', str(source_index))],
+                )
             )
             for i, (source_index, avro_branch) in enumerate(union_avro_branches)
         ]
@@ -1278,7 +1268,16 @@ class AvroToRust:
         seen_names: dict = {}
         union_fields = []
         for i, t in enumerate(union_types):
-            predicate = self.get_is_json_match_clause(field_name, t, for_union=True)
+            is_null = union_avro_types[i] == 'null'
+            predicate = (
+                'node.is_null()'
+                if is_null
+                else self.get_is_json_match_clause(
+                    field_name,
+                    t,
+                    for_union=True,
+                )
+            )
             predicate_key = self.get_json_shape_signature(
                 union_avro_types[i],
                 namespace,
@@ -1288,7 +1287,7 @@ class AvroToRust:
             seen_predicates.add(predicate_key)
             
             # Deduplicate variant names
-            variant_name = pascal(t.rsplit('::',1)[-1])
+            variant_name = 'Null' if is_null else pascal(t.rsplit('::',1)[-1])
             if variant_name in seen_names:
                 seen_names[variant_name] += 1
                 variant_name = f"{variant_name}{seen_names[variant_name]}"
@@ -1298,23 +1297,41 @@ class AvroToRust:
             union_fields.append({
                 'name': variant_name, 
                 'type': t, 
+                'avro_type': union_avro_types[i],
+                'is_null': is_null,
                 'avro_index': i,
                 'source_avro_index': union_avro_branches[i][0],
-                'avro_decode': self.render_avro_decode_value(
-                    union_avro_types[i],
-                    t,
-                    namespace,
-                    'value',
-                    [0],
+                'avro_decode': (
+                    '()'
+                    if is_null
+                    else self.render_avro_decode_value(
+                        union_avro_types[i],
+                        t,
+                        namespace,
+                        'value',
+                        [0],
+                    )
                 ),
-                'avro_encode': self.render_avro_encode_value(
-                    union_avro_types[i],
-                    t,
-                    namespace,
-                    'value',
-                    [0],
+                'avro_encode': (
+                    'apache_avro::types::Value::Null'
+                    if is_null
+                    else self.render_avro_encode_value(
+                        union_avro_types[i],
+                        t,
+                        namespace,
+                        'value',
+                        [0],
+                    )
                 ),
-                'random_value': self.generate_random_value(t),
+                'random_value': (
+                    '()'
+                    if is_null
+                    else self.generate_random_value_for_avro(
+                        t,
+                        union_avro_types[i],
+                        namespace,
+                    )
+                ),
                 'default_value': 'Default::default()',
                 'json_match_predicate': predicate,
                 'is_first_with_predicate': is_first_with_predicate,
@@ -1349,15 +1366,31 @@ class AvroToRust:
         }
         
         qualified_union_enum_name = self.safe_package(self.concat_package(ns, union_enum_name))
+        if self.avro_annotation:
+            legacy_name = pascal(field_name) + 'Union'
+            self.union_alias_candidates.setdefault(
+                (namespace, legacy_name),
+                [],
+            ).append(qualified_union_enum_name)
         context = {
             'serde_annotation': self.serde_annotation,
             'avro_annotation': self.avro_annotation,
             'xml_annotation': self.xml_annotation,
             'union_enum_name': union_enum_name,
             'union_fields': union_fields,
+            'default_union_field': next(
+                (
+                    field for field in union_fields
+                    if field['is_null']
+                ),
+                union_fields[0],
+            ),
             'xml_string_guards': xml_string_guards,
             'avro_schema': avro_schema_str,
-            'json_match_predicates': [self.get_is_json_match_clause(f['name'], f['type'], for_union=True) for f in union_fields]
+            'json_match_predicates': [
+                field['json_match_predicate']
+                for field in union_fields
+            ],
         }
 
         file_name = self.to_file_name(qualified_union_enum_name)
@@ -1369,6 +1402,43 @@ class AvroToRust:
         self.write_mod_rs(namespace)
 
         return qualified_union_enum_name
+
+    def write_union_aliases(self):
+        """Emits legacy Avro union names when they are unambiguous."""
+        for (namespace, legacy_name), targets in sorted(
+            self.union_alias_candidates.items()
+        ):
+            unique_targets = sorted(set(targets))
+            if len(unique_targets) != 1:
+                continue
+            ns = namespace.replace('.', '::').lower()
+            qualified_alias = self.safe_package(
+                self.concat_package(ns, legacy_name)
+            )
+            if qualified_alias in self.generated_types_rust_package:
+                continue
+            target_file = os.path.join(
+                self.output_dir,
+                'src',
+                self.to_file_name(qualified_alias) + '.rs',
+            ).lower()
+            module_directory = os.path.splitext(target_file)[0]
+            if os.path.exists(target_file) or os.path.isdir(module_directory):
+                continue
+            os.makedirs(os.path.dirname(target_file), exist_ok=True)
+            with open(target_file, 'w', encoding='utf-8') as alias_file:
+                alias_file.write(
+                    f'pub type {legacy_name} = {unique_targets[0]};\n\n'
+                    '#[cfg(test)]\n'
+                    'mod tests {\n'
+                    '    use super::*;\n\n'
+                    '    #[test]\n'
+                    '    fn legacy_alias_compiles() {\n'
+                    f'        let _ = {legacy_name}::default();\n'
+                    '    }\n'
+                    '}\n'
+                )
+            self.write_mod_rs(namespace)
 
     def get_json_shape_signature(
         self,
@@ -1463,6 +1533,63 @@ class AvroToRust:
             qualified_name = qualified_name[(len('crate::')):]
         qualified_name = qualified_name.replace('r#', '')
         return qualified_name.rsplit('::',1)[0].replace('::', os.sep).lower()
+
+    def generate_random_value_for_avro(
+        self,
+        rust_type: str,
+        avro_type,
+        namespace: str,
+    ) -> str:
+        """Generates a random value that respects schema-specific sizes."""
+        resolved_type = avro_type
+        if isinstance(avro_type, str):
+            resolved_type = (
+                self.resolve_avro_named_type(avro_type, namespace)
+                or avro_type
+            )
+        if isinstance(resolved_type, dict):
+            node_type = resolved_type.get('type')
+            if node_type == 'fixed' and 'logicalType' not in resolved_type:
+                return (
+                    'vec![rand::Rng::gen::<u8>(&mut rng); '
+                    f'{resolved_type["size"]}]'
+                )
+            if node_type == 'array':
+                inner_type = rust_type[4:-1]
+                inner_value = self.generate_random_value_for_avro(
+                    inner_type,
+                    resolved_type['items'],
+                    namespace,
+                )
+                return f'(0..3).map(|_| {inner_value}).collect()'
+            if node_type == 'map':
+                inner_type = rust_type.split(', ', 1)[1][:-1]
+                inner_value = self.generate_random_value_for_avro(
+                    inner_type,
+                    resolved_type['values'],
+                    namespace,
+                )
+                return (
+                    '(0..3).map(|_| ('
+                    'format!("key_{}", rand::Rng::gen::<u32>(&mut rng)), '
+                    f'{inner_value})).collect()'
+                )
+        if isinstance(avro_type, list):
+            non_null_types = [
+                item for item in avro_type if item != 'null'
+            ]
+            if len(non_null_types) == 1:
+                inner_type = (
+                    rust_type[7:-1]
+                    if rust_type.startswith('Option<') else rust_type
+                )
+                return self.generate_random_value_for_avro(
+                    inner_type,
+                    non_null_types[0],
+                    namespace,
+                )
+            return self.generate_random_value(rust_type)
+        return self.generate_random_value(rust_type)
     
     def generate_random_value(self, rust_type: str) -> str:
         """Generates a random value for a given Rust type"""
@@ -1488,6 +1615,8 @@ class AvroToRust:
             return 'chrono::NaiveDateTime::new(chrono::NaiveDate::from_ymd(rand::Rng::gen_range(&mut rng, 2000..2023), rand::Rng::gen_range(&mut rng, 1..13), rand::Rng::gen_range(&mut rng, 1..29)), chrono::NaiveTime::from_hms(rand::Rng::gen_range(&mut rng, 0..24), rand::Rng::gen_range(&mut rng, 0..60), rand::Rng::gen_range(&mut rng, 0..60)))'
         elif rust_type == 'uuid::Uuid':
             return 'uuid::Uuid::new_v4()'
+        elif rust_type.startswith('Option<'):
+            return self.generate_random_value(rust_type[7:-1])
         elif rust_type.startswith('std::collections::HashMap<String, '):
             inner_type = rust_type.split(', ')[1][:-1]
             return f'(0..3).map(|_| (format!("key_{{}}", rand::Rng::gen::<u32>(&mut rng)), {self.generate_random_value(inner_type)})).collect()'
@@ -1501,7 +1630,7 @@ class AvroToRust:
 
     def write_mod_rs(self, namespace: str):
         """Writes the mod.rs file for a Rust module"""
-        directories = namespace.split('.')
+        directories = [part.lower() for part in namespace.split('.')]
         for i in range(len(directories)):
             sub_package = '::'.join(directories[:i + 1])
             directory_path = os.path.join(
@@ -1510,9 +1639,17 @@ class AvroToRust:
                 os.makedirs(directory_path, exist_ok=True)
             mod_rs_path = os.path.join(directory_path, "mod.rs")
             
-            types = [file.replace('.rs', '') for file in os.listdir(directory_path) if file.endswith('.rs') and file != "mod.rs"]
+            types = sorted(
+                file.replace('.rs', '')
+                for file in os.listdir(directory_path)
+                if file.endswith('.rs') and file != "mod.rs"
+            )
             mod_statements = '\n'.join(f'pub mod {self.escaped_identifier(typ.lower())};' for typ in types)
-            mods = [dir for dir in os.listdir(directory_path) if os.path.isdir(os.path.join(directory_path, dir))]
+            mods = sorted(
+                directory
+                for directory in os.listdir(directory_path)
+                if os.path.isdir(os.path.join(directory_path, directory))
+            )
             mod_statements += '\n' + '\n'.join(f'pub mod {self.escaped_identifier(mod.lower())};' for mod in mods)
 
             with open(mod_rs_path, 'w', encoding='utf-8') as file:
@@ -1548,7 +1685,9 @@ class AvroToRust:
     def write_lib_rs(self):
         """Writes the lib.rs file for the Rust project"""
         modules = {name[(len('crate::')):].split('::')[0] for name in self.generated_types_rust_package}
-        mod_statements = '\n'.join(f'pub mod {module};' for module in modules)
+        mod_statements = '\n'.join(
+            f'pub mod {module};' for module in sorted(modules)
+        )
         if self.xml_annotation:
             mod_statements = 'pub(crate) mod xml_support;\n' + mod_statements
         
@@ -1582,6 +1721,7 @@ class AvroToRust:
         for avro_schema in (x for x in schema if isinstance(x, dict)):
             self.generate_class_or_enum(avro_schema)
 
+        self.write_union_aliases()
         self.write_cargo_toml()
         self.write_xml_support_rs()
         self.write_lib_rs()

--- a/avrotize/avrotorust.py
+++ b/avrotize/avrotorust.py
@@ -175,6 +175,102 @@ class AvroToRust:
         elif isinstance(node_type, (dict, list)):
             self.index_avro_named_types(node_type, namespace)
 
+    def inline_avro_references(
+        self,
+        node,
+        namespace='',
+        resolving=None,
+        defined_names=None,
+    ):
+        """Inline named types so each generated module owns a self-contained schema."""
+        resolving = set() if resolving is None else resolving
+        defined_names = set() if defined_names is None else defined_names
+        if isinstance(node, str):
+            qualified_name = f"{namespace}.{node}" if namespace and '.' not in node else node
+            resolved = self.avro_named_types.get(qualified_name) or self.avro_named_types.get(node)
+            if not resolved:
+                return node
+            resolved_namespace = resolved.get('namespace', namespace)
+            full_name = (
+                f"{resolved_namespace}.{resolved['name']}"
+                if resolved_namespace else resolved['name']
+            )
+            if full_name in resolving:
+                return full_name
+            if full_name in defined_names:
+                return full_name
+            defined_names.add(full_name)
+            return self.inline_avro_references(
+                resolved,
+                resolved_namespace,
+                resolving | {full_name},
+                defined_names,
+            )
+        if isinstance(node, list):
+            return [
+                self.inline_avro_references(
+                    item,
+                    namespace,
+                    resolving,
+                    defined_names,
+                )
+                for item in node
+            ]
+        if not isinstance(node, dict):
+            return node
+
+        result = dict(node)
+        node_type = node.get('type')
+        current_namespace = node.get('namespace', namespace)
+        current_resolving = resolving
+        if node_type in ('record', 'enum', 'fixed') and node.get('name'):
+            if current_namespace and 'namespace' not in result:
+                result['namespace'] = current_namespace
+            full_name = (
+                f"{current_namespace}.{node['name']}"
+                if current_namespace else node['name']
+            )
+            if full_name in defined_names and full_name not in resolving:
+                return full_name
+            defined_names.add(full_name)
+            current_resolving = resolving | {full_name}
+
+        if node_type == 'record':
+            result['fields'] = [
+                {
+                    **field,
+                    'type': self.inline_avro_references(
+                        field.get('type'),
+                        current_namespace,
+                        current_resolving,
+                        defined_names,
+                    ),
+                }
+                for field in node.get('fields', [])
+            ]
+        elif node_type == 'array':
+            result['items'] = self.inline_avro_references(
+                node.get('items'),
+                current_namespace,
+                current_resolving,
+                defined_names,
+            )
+        elif node_type == 'map':
+            result['values'] = self.inline_avro_references(
+                node.get('values'),
+                current_namespace,
+                current_resolving,
+                defined_names,
+            )
+        elif isinstance(node_type, (dict, list)):
+            result['type'] = self.inline_avro_references(
+                node_type,
+                current_namespace,
+                current_resolving,
+                defined_names,
+            )
+        return result
+
     def collect_xml_field_metadata(
         self, avro_type
     ) -> tuple[
@@ -292,7 +388,9 @@ class AvroToRust:
         qualified_struct_name = self.safe_package(self.concat_package(ns, struct_name))
         if not 'namespace' in avro_schema:
             avro_schema['namespace'] = parent_namespace
-        avro_schema_str = json.dumps(avro_schema)        
+        avro_schema_str = json.dumps(
+            self.inline_avro_references(avro_schema, parent_namespace)
+        )
         avro_schema_str = avro_schema_str.replace('"', '§')
         avro_schema_str = f"\",\n{INDENT*2}\"".join(
             [avro_schema_str[i:i+80] for i in range(0, len(avro_schema_str), 80)])
@@ -399,7 +497,9 @@ class AvroToRust:
         
         if not 'namespace' in avro_schema:
             avro_schema['namespace'] = parent_namespace
-        avro_schema_str = json.dumps(avro_schema)
+        avro_schema_str = json.dumps(
+            self.inline_avro_references(avro_schema, parent_namespace)
+        )
         avro_schema_str = avro_schema_str.replace('"', '§')
         avro_schema_str = f"\",\n{INDENT*2}\"".join(
             [avro_schema_str[i:i+80] for i in range(0, len(avro_schema_str), 80)])
@@ -431,12 +531,21 @@ class AvroToRust:
         ns = namespace.replace('.', '::').lower()
         union_enum_name = pascal(field_name) + 'Union'
         union_types = [self.convert_avro_type_to_rust(field_name + "Option" + str(i), t, namespace) for i, t in enumerate(avro_type) if t != 'null']
+        avro_schema_str = json.dumps(
+            self.inline_avro_references(avro_type, namespace)
+        )
+        avro_schema_str = avro_schema_str.replace('"', '§')
+        avro_schema_str = f"\",\n{INDENT*2}\"".join(
+            [avro_schema_str[i:i+80] for i in range(0, len(avro_schema_str), 80)])
+        avro_schema_str = avro_schema_str.replace('§', '\\"')
+        avro_schema_str = f"concat!(\"{avro_schema_str}\")"
         
         # Track seen predicates to identify structurally identical variants
         seen_predicates: set = set()
         # Track seen variant names to deduplicate
         seen_names: dict = {}
         union_fields = []
+        avro_indexes = [i for i, t in enumerate(avro_type) if t != 'null']
         for i, t in enumerate(union_types):
             predicate = self.get_is_json_match_clause(field_name, t, for_union=True)
             # Mark if this is the first variant with this predicate structure
@@ -454,6 +563,7 @@ class AvroToRust:
             union_fields.append({
                 'name': variant_name, 
                 'type': t, 
+                'avro_index': avro_indexes[i],
                 'random_value': self.generate_random_value(t),
                 'default_value': 'Default::default()',
                 'json_match_predicate': predicate,
@@ -496,6 +606,7 @@ class AvroToRust:
             'union_enum_name': union_enum_name,
             'union_fields': union_fields,
             'xml_string_guards': xml_string_guards,
+            'avro_schema': avro_schema_str,
             'json_match_predicates': [self.get_is_json_match_clause(f['name'], f['type'], for_union=True) for f in union_fields]
         }
 

--- a/avrotize/avrotorust.py
+++ b/avrotize/avrotorust.py
@@ -27,6 +27,7 @@ class AvroToRust:
         self.generated_union_fields: Dict[str, List[Dict]] = {}
         self.generated_struct_avro_test_values: Dict[str, List[str]] = {}
         self.avro_named_types: Dict[str, Dict] = {}
+        self.current_record_name = ''
         self.avro_annotation = False
         self.serde_annotation = False
         self.xml_annotation = False
@@ -384,6 +385,9 @@ class AvroToRust:
 
     def generate_struct(self, avro_schema: Dict, parent_namespace: str) -> str:
         """Generates a Rust struct from an Avro record schema"""
+        struct_name = self.safe_identifier(pascal(avro_schema['name']))
+        previous_record_name = self.current_record_name
+        self.current_record_name = struct_name
         fields = []
         for field in avro_schema.get('fields', []):
             original_field_name = field['name']
@@ -442,7 +446,6 @@ class AvroToRust:
                 'avro_decode': avro_decode,
             })
         
-        struct_name = self.safe_identifier(pascal(avro_schema['name']))
         ns = parent_namespace.replace('.', '::').lower()
         qualified_struct_name = self.safe_package(self.concat_package(ns, struct_name))
         avro_test_instances = []
@@ -515,6 +518,7 @@ class AvroToRust:
 
         self.generated_types_avro_namespace[qualified_struct_name] = "struct"
         self.generated_types_rust_package[qualified_struct_name] = "struct"
+        self.current_record_name = previous_record_name
 
         return qualified_struct_name
 
@@ -845,7 +849,11 @@ class AvroToRust:
     def generate_union_enum(self, field_name: str, avro_type: List, namespace: str) -> str:
         """Generates a union enum for Rust"""
         ns = namespace.replace('.', '::').lower()
-        union_enum_name = pascal(field_name) + 'Union'
+        union_owner = (
+            f'Record{len(self.current_record_name)}{self.current_record_name}'
+            if self.avro_annotation else ''
+        )
+        union_enum_name = union_owner + pascal(field_name) + 'Union'
         union_avro_branches = [
             (source_index, avro_branch)
             for source_index, avro_branch in enumerate(avro_type)

--- a/avrotize/avrotorust.py
+++ b/avrotize/avrotorust.py
@@ -25,6 +25,7 @@ class AvroToRust:
         self.generated_types_avro_namespace: Dict[str, str] = {}
         self.generated_types_rust_package: Dict[str, str] = {}
         self.generated_union_fields: Dict[str, List[Dict]] = {}
+        self.generated_struct_avro_test_values: Dict[str, List[str]] = {}
         self.avro_named_types: Dict[str, Dict] = {}
         self.avro_annotation = False
         self.serde_annotation = False
@@ -131,6 +132,12 @@ class AvroToRust:
                     type_name = self.map_primitive_to_rust(non_null_types[0], True)
                 else:
                     type_name = self.convert_avro_type_to_rust(field_name, non_null_types[0], namespace)
+                if (
+                    self.avro_annotation
+                    and 'null' in avro_type
+                    and not type_name.startswith('Option<')
+                ):
+                    type_name = f'Option<{type_name}>'
             else:
                 type_name = self.generate_union_enum(field_name, avro_type, namespace)
                 if self.avro_annotation and 'null' in avro_type:
@@ -405,6 +412,16 @@ class AvroToRust:
                 and 'null' in field['type']
                 else -1
             )
+            avro_decode = (
+                self.render_avro_decode_value(
+                    field['type'],
+                    field_type,
+                    parent_namespace,
+                    'field_value',
+                    [0],
+                )
+                if self.avro_annotation else ''
+            )
             fields.append({
                 'original_name': original_field_name,
                 'json_name': original_field_name,
@@ -422,11 +439,36 @@ class AvroToRust:
                 'avro_union_type': base_field_type,
                 'avro_union_fields': avro_union_fields,
                 'avro_null_index': source_null_index,
+                'avro_decode': avro_decode,
             })
         
         struct_name = self.safe_identifier(pascal(avro_schema['name']))
         ns = parent_namespace.replace('.', '::').lower()
         qualified_struct_name = self.safe_package(self.concat_package(ns, struct_name))
+        avro_test_instances = []
+        if self.avro_annotation:
+            for field, field_schema in zip(fields, avro_schema.get('fields', [])):
+                for test_value in self.generate_avro_test_values(
+                    field_schema['type'],
+                    field['type'],
+                    parent_namespace,
+                ):
+                    avro_test_instances.append(
+                        f'''{{
+            let mut instance = {struct_name}::generate_random_instance();
+            instance.{field["name"]} = {test_value};
+            instance
+        }}'''
+                    )
+        self.generated_struct_avro_test_values[
+            qualified_struct_name
+        ] = [
+            instance.replace(
+                f'{struct_name}::generate_random_instance()',
+                f'{qualified_struct_name}::generate_random_instance()',
+            )
+            for instance in avro_test_instances
+        ]
         if not 'namespace' in avro_schema:
             avro_schema['namespace'] = parent_namespace
         avro_schema_str = json.dumps(
@@ -462,6 +504,7 @@ class AvroToRust:
             'xml_attribute_owners': sorted(attribute_owners),
             'fields': fields,
             'avro_schema': avro_schema_str,
+            'avro_test_instances': avro_test_instances,
             'json_match_predicates': [self.get_is_json_match_clause(f['original_name'], f['type']) for f in fields]
         }
 
@@ -474,6 +517,238 @@ class AvroToRust:
         self.generated_types_rust_package[qualified_struct_name] = "struct"
 
         return qualified_struct_name
+
+    def generate_avro_test_values(
+        self,
+        avro_type,
+        rust_type: str,
+        namespace: str,
+    ) -> List[str]:
+        """Generates deterministic values for every nested Avro union branch."""
+        if isinstance(avro_type, list):
+            if is_generic_avro_type(avro_type):
+                return []
+            non_null_types = [item for item in avro_type if item != 'null']
+            if len(non_null_types) > 1:
+                union_type = (
+                    rust_type[7:-1]
+                    if rust_type.startswith('Option<') else rust_type
+                )
+                values = []
+                union_fields = self.generated_union_fields.get(union_type, [])
+                union_avro_types = [
+                    item for item in avro_type if item != 'null'
+                ]
+                for field, branch_type in zip(
+                    union_fields,
+                    union_avro_types,
+                ):
+                    branch_values = self.generate_avro_test_values(
+                        branch_type,
+                        field['type'],
+                        namespace,
+                    ) or [field['random_value']]
+                    values.extend(
+                        f'{union_type}::{field["name"]}({value})'
+                        for value in branch_values
+                    )
+                if rust_type.startswith('Option<'):
+                    values = [f'Some({value})' for value in values]
+                    if 'null' in avro_type:
+                        values.insert(0, 'None')
+                return values
+            if len(non_null_types) == 1 and rust_type.startswith('Option<'):
+                inner_type = rust_type[7:-1]
+                inner_values = self.generate_avro_test_values(
+                    non_null_types[0],
+                    inner_type,
+                    namespace,
+                )
+                return ['None'] + [f'Some({value})' for value in inner_values]
+
+        resolved_type = avro_type
+        if isinstance(avro_type, str):
+            if is_any_value_type(avro_type):
+                return []
+            qualified_name = (
+                f'{namespace}.{avro_type}'
+                if namespace and '.' not in avro_type else avro_type
+            )
+            resolved_type = (
+                self.avro_named_types.get(qualified_name)
+                or self.avro_named_types.get(avro_type)
+                or avro_type
+            )
+
+        if isinstance(resolved_type, dict):
+            node_type = resolved_type.get('type')
+            if node_type == 'record':
+                return self.generated_struct_avro_test_values.get(rust_type, [])
+            if node_type == 'array':
+                inner_type = rust_type[4:-1]
+                return [
+                    f'vec![{value}]'
+                    for value in self.generate_avro_test_values(
+                        resolved_type['items'],
+                        inner_type,
+                        namespace,
+                    )
+                ]
+            if node_type == 'map':
+                inner_type = rust_type.split(', ', 1)[1][:-1]
+                return [
+                    (
+                        'std::iter::once(('
+                        '"branch".to_string(), '
+                        f'{value})).collect()'
+                    )
+                    for value in self.generate_avro_test_values(
+                        resolved_type['values'],
+                        inner_type,
+                        namespace,
+                    )
+                ]
+        return []
+
+    def render_avro_decode_value(
+        self,
+        avro_type,
+        rust_type: str,
+        namespace: str,
+        value_expression: str,
+        counter: List[int],
+    ) -> str:
+        """Renders index-aware Rust decoding for a generated field value."""
+        counter[0] += 1
+        suffix = counter[0]
+
+        if isinstance(avro_type, list):
+            if is_generic_avro_type(avro_type):
+                return f'apache_avro::from_value({value_expression})?'
+            non_null_types = [item for item in avro_type if item != 'null']
+            if len(non_null_types) > 1:
+                union_type = (
+                    rust_type[7:-1]
+                    if rust_type.startswith('Option<') else rust_type
+                )
+                union_fields = self.generated_union_fields.get(union_type, [])
+                null_index = avro_type.index('null') if 'null' in avro_type else -1
+                arms = []
+                if null_index >= 0 and rust_type.startswith('Option<'):
+                    arms.append(f'{null_index} => None')
+                for union_field in union_fields:
+                    decoded = (
+                        f'{union_type}::from_avro_branch('
+                        f'{union_field["avro_index"]}, value)?'
+                    )
+                    if rust_type.startswith('Option<'):
+                        decoded = f'Some({decoded})'
+                    arms.append(
+                        f'{union_field["source_avro_index"]} => {decoded}'
+                    )
+                arms_text = ',\n'.join(arms)
+                return f'''match {value_expression} {{
+                    apache_avro::types::Value::Union(index, value) => match index {{
+                        {arms_text},
+                        _ => return Err(format!(
+                            "unsupported Avro union branch {{}}",
+                            index,
+                        ).into()),
+                    }},
+                    _ => return Err("expected an Avro union value".into()),
+                }}'''
+
+            if len(non_null_types) == 1:
+                inner_rust_type = (
+                    rust_type[7:-1]
+                    if rust_type.startswith('Option<') else rust_type
+                )
+                inner_decode = self.render_avro_decode_value(
+                    non_null_types[0],
+                    inner_rust_type,
+                    namespace,
+                    'value.as_ref()',
+                    counter,
+                )
+                null_index = avro_type.index('null')
+                value_index = next(
+                    index for index, item in enumerate(avro_type)
+                    if item != 'null'
+                )
+                return f'''match {value_expression} {{
+                    apache_avro::types::Value::Union(index, value) => match index {{
+                        {null_index} => None,
+                        {value_index} => Some({inner_decode}),
+                        _ => return Err(format!(
+                            "unsupported Avro optional branch {{}}",
+                            index,
+                        ).into()),
+                    }},
+                    _ => return Err("expected an Avro optional value".into()),
+                }}'''
+
+        resolved_type = avro_type
+        if isinstance(avro_type, str):
+            if is_any_value_type(avro_type):
+                return f'apache_avro::from_value({value_expression})?'
+            qualified_name = (
+                f'{namespace}.{avro_type}'
+                if namespace and '.' not in avro_type else avro_type
+            )
+            resolved_type = (
+                self.avro_named_types.get(qualified_name)
+                or self.avro_named_types.get(avro_type)
+                or avro_type
+            )
+
+        if isinstance(resolved_type, dict):
+            node_type = resolved_type.get('type')
+            if node_type == 'record':
+                return f'{rust_type}::from_avro_value({value_expression})?'
+            if node_type == 'array':
+                inner_rust_type = rust_type[4:-1]
+                item_name = f'item_{suffix}'
+                values_name = f'values_{suffix}'
+                inner_decode = self.render_avro_decode_value(
+                    resolved_type['items'],
+                    inner_rust_type,
+                    namespace,
+                    item_name,
+                    counter,
+                )
+                return f'''match {value_expression} {{
+                    apache_avro::types::Value::Array(items) => {{
+                        let mut {values_name} = Vec::with_capacity(items.len());
+                        for {item_name} in items {{
+                            {values_name}.push({inner_decode});
+                        }}
+                        {values_name}
+                    }},
+                    _ => return Err("expected an Avro array value".into()),
+                }}'''
+            if node_type == 'map':
+                inner_rust_type = rust_type.split(', ', 1)[1][:-1]
+                item_name = f'item_{suffix}'
+                values_name = f'values_{suffix}'
+                inner_decode = self.render_avro_decode_value(
+                    resolved_type['values'],
+                    inner_rust_type,
+                    namespace,
+                    item_name,
+                    counter,
+                )
+                return f'''match {value_expression} {{
+                    apache_avro::types::Value::Map(items) => {{
+                        let mut {values_name} = std::collections::HashMap::new();
+                        for (key, {item_name}) in items {{
+                            {values_name}.insert(key.clone(), {inner_decode});
+                        }}
+                        {values_name}
+                    }},
+                    _ => return Err("expected an Avro map value".into()),
+                }}'''
+
+        return f'apache_avro::from_value({value_expression})?'
     
     def get_is_json_match_clause(self, field_name: str, field_type: str, for_union=False) -> str:
         """Generates the is_json_match clause for a field"""
@@ -620,6 +895,13 @@ class AvroToRust:
                 'type': t, 
                 'avro_index': i,
                 'source_avro_index': union_avro_branches[i][0],
+                'avro_decode': self.render_avro_decode_value(
+                    union_avro_types[i],
+                    t,
+                    namespace,
+                    'value',
+                    [0],
+                ),
                 'random_value': self.generate_random_value(t),
                 'default_value': 'Default::default()',
                 'json_match_predicate': predicate,

--- a/avrotize/avrotorust.py
+++ b/avrotize/avrotorust.py
@@ -1265,7 +1265,7 @@ class AvroToRust:
         ]
         union_types = [
             self.convert_avro_type_to_rust(
-                field_name + "Option" + str(i),
+                field_name + "Option" + str(source_index),
                 avro_branch,
                 namespace,
                 path=(path or []) + [('branch', str(source_index))],
@@ -1722,7 +1722,7 @@ class AvroToRust:
         if not isinstance(schema, list):
             schema = [schema]
         self.index_avro_named_types(schema)
-        self.validate_rust_type_paths()
+        self.validate_rust_generation_plan(schema)
         if not os.path.exists(output_dir):
             os.makedirs(output_dir, exist_ok=True)
         self.output_dir = output_dir
@@ -1734,52 +1734,162 @@ class AvroToRust:
         self.write_xml_support_rs()
         self.write_lib_rs()
 
-    def validate_rust_type_paths(self):
-        """Rejects canonical Avro names that normalize to one Rust path."""
-        rust_paths = {}
-        for fullname in sorted(self.avro_named_types):
-            node = self.avro_named_types[fullname]
-            if node.get('type') not in ('record', 'enum'):
-                continue
-            namespace, _, short_name = fullname.rpartition('.')
-            rust_name = self.safe_identifier(pascal(short_name))
-            namespace_parts = (
-                tuple(part.lower() for part in namespace.split('.'))
-                if namespace else ()
-            )
-            if 'mod' in namespace_parts:
+    def validate_rust_generation_plan(self, schema: JsonNode):
+        """Validates every planned Rust source path before creating output."""
+        planned = {}
+        alias_candidates = {}
+        visited_named = set()
+
+        def add(path, description):
+            path = tuple(part.lower() for part in path)
+            existing = planned.get(path)
+            if existing is not None and existing != description:
+                path_text = '::'.join(path)
                 raise ValueError(
-                    'Avro named type namespace collides with generated Rust '
-                    f"mod.rs path: '{fullname}'"
+                    'Rust generation plan has an exact path collision at '
+                    f"'{path_text}': '{existing}' and '{description}'"
                 )
-            if namespace_parts and namespace_parts[0] == 'lib':
-                raise ValueError(
-                    'Avro named type namespace collides with generated Rust '
-                    f"lib.rs path: '{fullname}'"
+            planned[path] = description
+
+        def visit(node, namespace='', path=None, field_name=''):
+            if isinstance(node, str):
+                return
+            if isinstance(node, list):
+                if is_generic_avro_type(node):
+                    return
+                non_null = [
+                    (index, item)
+                    for index, item in enumerate(node)
+                    if item != 'null'
+                ]
+                if len(non_null) > 1:
+                    union_name = (
+                        self.union_name_from_path(
+                            path or [('field', field_name)]
+                        )
+                        if self.avro_annotation
+                        else pascal(field_name) + 'Union'
+                    )
+                    namespace_parts = (
+                        tuple(namespace.lower().split('.'))
+                        if namespace else ()
+                    )
+                    union_output_path = (
+                        namespace_parts + (union_name.lower(),)
+                    )
+                    if (
+                        self.avro_annotation
+                        or union_output_path not in planned
+                    ):
+                        add(
+                            union_output_path,
+                            f"generated union {union_name} at "
+                            f"{path or [('field', field_name)]}",
+                        )
+                    if self.avro_annotation:
+                        legacy_name = pascal(field_name) + 'Union'
+                        alias_candidates.setdefault(
+                            (namespace_parts, legacy_name.lower()),
+                            set(),
+                        ).add(union_name)
+                    for source_index, branch in non_null:
+                        visit(
+                            branch,
+                            namespace,
+                            (path or []) + [
+                                ('branch', str(source_index))
+                            ],
+                            field_name + 'Option' + str(source_index),
+                        )
+                elif len(non_null) == 1:
+                    visit(
+                        non_null[0][1],
+                        namespace,
+                        path,
+                        field_name,
+                    )
+                return
+            if not isinstance(node, dict):
+                return
+
+            node_type = node.get('type')
+            if node_type in ('record', 'enum', 'fixed') and node.get('name'):
+                fullname, node_namespace, short_name = (
+                    self.canonical_avro_name(
+                        node['name'],
+                        node.get('namespace', namespace),
+                    )
                 )
-            normalized_path = (
-                namespace_parts + (rust_name.lower(),)
-            )
-            if normalized_path[-1] == 'mod':
-                path_text = '::'.join(normalized_path)
-                raise ValueError(
-                    'Avro named type collides with generated Rust mod.rs '
-                    f"path '{path_text}': '{fullname}'"
+                namespace = node_namespace
+                if node_type in ('record', 'enum'):
+                    namespace_parts = (
+                        tuple(namespace.lower().split('.'))
+                        if namespace else ()
+                    )
+                    add(
+                        namespace_parts + (
+                            self.safe_identifier(
+                                pascal(short_name)
+                            ).lower(),
+                        ),
+                        f"named type {fullname}",
+                    )
+                if fullname in visited_named:
+                    return
+                visited_named.add(fullname)
+                if node_type == 'record':
+                    record_path = path or [('record', fullname)]
+                    for field in node.get('fields', []):
+                        visit(
+                            field.get('type'),
+                            namespace,
+                            record_path + [
+                                ('field', field['name'])
+                            ],
+                            self.safe_identifier(snake(field['name'])),
+                        )
+                return
+            if node_type == 'array':
+                visit(
+                    node.get('items'),
+                    namespace,
+                    (path or []) + [('array', 'items')],
+                    field_name,
                 )
-            if normalized_path == ('lib',):
-                raise ValueError(
-                    'Avro named type collides with generated Rust lib.rs '
-                    f"path 'lib': '{fullname}'"
+            elif node_type == 'map':
+                visit(
+                    node.get('values'),
+                    namespace,
+                    (path or []) + [('map', 'values')],
+                    field_name,
                 )
-            existing = rust_paths.get(normalized_path)
-            if existing is not None and existing != fullname:
-                path_text = '::'.join(str(part) for part in normalized_path)
-                raise ValueError(
-                    'Avro named types normalize to the same Rust path '
-                    f"'{path_text}': '{existing}' and '{fullname}'"
+            elif isinstance(node_type, (dict, list)):
+                visit(node_type, namespace, path, field_name)
+
+        for top_level in schema:
+            visit(top_level)
+
+        if self.avro_annotation:
+            for (namespace_parts, alias_name), targets in sorted(
+                alias_candidates.items()
+            ):
+                if len(targets) == 1:
+                    add(
+                        namespace_parts + (alias_name,),
+                        f"legacy union alias {alias_name}",
+                    )
+
+        source_paths = list(planned)
+        add(('lib',), 'generated infrastructure lib.rs')
+        for source_path in source_paths:
+            for length in range(1, len(source_path)):
+                add(
+                    source_path[:length] + ('mod',),
+                    'generated infrastructure mod.rs for '
+                    + '::'.join(source_path[:length]),
                 )
-            rust_paths[normalized_path] = fullname
-        normalized_paths = sorted(rust_paths)
+
+        normalized_paths = sorted(planned)
         for file_path, other_path in zip(
             normalized_paths,
             normalized_paths[1:],
@@ -1787,13 +1897,12 @@ class AvroToRust:
             if len(file_path) < len(other_path) and (
                 other_path[:len(file_path)] == file_path
             ):
-                file_name = rust_paths[file_path]
-                directory_name = rust_paths[other_path]
                 path_text = '::'.join(file_path)
                 raise ValueError(
-                    'Avro named types require the same normalized Rust '
-                    f"path '{path_text}' as both a file and directory: "
-                    f"'{file_name}' and '{directory_name}'"
+                    'Rust generation plan requires the same path '
+                    f"'{path_text}' as both a file and directory: "
+                    f"'{planned[file_path]}' and "
+                    f"'{planned[other_path]}'"
                 )
 
     def convert(self, avro_schema_path: str, output_dir: str):

--- a/avrotize/avrotorust.py
+++ b/avrotize/avrotorust.py
@@ -34,7 +34,12 @@ class AvroToRust:
         self.union_path_identities: Dict[str, str] = {}
         self.union_alias_candidates: Dict[tuple[str, str], List[str]] = {}
         self.planned_alias_contents: Dict[str, str] = {}
-        self.generated_aliases_to_remove: List[tuple[str, str]] = []
+        self.generated_aliases_to_remove: List[
+            tuple[str, str, tuple[str, ...]]
+        ] = []
+        self.planned_source_paths: set[tuple[str, ...]] = set()
+        self.union_schema_targets: Dict[tuple, str] = {}
+        self.union_targets_in_progress: set[tuple] = set()
         self.avro_annotation = False
         self.serde_annotation = False
         self.xml_annotation = False
@@ -150,11 +155,22 @@ class AvroToRust:
                         namespace,
                         path=path,
                     )
-                    type_name = (
-                        inner_type
-                        if inner_type.startswith('Option<')
-                        else f'Option<{inner_type}>'
+                    named_type = self.resolve_avro_named_type(
+                        non_null_types[0],
+                        namespace,
                     )
+                    if named_type and named_type.get('type') in (
+                        'record',
+                        'enum',
+                        'fixed',
+                    ):
+                        type_name = inner_type
+                    else:
+                        type_name = (
+                            inner_type
+                            if inner_type.startswith('Option<')
+                            else f'Option<{inner_type}>'
+                        )
                 else:
                     type_name = self.convert_avro_type_to_rust(
                         field_name,
@@ -1284,6 +1300,36 @@ class AvroToRust:
         union_avro_types = [
             avro_branch for _, avro_branch in union_avro_branches
         ]
+        structural_identity = json.dumps(
+            self.inline_avro_references(union_avro_types, namespace),
+            sort_keys=True,
+        )
+        source_indexes = tuple(
+            source_index for source_index, _ in union_avro_branches
+        )
+        target_key = (
+            namespace.lower(),
+            structural_identity,
+            source_indexes,
+        )
+        existing_target = self.union_schema_targets.get(target_key)
+        if existing_target is None:
+            existing_target = self.safe_package(
+                self.concat_package(ns, union_enum_name)
+            )
+            self.union_schema_targets[target_key] = existing_target
+            is_new_target = True
+        else:
+            is_new_target = False
+            legacy_name = pascal(field_name) + 'Union'
+            self.union_alias_candidates.setdefault(
+                (namespace.lower(), legacy_name),
+                [],
+            ).append(existing_target)
+            if target_key in self.union_targets_in_progress:
+                return existing_target
+
+        self.union_targets_in_progress.add(target_key)
         union_types = [
             self.convert_avro_type_to_rust(
                 field_name + "Option" + str(source_index),
@@ -1291,8 +1337,13 @@ class AvroToRust:
                 namespace,
                 path=(path or []) + [('branch', str(source_index))],
             )
-            for i, (source_index, avro_branch) in enumerate(union_avro_branches)
+            for _, (source_index, avro_branch) in enumerate(
+                union_avro_branches
+            )
         ]
+        self.union_targets_in_progress.remove(target_key)
+        if not is_new_target:
+            return existing_target
         avro_schema_str = json.dumps(
             self.inline_avro_references(union_avro_types, namespace)
         )
@@ -1390,7 +1441,7 @@ class AvroToRust:
         qualified_union_enum_name = self.safe_package(self.concat_package(ns, union_enum_name))
         legacy_name = pascal(field_name) + 'Union'
         self.union_alias_candidates.setdefault(
-            (namespace, legacy_name),
+            (namespace.lower(), legacy_name),
             [],
         ).append(qualified_union_enum_name)
         context = {
@@ -1419,8 +1470,15 @@ class AvroToRust:
 
     def write_union_aliases(self):
         """Emits legacy Avro union names when they are unambiguous."""
-        for alias_path, namespace in self.generated_aliases_to_remove:
-            if os.path.exists(alias_path):
+        for (
+            alias_path,
+            namespace,
+            normalized_path,
+        ) in self.generated_aliases_to_remove:
+            if (
+                normalized_path not in self.planned_source_paths
+                and os.path.exists(alias_path)
+            ):
                 os.remove(alias_path)
                 self.write_mod_rs(namespace)
         for (namespace, legacy_name), targets in sorted(
@@ -1804,6 +1862,7 @@ class AvroToRust:
         planned = {}
         alias_candidates = {}
         visited_named = set()
+        union_identity_targets = {}
 
         def add(path, kind, identity, description):
             path = tuple(part.lower() for part in path)
@@ -1848,22 +1907,42 @@ class AvroToRust:
                         tuple(namespace.lower().split('.'))
                         if namespace else ()
                     )
-                    union_output_path = (
-                        namespace_parts + (union_name.lower(),)
+                    structural_identity = json.dumps(
+                        self.inline_avro_references(
+                            [item for _, item in non_null],
+                            namespace,
+                        ),
+                        sort_keys=True,
                     )
-                    union_identity = union_name
+                    identity_key = (
+                        namespace.lower(),
+                        structural_identity,
+                        tuple(index for index, _ in non_null),
+                    )
+                    canonical_union_name = union_identity_targets.setdefault(
+                        identity_key,
+                        union_name,
+                    )
+                    union_output_path = (
+                        namespace_parts
+                        + (canonical_union_name.lower(),)
+                    )
+                    union_identity = (
+                        structural_identity,
+                        tuple(index for index, _ in non_null),
+                    )
                     add(
                         union_output_path,
                         'union',
                         union_identity,
-                        f"generated union {union_name} at "
+                        f"generated union {canonical_union_name} at "
                         f"{path or [('field', field_name)]}",
                     )
                     legacy_name = pascal(field_name) + 'Union'
                     alias_candidates.setdefault(
                         (namespace_parts, legacy_name),
                         set(),
-                    ).add(union_name)
+                    ).add(canonical_union_name)
                     for source_index, branch in non_null:
                         visit(
                             branch,
@@ -1984,7 +2063,11 @@ class AvroToRust:
                         )
                     ):
                         self.generated_aliases_to_remove.append(
-                            (alias_path, namespace)
+                            (
+                                alias_path,
+                                namespace,
+                                namespace_parts + (alias_name,),
+                            )
                         )
                     else:
                         raise ValueError(
@@ -2027,6 +2110,7 @@ class AvroToRust:
                 self.planned_alias_contents[alias_path] = alias_content
 
         source_paths = list(planned)
+        self.planned_source_paths = set(source_paths)
         add(
             ('lib',),
             'infrastructure',

--- a/avrotize/avrotorust.py
+++ b/avrotize/avrotorust.py
@@ -129,7 +129,7 @@ class AvroToRust:
                     type_name = self.convert_avro_type_to_rust(field_name, non_null_types[0], namespace)
             else:
                 type_name = self.generate_union_enum(field_name, avro_type, namespace)
-                if 'null' in avro_type:
+                if self.avro_annotation and 'null' in avro_type:
                     type_name = f'Option<{type_name}>'
         elif isinstance(avro_type, dict):
             if avro_type['type'] in ['record', 'enum']:

--- a/avrotize/avrotorust.py
+++ b/avrotize/avrotorust.py
@@ -1746,9 +1746,12 @@ class AvroToRust:
                 continue
             namespace, _, short_name = fullname.rpartition('.')
             rust_name = self.safe_identifier(pascal(short_name))
-            normalized_path = (
+            namespace_parts = (
                 tuple(part.lower() for part in namespace.split('.'))
-                + (rust_name.lower(),)
+                if namespace else ()
+            )
+            normalized_path = (
+                namespace_parts + (rust_name.lower(),)
             )
             existing = rust_paths.get(normalized_path)
             if existing is not None and existing != fullname:
@@ -1758,6 +1761,22 @@ class AvroToRust:
                     f"'{path_text}': '{existing}' and '{fullname}'"
                 )
             rust_paths[normalized_path] = fullname
+        normalized_paths = sorted(rust_paths)
+        for file_path, other_path in zip(
+            normalized_paths,
+            normalized_paths[1:],
+        ):
+            if len(file_path) < len(other_path) and (
+                other_path[:len(file_path)] == file_path
+            ):
+                file_name = rust_paths[file_path]
+                directory_name = rust_paths[other_path]
+                path_text = '::'.join(file_path)
+                raise ValueError(
+                    'Avro named types require the same normalized Rust '
+                    f"path '{path_text}' as both a file and directory: "
+                    f"'{file_name}' and '{directory_name}'"
+                )
 
     def convert(self, avro_schema_path: str, output_dir: str):
         """Converts Avro schema to Rust"""

--- a/avrotize/avrotorust.py
+++ b/avrotize/avrotorust.py
@@ -727,11 +727,15 @@ class AvroToRust:
             'fields': fields,
             'avro_schema': avro_schema_str,
             'avro_test_instances': avro_test_instances,
+            'json_round_trip_safe': self.is_json_round_trip_safe(
+                avro_schema,
+                parent_namespace,
+            ),
             'json_match_predicates': [self.get_is_json_match_clause(f['original_name'], f['type']) for f in fields]
         }
 
         file_name = self.to_file_name(qualified_struct_name)
-        target_file = os.path.join(self.output_dir, "src", file_name + ".rs")
+        target_file = self.output_path("src", file_name + ".rs")
         render_template('avrotorust/dataclass_struct.rs.jinja', target_file, **context)
         self.write_mod_rs(parent_namespace)
 
@@ -1024,7 +1028,7 @@ class AvroToRust:
                 )
                 return (
                     f'{union_type}::from_avro_source_value('
-                    f'{value_expression})?'
+                    f'{value_expression}, depth + 1)?'
                 )
 
             if len(non_null_types) == 1:
@@ -1100,7 +1104,10 @@ class AvroToRust:
                     _ => return Err("expected an Avro fixed value".into()),
                 }}'''
             if node_type == 'record':
-                return f'{rust_type}::from_avro_value({value_expression})?'
+                return (
+                    f'{rust_type}::from_avro_value_at('
+                    f'{value_expression}, depth + 1)?'
+                )
             if node_type == 'array':
                 inner_rust_type = rust_type[4:-1]
                 item_name = f'item_{suffix}'
@@ -1235,7 +1242,7 @@ class AvroToRust:
         }
 
         file_name = self.to_file_name(qualified_enum_name)
-        target_file = os.path.join(self.output_dir, "src", file_name + ".rs")
+        target_file = self.output_path("src", file_name + ".rs")
         render_template('avrotorust/dataclass_enum.rs.jinja', target_file, **context)
         self.write_mod_rs(parent_namespace)
 
@@ -1271,10 +1278,15 @@ class AvroToRust:
         source_indexes = tuple(
             source_index for source_index, _ in union_avro_branches
         )
+        source_null_index = (
+            avro_type.index('null')
+            if self.avro_annotation and 'null' in avro_type else -1
+        )
         target_key = (
             namespace.lower(),
             structural_identity,
             source_indexes,
+            source_null_index,
         )
         existing_target = self.union_schema_targets.get(target_key)
         if existing_target is None:
@@ -1316,6 +1328,18 @@ class AvroToRust:
             [avro_schema_str[i:i+80] for i in range(0, len(avro_schema_str), 80)])
         avro_schema_str = avro_schema_str.replace('§', '\\"')
         avro_schema_str = f"concat!(\"{avro_schema_str}\")"
+        source_avro_schema_str = json.dumps(
+            self.inline_avro_references(avro_type, namespace)
+        )
+        source_avro_schema_str = source_avro_schema_str.replace('"', '§')
+        source_avro_schema_str = f"\",\n{INDENT*2}\"".join(
+            [
+                source_avro_schema_str[i:i+80]
+                for i in range(0, len(source_avro_schema_str), 80)
+            ]
+        )
+        source_avro_schema_str = source_avro_schema_str.replace('§', '\\"')
+        source_avro_schema_str = f"concat!(\"{source_avro_schema_str}\")"
         
         # Track seen predicates to identify structurally identical variants
         seen_predicates: set = set()
@@ -1328,7 +1352,11 @@ class AvroToRust:
                 t,
                 for_union=True,
             )
-            predicate_key = self.get_json_shape_signature(
+            predicate_key = self.get_json_match_signature(
+                union_avro_types[i],
+                namespace,
+            )
+            shape_signature = self.get_json_shape_signature(
                 union_avro_types[i],
                 namespace,
             )
@@ -1371,6 +1399,8 @@ class AvroToRust:
                 ),
                 'default_value': 'Default::default()',
                 'json_match_predicate': predicate,
+                'json_match_signature': predicate_key,
+                'json_shape_signature': shape_signature,
                 'is_first_with_predicate': is_first_with_predicate,
             })
         scalar_kinds = {
@@ -1382,20 +1412,31 @@ class AvroToRust:
             'f32': 'float', 'f64': 'float',
         }
         present_scalar_kinds = {scalar_kinds[field['type']] for field in union_fields if field['type'] in scalar_kinds}
-        predicate_counts = {
-            predicate: sum(1 for field in union_fields if field['json_match_predicate'] == predicate)
-            for predicate in {field['json_match_predicate'] for field in union_fields}
-        }
         for field in union_fields:
+            json_ambiguous = sum(
+                1 for candidate in union_fields
+                if self.json_match_accepts_shape(
+                    candidate['json_match_signature'],
+                    field['json_shape_signature'],
+                )
+            ) > 1
             scalar_kind = scalar_kinds.get(field['type'])
             field['xml_scalar_kind'] = scalar_kind or ''
             field['xml_guard_string'] = scalar_kind == 'string' and len(present_scalar_kinds) > 1
             field['xml_reject_value'] = (
                 (scalar_kind is not None and scalar_kind != 'string' and 'string' in present_scalar_kinds)
                 or (scalar_kind == 'integer' and 'float' in present_scalar_kinds)
-                or predicate_counts[field['json_match_predicate']] > 1
+                or json_ambiguous
             )
             field['xml_safe_for_random'] = not field['xml_reject_value']
+            field['json_ambiguous'] = json_ambiguous
+            field['json_round_trip_safe'] = (
+                not field['json_ambiguous']
+                and self.is_json_round_trip_safe(
+                    field['avro_type'],
+                    namespace,
+                )
+            )
         xml_string_guards = {
             'bool': 'bool' in present_scalar_kinds,
             'integer': 'integer' in present_scalar_kinds,
@@ -1416,6 +1457,17 @@ class AvroToRust:
             'union_fields': union_fields,
             'xml_string_guards': xml_string_guards,
             'avro_schema': avro_schema_str,
+            'source_avro_schema': source_avro_schema_str,
+            'source_null_index': (
+                avro_type.index('null') if 'null' in avro_type else -1
+            ),
+            'ambiguous_json_field': next(
+                (
+                    field for field in union_fields
+                    if field['json_ambiguous']
+                ),
+                None,
+            ),
             'json_match_predicates': [
                 field['json_match_predicate']
                 for field in union_fields
@@ -1423,7 +1475,7 @@ class AvroToRust:
         }
 
         file_name = self.to_file_name(qualified_union_enum_name)
-        target_file = os.path.join(self.output_dir, "src", file_name + ".rs")
+        target_file = self.output_path("src", file_name + ".rs")
         render_template('avrotorust/dataclass_union.rs.jinja', target_file, **context)
         self.generated_types_avro_namespace[qualified_union_enum_name] = "union"
         self.generated_types_rust_package[qualified_union_enum_name] = "union"
@@ -1457,8 +1509,7 @@ class AvroToRust:
             )
             if qualified_alias in self.generated_types_rust_package:
                 continue
-            target_file = os.path.join(
-                self.output_dir,
+            target_file = self.output_path(
                 'src',
                 self.to_file_name(qualified_alias) + '.rs',
             )
@@ -1615,12 +1666,249 @@ class AvroToRust:
             resolving,
         )
 
+    def is_json_round_trip_safe(
+        self,
+        avro_type,
+        namespace: str,
+        resolving=None,
+    ) -> bool:
+        """Checks whether generated untagged JSON has a deterministic branch."""
+        resolving = () if resolving is None else resolving
+        if isinstance(avro_type, str):
+            resolved = self.resolve_avro_named_type(avro_type, namespace)
+            if not resolved:
+                return True
+            fullname = self.avro_type_fullnames[id(resolved)]
+            if fullname in resolving:
+                return True
+            return self.is_json_round_trip_safe(
+                resolved,
+                fullname.rpartition('.')[0],
+                resolving + (fullname,),
+            )
+        if isinstance(avro_type, list):
+            branches = [item for item in avro_type if item != 'null']
+            if len(branches) <= 1:
+                return (
+                    not branches
+                    or self.is_json_round_trip_safe(
+                        branches[0],
+                        namespace,
+                        resolving,
+                    )
+                )
+            match_signatures = [
+                self.get_json_match_signature(
+                    branch,
+                    namespace,
+                    resolving,
+                )
+                for branch in branches
+            ]
+            shape_signatures = [
+                self.get_json_shape_signature(
+                    branch,
+                    namespace,
+                    resolving,
+                )
+                for branch in branches
+            ]
+            return any(
+                sum(
+                    1 for match_signature in match_signatures
+                    if self.json_match_accepts_shape(
+                        match_signature,
+                        shape_signature,
+                    )
+                ) == 1
+                and self.is_json_round_trip_safe(
+                    branch,
+                    namespace,
+                    resolving,
+                )
+                for branch, shape_signature
+                in zip(branches, shape_signatures)
+            )
+        if not isinstance(avro_type, dict):
+            return True
+
+        node_type = avro_type.get('type')
+        if node_type == 'record':
+            fullname, record_namespace, _ = self.canonical_avro_name(
+                avro_type['name'],
+                avro_type.get('namespace', namespace),
+            )
+            if fullname in resolving:
+                return True
+            nested_resolving = resolving + (fullname,)
+            return all(
+                self.is_json_round_trip_safe(
+                    field['type'],
+                    record_namespace,
+                    nested_resolving,
+                )
+                for field in avro_type.get('fields', [])
+            )
+        if node_type == 'array':
+            return self.is_json_round_trip_safe(
+                avro_type['items'],
+                namespace,
+                resolving,
+            )
+        if node_type == 'map':
+            return self.is_json_round_trip_safe(
+                avro_type['values'],
+                namespace,
+                resolving,
+            )
+        if isinstance(node_type, (dict, list)):
+            return self.is_json_round_trip_safe(
+                node_type,
+                namespace,
+                resolving,
+            )
+        return True
+
+    def get_json_match_signature(
+        self,
+        avro_type,
+        namespace: str,
+        resolving=None,
+    ):
+        """Returns the JSON shape accepted by a generated union matcher."""
+        resolving = () if resolving is None else resolving
+        if isinstance(avro_type, str):
+            resolved = self.resolve_avro_named_type(avro_type, namespace)
+            if resolved:
+                fullname = self.avro_type_fullnames[id(resolved)]
+                if fullname in resolving:
+                    return ('ref', resolving.index(fullname))
+                return self.get_json_match_signature(
+                    resolved,
+                    fullname.rpartition('.')[0],
+                    resolving,
+                )
+            if avro_type in ('int', 'long'):
+                return 'integer'
+            if avro_type in ('float', 'double'):
+                return 'number'
+            if avro_type == 'bytes':
+                return 'array'
+            return avro_type
+        if isinstance(avro_type, list):
+            return (
+                'union',
+                tuple(
+                    self.get_json_match_signature(
+                        item,
+                        namespace,
+                        resolving,
+                    )
+                    for item in avro_type
+                ),
+            )
+        if not isinstance(avro_type, dict):
+            return str(avro_type)
+        node_type = avro_type.get('type')
+        if node_type == 'record':
+            fullname, record_namespace, _ = self.canonical_avro_name(
+                avro_type['name'],
+                avro_type.get('namespace', namespace),
+            )
+            if fullname in resolving:
+                return ('ref', resolving.index(fullname))
+            nested_resolving = resolving + (fullname,)
+            return (
+                'record_match',
+                tuple(
+                    (
+                        field['name'],
+                        self.get_json_match_signature(
+                            field['type'],
+                            record_namespace,
+                            nested_resolving,
+                        ),
+                    )
+                    for field in avro_type.get('fields', [])
+                ),
+            )
+        if node_type == 'enum':
+            return 'string'
+        if node_type in ('array', 'fixed', 'bytes'):
+            return 'array'
+        if node_type == 'map':
+            return 'object'
+        return self.get_json_match_signature(
+            node_type,
+            namespace,
+            resolving,
+        )
+
+    @staticmethod
+    def json_match_accepts_shape(match_signature, shape_signature) -> bool:
+        """Checks whether a generated matcher accepts a serialized shape."""
+        shape_kind = (
+            shape_signature[0]
+            if isinstance(shape_signature, tuple) and shape_signature
+            else shape_signature
+        )
+        match_kind = (
+            match_signature[0]
+            if isinstance(match_signature, tuple) and match_signature
+            else match_signature
+        )
+        if match_kind == 'record_match':
+            if shape_kind != 'record':
+                return False
+            expected_fields = dict(match_signature[1])
+            value_fields = dict(shape_signature[1])
+            return all(
+                field_name in value_fields
+                and AvroToRust.json_match_accepts_shape(
+                    field_match,
+                    value_fields[field_name],
+                )
+                for field_name, field_match in expected_fields.items()
+            )
+        if match_signature == 'object':
+            return shape_kind in ('map', 'record')
+        if match_signature == 'array':
+            return shape_kind in ('array', 'bytes', 'fixed')
+        return match_signature == shape_signature
+
     def to_file_name(self, qualified_name):
         """Converts a qualified union enum name to a file name"""
         if qualified_name.startswith('crate::'):
             qualified_name = qualified_name[(len('crate::')):]
         qualified_name = qualified_name.replace('r#', '')
         return qualified_name.rsplit('::',1)[0].replace('::', os.sep).lower()
+
+    def output_path(self, *relative_parts: str) -> str:
+        """Returns a contained output path for generated artifacts."""
+        output_root = os.path.abspath(self.output_dir)
+        candidate = os.path.abspath(
+            os.path.join(output_root, *relative_parts)
+        )
+        if os.path.commonpath((output_root, candidate)) != output_root:
+            raise ValueError(
+                f"generated Rust path escapes output directory: {candidate}"
+            )
+        return candidate
+
+    @staticmethod
+    def validate_rust_path_components(parts, owner: str):
+        """Rejects generated relative path components that can escape."""
+        for part in parts:
+            if (
+                part in ('', '.', '..')
+                or '/' in part
+                or '\\' in part
+                or os.path.isabs(part)
+            ):
+                raise ValueError(
+                    f"invalid generated Rust path component '{part}' "
+                    f"for '{owner}'"
+                )
 
     def generate_random_value_for_avro(
         self,
@@ -1723,11 +2011,17 @@ class AvroToRust:
         directories = [part.lower() for part in namespace.split('.')]
         for i in range(len(directories)):
             sub_package = '::'.join(directories[:i + 1])
-            directory_path = os.path.join(
-                self.output_dir, "src", sub_package.replace('.', os.sep).replace('::', os.sep))
+            directory_path = self.output_path(
+                "src",
+                sub_package.replace('.', os.sep).replace('::', os.sep),
+            )
             if not os.path.exists(directory_path):
                 os.makedirs(directory_path, exist_ok=True)
-            mod_rs_path = os.path.join(directory_path, "mod.rs")
+            mod_rs_path = self.output_path(
+                "src",
+                sub_package.replace('.', os.sep).replace('::', os.sep),
+                "mod.rs",
+            )
             
             types = sorted(
                 file.replace('.rs', '')
@@ -1768,7 +2062,7 @@ class AvroToRust:
         cargo_toml_content += f"edition = \"2021\"\n\n"
         cargo_toml_content += f"[dependencies]\n"
         cargo_toml_content += "\n".join(f"{dependency}" for dependency in dependencies)
-        cargo_toml_path = os.path.join(self.output_dir, "Cargo.toml")
+        cargo_toml_path = self.output_path("Cargo.toml")
         with open(cargo_toml_path, 'w', encoding='utf-8') as file:
             file.write(cargo_toml_content)
 
@@ -1790,7 +2084,7 @@ class AvroToRust:
 
 {mod_statements}
 """
-        lib_rs_path = os.path.join(self.output_dir, "src", "lib.rs")
+        lib_rs_path = self.output_path("src", "lib.rs")
         if not os.path.exists(os.path.dirname(lib_rs_path)):
             os.makedirs(os.path.dirname(lib_rs_path), exist_ok=True)
         with open(lib_rs_path, 'w', encoding='utf-8') as file:
@@ -1801,7 +2095,7 @@ class AvroToRust:
         if self.xml_annotation:
             render_template(
                 'rust/xml_support.rs.jinja',
-                os.path.join(self.output_dir, "src", "xml_support.rs"),
+                self.output_path("src", "xml_support.rs"),
             )
 
     def convert_schema(self, schema: JsonNode, output_dir: str):
@@ -1872,6 +2166,10 @@ class AvroToRust:
                         tuple(namespace.lower().split('.'))
                         if namespace else ()
                     )
+                    self.validate_rust_path_components(
+                        namespace_parts + (union_name.lower(),),
+                        union_name,
+                    )
                     structural_identity = json.dumps(
                         self.inline_avro_references(
                             [item for _, item in non_null],
@@ -1883,6 +2181,10 @@ class AvroToRust:
                         namespace.lower(),
                         structural_identity,
                         tuple(index for index, _ in non_null),
+                        (
+                            node.index('null')
+                            if self.avro_annotation and 'null' in node else -1
+                        ),
                     )
                     canonical_union_name = union_identity_targets.setdefault(
                         identity_key,
@@ -1895,6 +2197,10 @@ class AvroToRust:
                     union_identity = (
                         structural_identity,
                         tuple(index for index, _ in non_null),
+                        (
+                            node.index('null')
+                            if self.avro_annotation and 'null' in node else -1
+                        ),
                     )
                     add(
                         union_output_path,
@@ -1941,6 +2247,14 @@ class AvroToRust:
                     namespace_parts = (
                         tuple(namespace.lower().split('.'))
                         if namespace else ()
+                    )
+                    self.validate_rust_path_components(
+                        namespace_parts + (
+                            self.safe_identifier(
+                                pascal(short_name)
+                            ).lower(),
+                        ),
+                        fullname,
                     )
                     add(
                         namespace_parts + (
@@ -1994,8 +2308,7 @@ class AvroToRust:
             relative_parts = list(namespace_parts) + [
                 alias_name + '.rs'
             ]
-            alias_path = os.path.join(
-                self.output_dir,
+            alias_path = self.output_path(
                 'src',
                 *relative_parts,
             )

--- a/avrotize/avrotorust.py
+++ b/avrotize/avrotorust.py
@@ -96,7 +96,23 @@ class AvroToRust:
         ns = namespace.replace('.', '::').lower()
         type_name = ''
         if isinstance(avro_type, str):
-            type_name = self.map_primitive_to_rust(avro_type, nullable)
+            qualified_avro_name = (
+                f"{namespace}.{avro_type}"
+                if namespace and '.' not in avro_type else avro_type
+            )
+            named_type = (
+                self.avro_named_types.get(qualified_avro_name)
+                or self.avro_named_types.get(avro_type)
+            )
+            if named_type and named_type.get('type') in ('record', 'enum', 'fixed'):
+                named_namespace = named_type.get('namespace', namespace)
+                rust_namespace = named_namespace.replace('.', '::').lower()
+                rust_name = self.safe_identifier(pascal(named_type['name']))
+                type_name = self.safe_package(
+                    self.concat_package(rust_namespace, rust_name)
+                )
+            else:
+                type_name = self.map_primitive_to_rust(avro_type, nullable)
         elif isinstance(avro_type, list):
             if is_generic_avro_type(avro_type):
                 return 'serde_json::Value' if self.serde_annotation or self.xml_annotation else 'std::collections::HashMap<String, String>'
@@ -113,6 +129,8 @@ class AvroToRust:
                     type_name = self.convert_avro_type_to_rust(field_name, non_null_types[0], namespace)
             else:
                 type_name = self.generate_union_enum(field_name, avro_type, namespace)
+                if 'null' in avro_type:
+                    type_name = f'Option<{type_name}>'
         elif isinstance(avro_type, dict):
             if avro_type['type'] in ['record', 'enum']:
                 type_name = self.generate_class_or_enum(avro_type, namespace)
@@ -530,9 +548,17 @@ class AvroToRust:
         """Generates a union enum for Rust"""
         ns = namespace.replace('.', '::').lower()
         union_enum_name = pascal(field_name) + 'Union'
-        union_types = [self.convert_avro_type_to_rust(field_name + "Option" + str(i), t, namespace) for i, t in enumerate(avro_type) if t != 'null']
+        union_avro_types = [t for t in avro_type if t != 'null']
+        union_types = [
+            self.convert_avro_type_to_rust(
+                field_name + "Option" + str(i),
+                avro_branch,
+                namespace,
+            )
+            for i, avro_branch in enumerate(union_avro_types)
+        ]
         avro_schema_str = json.dumps(
-            self.inline_avro_references(avro_type, namespace)
+            self.inline_avro_references(union_avro_types, namespace)
         )
         avro_schema_str = avro_schema_str.replace('"', '§')
         avro_schema_str = f"\",\n{INDENT*2}\"".join(
@@ -545,7 +571,6 @@ class AvroToRust:
         # Track seen variant names to deduplicate
         seen_names: dict = {}
         union_fields = []
-        avro_indexes = [i for i, t in enumerate(avro_type) if t != 'null']
         for i, t in enumerate(union_types):
             predicate = self.get_is_json_match_clause(field_name, t, for_union=True)
             # Mark if this is the first variant with this predicate structure
@@ -563,7 +588,7 @@ class AvroToRust:
             union_fields.append({
                 'name': variant_name, 
                 'type': t, 
-                'avro_index': avro_indexes[i],
+                'avro_index': i,
                 'random_value': self.generate_random_value(t),
                 'default_value': 'Default::default()',
                 'json_match_predicate': predicate,

--- a/avrotize/avrotorust.py
+++ b/avrotize/avrotorust.py
@@ -96,7 +96,9 @@ class AvroToRust:
 
     def concat_package(self, package: str, name: str) -> str:
         """Concatenates package and name using a double colon separator"""
-        return f"crate::{package.lower()}::{name.lower()}::{name}" if package else name
+        if package:
+            return f"crate::{package.lower()}::{name.lower()}::{name}"
+        return f"crate::{name.lower()}::{name}"
 
     def convert_avro_type_to_rust(
         self,
@@ -135,7 +137,9 @@ class AvroToRust:
             if is_generic_avro_type(avro_type):
                 return 'serde_json::Value' if self.serde_annotation or self.xml_annotation else 'std::collections::HashMap<String, String>'
             non_null_types = [t for t in avro_type if t != 'null']
-            if len(non_null_types) == 1:
+            if len(non_null_types) == 0:
+                type_name = '()'
+            elif len(non_null_types) == 1:
                 if isinstance(non_null_types[0], str):
                     inner_type = self.convert_avro_type_to_rust(
                         field_name,
@@ -1004,8 +1008,15 @@ class AvroToRust:
                 union_fields = self.generated_union_fields.get(union_type, [])
                 null_index = avro_type.index('null') if 'null' in avro_type else -1
                 arms = []
-                if null_index >= 0 and rust_type.startswith('Option<'):
-                    arms.append(f'{null_index} => None')
+                if null_index >= 0:
+                    if rust_type.startswith('Option<'):
+                        arms.append(f'{null_index} => None')
+                    else:
+                        arms.append(
+                            f'''{null_index} => return Err(
+                                "nullable Avro union null is unsupported by the generated Rust union API".into()
+                            )'''
+                        )
                 for union_field in union_fields:
                     decoded = (
                         f'{union_type}::from_avro_branch('
@@ -1160,6 +1171,8 @@ class AvroToRust:
             return f"({ref}.is_f64(){null_check})"
         elif base_type == 'Vec<u8>':
             return f"({ref}.is_array(){null_check})"
+        elif base_type == '()':
+            return f"({ref}.is_null(){null_check})"
         elif base_type == 'std::collections::HashMap<String, String>':
             return f"({ref}.is_object(){null_check})"
         elif base_type.startswith('std::collections::HashMap<String, '):
@@ -1245,21 +1258,17 @@ class AvroToRust:
         union_avro_branches = [
             (source_index, avro_branch)
             for source_index, avro_branch in enumerate(avro_type)
-            if self.avro_annotation or avro_branch != 'null'
+            if avro_branch != 'null'
         ]
         union_avro_types = [
             avro_branch for _, avro_branch in union_avro_branches
         ]
         union_types = [
-            (
-                '()'
-                if avro_branch == 'null'
-                else self.convert_avro_type_to_rust(
-                    field_name + "Option" + str(i),
-                    avro_branch,
-                    namespace,
-                    path=(path or []) + [('branch', str(source_index))],
-                )
+            self.convert_avro_type_to_rust(
+                field_name + "Option" + str(i),
+                avro_branch,
+                namespace,
+                path=(path or []) + [('branch', str(source_index))],
             )
             for i, (source_index, avro_branch) in enumerate(union_avro_branches)
         ]
@@ -1278,15 +1287,10 @@ class AvroToRust:
         seen_names: dict = {}
         union_fields = []
         for i, t in enumerate(union_types):
-            is_null = union_avro_types[i] == 'null'
-            predicate = (
-                'node.is_null()'
-                if is_null
-                else self.get_is_json_match_clause(
-                    field_name,
-                    t,
-                    for_union=True,
-                )
+            predicate = self.get_is_json_match_clause(
+                field_name,
+                t,
+                for_union=True,
             )
             predicate_key = self.get_json_shape_signature(
                 union_avro_types[i],
@@ -1297,7 +1301,7 @@ class AvroToRust:
             seen_predicates.add(predicate_key)
             
             # Deduplicate variant names
-            variant_name = 'Null' if is_null else pascal(t.rsplit('::',1)[-1])
+            variant_name = pascal(t.rsplit('::',1)[-1])
             if variant_name in seen_names:
                 seen_names[variant_name] += 1
                 variant_name = f"{variant_name}{seen_names[variant_name]}"
@@ -1308,39 +1312,26 @@ class AvroToRust:
                 'name': variant_name, 
                 'type': t, 
                 'avro_type': union_avro_types[i],
-                'is_null': is_null,
                 'avro_index': i,
                 'source_avro_index': union_avro_branches[i][0],
-                'avro_decode': (
-                    '()'
-                    if is_null
-                    else self.render_avro_decode_value(
-                        union_avro_types[i],
-                        t,
-                        namespace,
-                        'value',
-                        [0],
-                    )
+                'avro_decode': self.render_avro_decode_value(
+                    union_avro_types[i],
+                    t,
+                    namespace,
+                    'value',
+                    [0],
                 ),
-                'avro_encode': (
-                    'apache_avro::types::Value::Null'
-                    if is_null
-                    else self.render_avro_encode_value(
-                        union_avro_types[i],
-                        t,
-                        namespace,
-                        'value',
-                        [0],
-                    )
+                'avro_encode': self.render_avro_encode_value(
+                    union_avro_types[i],
+                    t,
+                    namespace,
+                    'value',
+                    [0],
                 ),
-                'random_value': (
-                    '()'
-                    if is_null
-                    else self.generate_random_value_for_avro(
-                        t,
-                        union_avro_types[i],
-                        namespace,
-                    )
+                'random_value': self.generate_random_value_for_avro(
+                    t,
+                    union_avro_types[i],
+                    namespace,
                 ),
                 'default_value': 'Default::default()',
                 'json_match_predicate': predicate,
@@ -1388,13 +1379,6 @@ class AvroToRust:
             'xml_annotation': self.xml_annotation,
             'union_enum_name': union_enum_name,
             'union_fields': union_fields,
-            'default_union_field': next(
-                (
-                    field for field in union_fields
-                    if field['is_null']
-                ),
-                union_fields[0],
-            ),
             'xml_string_guards': xml_string_guards,
             'avro_schema': avro_schema_str,
             'json_match_predicates': [
@@ -1433,21 +1417,30 @@ class AvroToRust:
                 self.to_file_name(qualified_alias) + '.rs',
             ).lower()
             module_directory = os.path.splitext(target_file)[0]
-            if os.path.exists(target_file) or os.path.isdir(module_directory):
+            alias_content = (
+                f'pub type {legacy_name} = {unique_targets[0]};\n\n'
+                '#[cfg(test)]\n'
+                'mod tests {\n'
+                '    use super::*;\n\n'
+                '    #[test]\n'
+                '    fn legacy_alias_compiles() {\n'
+                f'        let _ = {legacy_name}::default();\n'
+                '    }\n'
+                '}\n'
+            )
+            if os.path.isdir(module_directory):
+                continue
+            if os.path.exists(target_file):
+                with open(target_file, 'r', encoding='utf-8') as alias_file:
+                    if alias_file.read() != alias_content:
+                        continue
+                self.generated_types_rust_package[qualified_alias] = 'alias'
+                self.write_mod_rs(namespace)
                 continue
             os.makedirs(os.path.dirname(target_file), exist_ok=True)
             with open(target_file, 'w', encoding='utf-8') as alias_file:
-                alias_file.write(
-                    f'pub type {legacy_name} = {unique_targets[0]};\n\n'
-                    '#[cfg(test)]\n'
-                    'mod tests {\n'
-                    '    use super::*;\n\n'
-                    '    #[test]\n'
-                    '    fn legacy_alias_compiles() {\n'
-                    f'        let _ = {legacy_name}::default();\n'
-                    '    }\n'
-                    '}\n'
-                )
+                alias_file.write(alias_content)
+            self.generated_types_rust_package[qualified_alias] = 'alias'
             self.write_mod_rs(namespace)
 
     def get_json_shape_signature(
@@ -1694,9 +1687,13 @@ class AvroToRust:
 
     def write_lib_rs(self):
         """Writes the lib.rs file for the Rust project"""
-        modules = {name[(len('crate::')):].split('::')[0] for name in self.generated_types_rust_package}
+        modules = {
+            self.to_file_name(name).split(os.sep)[0]
+            for name in self.generated_types_rust_package
+        }
         mod_statements = '\n'.join(
-            f'pub mod {module};' for module in sorted(modules)
+            f'pub mod {self.escaped_identifier(module)};'
+            for module in sorted(modules)
         )
         if self.xml_annotation:
             mod_statements = 'pub(crate) mod xml_support;\n' + mod_statements
@@ -1750,9 +1747,30 @@ class AvroToRust:
                 tuple(part.lower() for part in namespace.split('.'))
                 if namespace else ()
             )
+            if 'mod' in namespace_parts:
+                raise ValueError(
+                    'Avro named type namespace collides with generated Rust '
+                    f"mod.rs path: '{fullname}'"
+                )
+            if namespace_parts and namespace_parts[0] == 'lib':
+                raise ValueError(
+                    'Avro named type namespace collides with generated Rust '
+                    f"lib.rs path: '{fullname}'"
+                )
             normalized_path = (
                 namespace_parts + (rust_name.lower(),)
             )
+            if normalized_path[-1] == 'mod':
+                path_text = '::'.join(normalized_path)
+                raise ValueError(
+                    'Avro named type collides with generated Rust mod.rs '
+                    f"path '{path_text}': '{fullname}'"
+                )
+            if normalized_path == ('lib',):
+                raise ValueError(
+                    'Avro named type collides with generated Rust lib.rs '
+                    f"path 'lib': '{fullname}'"
+                )
             existing = rust_paths.get(normalized_path)
             if existing is not None and existing != fullname:
                 path_text = '::'.join(str(part) for part in normalized_path)

--- a/avrotize/avrotorust.py
+++ b/avrotize/avrotorust.py
@@ -1790,17 +1790,29 @@ class AvroToRust:
         alias_candidates = {}
         visited_named = set()
 
-        def add(path, description):
+        def add(path, kind, identity, description):
             path = tuple(part.lower() for part in path)
             existing = planned.get(path)
-            if existing is not None and existing != description:
+            artifact = {
+                'kind': kind,
+                'identity': identity,
+                'description': description,
+            }
+            if existing is not None and (
+                existing['kind'] != kind
+                or existing['identity'] != identity
+                or kind not in ('union', 'infrastructure')
+            ):
                 path_text = '::'.join(path)
-                first, second = sorted((existing, description))
+                first, second = sorted((
+                    existing['description'],
+                    description,
+                ))
                 raise ValueError(
                     'Rust generation plan has an exact path collision at '
                     f"'{path_text}': '{first}' and '{second}'"
                 )
-            planned[path] = description
+            planned[path] = artifact
 
         def visit(node, namespace='', path=None, field_name=''):
             if isinstance(node, str):
@@ -1828,15 +1840,27 @@ class AvroToRust:
                     union_output_path = (
                         namespace_parts + (union_name.lower(),)
                     )
-                    if (
-                        self.avro_annotation
-                        or union_output_path not in planned
-                    ):
-                        add(
-                            union_output_path,
-                            f"generated union {union_name} at "
-                            f"{path or [('field', field_name)]}",
+                    union_identity = (
+                        union_name
+                        if self.avro_annotation
+                        else (
+                            union_name,
+                            json.dumps(
+                                self.inline_avro_references(
+                                    [item for _, item in non_null],
+                                    namespace,
+                                ),
+                                sort_keys=True,
+                            ),
                         )
+                    )
+                    add(
+                        union_output_path,
+                        'union',
+                        union_identity,
+                        f"generated union {union_name} at "
+                        f"{path or [('field', field_name)]}",
+                    )
                     if self.avro_annotation:
                         legacy_name = pascal(field_name) + 'Union'
                         alias_candidates.setdefault(
@@ -1883,6 +1907,8 @@ class AvroToRust:
                                 pascal(short_name)
                             ).lower(),
                         ),
+                        'named',
+                        fullname,
                         f"named type {fullname}",
                     )
                 if fullname in visited_named:
@@ -1927,13 +1953,15 @@ class AvroToRust:
                 if len(targets) == 1:
                     union_name = next(iter(targets))
                     alias_name = legacy_name.lower()
-                    add(
-                        namespace_parts + (alias_name,),
-                        f"legacy union alias {legacy_name}",
-                    )
                     namespace = '::'.join(namespace_parts)
                     qualified_target = self.safe_package(
                         self.concat_package(namespace, union_name)
+                    )
+                    add(
+                        namespace_parts + (alias_name,),
+                        'alias',
+                        qualified_target,
+                        f"legacy union alias {legacy_name}",
                     )
                     alias_content = self.union_alias_content(
                         legacy_name,
@@ -1974,11 +2002,18 @@ class AvroToRust:
                     self.planned_alias_contents[alias_path] = alias_content
 
         source_paths = list(planned)
-        add(('lib',), 'generated infrastructure lib.rs')
+        add(
+            ('lib',),
+            'infrastructure',
+            'lib.rs',
+            'generated infrastructure lib.rs',
+        )
         for source_path in source_paths:
             for length in range(1, len(source_path)):
                 add(
                     source_path[:length] + ('mod',),
+                    'infrastructure',
+                    '::'.join(source_path[:length]) + '::mod.rs',
                     'generated infrastructure mod.rs for '
                     + '::'.join(source_path[:length]),
                 )
@@ -1993,7 +2028,10 @@ class AvroToRust:
             ):
                 path_text = '::'.join(file_path)
                 first, second = sorted(
-                    (planned[file_path], planned[other_path])
+                    (
+                        planned[file_path]['description'],
+                        planned[other_path]['description'],
+                    )
                 )
                 raise ValueError(
                     'Rust generation plan requires the same path '

--- a/avrotize/avrotorust.py
+++ b/avrotize/avrotorust.py
@@ -24,6 +24,13 @@ class AvroToRust:
     def __init__(self, base_package: str = '') -> None:
         self.base_package = base_package.replace('.', '/').lower()
         self.output_dir = os.getcwd()
+        self.avro_annotation = False
+        self.serde_annotation = False
+        self.xml_annotation = False
+        self.reset_run_state()
+
+    def reset_run_state(self):
+        """Resets state that belongs to one conversion output."""
         self.generated_types_avro_namespace: Dict[str, str] = {}
         self.generated_types_rust_package: Dict[str, str] = {}
         self.generated_union_fields: Dict[str, List[Dict]] = {}
@@ -40,9 +47,6 @@ class AvroToRust:
         self.planned_source_paths: set[tuple[str, ...]] = set()
         self.union_schema_targets: Dict[tuple, str] = {}
         self.union_targets_in_progress: set[tuple] = set()
-        self.avro_annotation = False
-        self.serde_annotation = False
-        self.xml_annotation = False
         
     reserved_words = [
             'as', 'break', 'const', 'continue', 'crate', 'else', 'enum', 'extern', 'false', 'fn', 'for', 'if', 'impl',
@@ -1802,6 +1806,7 @@ class AvroToRust:
 
     def convert_schema(self, schema: JsonNode, output_dir: str):
         """Converts Avro schema to Rust"""
+        self.reset_run_state()
         if not isinstance(schema, list):
             schema = [schema]
         self.index_avro_named_types(schema)
@@ -2077,6 +2082,13 @@ class AvroToRust:
             'lib.rs',
             'generated infrastructure lib.rs',
         )
+        if self.xml_annotation:
+            add(
+                ('xml_support',),
+                'infrastructure',
+                'xml_support.rs',
+                'generated infrastructure xml_support.rs',
+            )
         for source_path in source_paths:
             for length in range(1, len(source_path)):
                 add(

--- a/avrotize/avrotorust.py
+++ b/avrotize/avrotorust.py
@@ -853,20 +853,9 @@ class AvroToRust:
                     rust_type[7:-1]
                     if rust_type.startswith('Option<') else rust_type
                 )
-                union_fields = self.generated_union_fields.get(union_type, [])
-                arms = []
-                for union_field in union_fields:
-                    arms.append(
-                        f'''{union_type}::{union_field["name"]}(value) =>
-                            apache_avro::types::Value::Union(
-                                {union_field["source_avro_index"]},
-                                Box::new({union_field["avro_encode"]}),
-                            )'''
-                    )
-                arms_text = ',\n'.join(arms)
-                return f'''match {value_expression} {{
-                    {arms_text},
-                }}'''
+                return (
+                    f'({value_expression}).to_avro_source_value()?'
+                )
 
             if len(non_null_types) == 1:
                 inner_type = (
@@ -1029,39 +1018,10 @@ class AvroToRust:
                     rust_type[7:-1]
                     if rust_type.startswith('Option<') else rust_type
                 )
-                union_fields = self.generated_union_fields.get(union_type, [])
-                null_index = avro_type.index('null') if 'null' in avro_type else -1
-                arms = []
-                if null_index >= 0:
-                    if rust_type.startswith('Option<'):
-                        arms.append(f'{null_index} => None')
-                    else:
-                        arms.append(
-                            f'''{null_index} => return Err(
-                                "nullable Avro union null is unsupported by the generated Rust union API".into()
-                            )'''
-                        )
-                for union_field in union_fields:
-                    decoded = (
-                        f'{union_type}::from_avro_branch('
-                        f'{union_field["avro_index"]}, value)?'
-                    )
-                    if rust_type.startswith('Option<'):
-                        decoded = f'Some({decoded})'
-                    arms.append(
-                        f'{union_field["source_avro_index"]} => {decoded}'
-                    )
-                arms_text = ',\n'.join(arms)
-                return f'''match {value_expression} {{
-                    apache_avro::types::Value::Union(index, value) => match index {{
-                        {arms_text},
-                        _ => return Err(format!(
-                            "unsupported Avro union branch {{}}",
-                            index,
-                        ).into()),
-                    }},
-                    _ => return Err("expected an Avro union value".into()),
-                }}'''
+                return (
+                    f'{union_type}::from_avro_source_value('
+                    f'{value_expression})?'
+                )
 
             if len(non_null_types) == 1:
                 inner_rust_type = (

--- a/avrotize/avrotorust.py
+++ b/avrotize/avrotorust.py
@@ -34,6 +34,7 @@ class AvroToRust:
         self.union_path_identities: Dict[str, str] = {}
         self.union_alias_candidates: Dict[tuple[str, str], List[str]] = {}
         self.planned_alias_contents: Dict[str, str] = {}
+        self.generated_aliases_to_remove: List[tuple[str, str]] = []
         self.avro_annotation = False
         self.serde_annotation = False
         self.xml_annotation = False
@@ -1272,9 +1273,8 @@ class AvroToRust:
     ) -> str:
         """Generates a union enum for Rust"""
         ns = namespace.replace('.', '::').lower()
-        union_enum_name = (
-            self.union_name_from_path(path or [('field', field_name)])
-            if self.avro_annotation else pascal(field_name) + 'Union'
+        union_enum_name = self.union_name_from_path(
+            path or [('field', field_name)]
         )
         union_avro_branches = [
             (source_index, avro_branch)
@@ -1388,12 +1388,11 @@ class AvroToRust:
         }
         
         qualified_union_enum_name = self.safe_package(self.concat_package(ns, union_enum_name))
-        if self.avro_annotation:
-            legacy_name = pascal(field_name) + 'Union'
-            self.union_alias_candidates.setdefault(
-                (namespace, legacy_name),
-                [],
-            ).append(qualified_union_enum_name)
+        legacy_name = pascal(field_name) + 'Union'
+        self.union_alias_candidates.setdefault(
+            (namespace, legacy_name),
+            [],
+        ).append(qualified_union_enum_name)
         context = {
             'serde_annotation': self.serde_annotation,
             'avro_annotation': self.avro_annotation,
@@ -1420,6 +1419,10 @@ class AvroToRust:
 
     def write_union_aliases(self):
         """Emits legacy Avro union names when they are unambiguous."""
+        for alias_path, namespace in self.generated_aliases_to_remove:
+            if os.path.exists(alias_path):
+                os.remove(alias_path)
+                self.write_mod_rs(namespace)
         for (namespace, legacy_name), targets in sorted(
             self.union_alias_candidates.items()
         ):
@@ -1490,6 +1493,18 @@ class AvroToRust:
             r'\}\n$'
         )
         return re.fullmatch(pattern, content) is not None
+
+    @staticmethod
+    def is_legacy_generated_union(content: str, legacy_name: str) -> bool:
+        """Checks whether source is a previously generated union module."""
+        markers = (
+            f'pub enum {legacy_name} {{',
+            f'impl Default for {legacy_name} {{',
+            'pub fn is_json_match(',
+            'pub fn generate_random_instance()',
+            f'fn test_union_variants_{legacy_name.lower()}()',
+        )
+        return all(marker in content for marker in markers)
 
     def get_json_shape_signature(
         self,
@@ -1826,12 +1841,8 @@ class AvroToRust:
                     if item != 'null'
                 ]
                 if len(non_null) > 1:
-                    union_name = (
-                        self.union_name_from_path(
-                            path or [('field', field_name)]
-                        )
-                        if self.avro_annotation
-                        else pascal(field_name) + 'Union'
+                    union_name = self.union_name_from_path(
+                        path or [('field', field_name)]
                     )
                     namespace_parts = (
                         tuple(namespace.lower().split('.'))
@@ -1840,20 +1851,7 @@ class AvroToRust:
                     union_output_path = (
                         namespace_parts + (union_name.lower(),)
                     )
-                    union_identity = (
-                        union_name
-                        if self.avro_annotation
-                        else (
-                            union_name,
-                            json.dumps(
-                                self.inline_avro_references(
-                                    [item for _, item in non_null],
-                                    namespace,
-                                ),
-                                sort_keys=True,
-                            ),
-                        )
-                    )
+                    union_identity = union_name
                     add(
                         union_output_path,
                         'union',
@@ -1861,12 +1859,11 @@ class AvroToRust:
                         f"generated union {union_name} at "
                         f"{path or [('field', field_name)]}",
                     )
-                    if self.avro_annotation:
-                        legacy_name = pascal(field_name) + 'Union'
-                        alias_candidates.setdefault(
-                            (namespace_parts, legacy_name),
-                            set(),
-                        ).add(union_name)
+                    legacy_name = pascal(field_name) + 'Union'
+                    alias_candidates.setdefault(
+                        (namespace_parts, legacy_name),
+                        set(),
+                    ).add(union_name)
                     for source_index, branch in non_null:
                         visit(
                             branch,
@@ -1946,60 +1943,88 @@ class AvroToRust:
         for top_level in schema:
             visit(top_level)
 
-        if self.avro_annotation:
-            for (namespace_parts, legacy_name), targets in sorted(
-                alias_candidates.items()
-            ):
-                if len(targets) == 1:
-                    union_name = next(iter(targets))
-                    alias_name = legacy_name.lower()
-                    namespace = '::'.join(namespace_parts)
-                    qualified_target = self.safe_package(
-                        self.concat_package(namespace, union_name)
-                    )
-                    add(
-                        namespace_parts + (alias_name,),
-                        'alias',
-                        qualified_target,
-                        f"legacy union alias {legacy_name}",
-                    )
-                    alias_content = self.union_alias_content(
-                        legacy_name,
-                        qualified_target,
-                    )
-                    relative_parts = list(namespace_parts) + [
-                        alias_name + '.rs'
-                    ]
-                    alias_path = os.path.join(
-                        self.output_dir,
-                        'src',
-                        *relative_parts,
-                    )
-                    alias_directory = os.path.splitext(alias_path)[0]
-                    if os.path.isdir(alias_directory):
+        for (namespace_parts, legacy_name), targets in sorted(
+            alias_candidates.items()
+        ):
+            alias_name = legacy_name.lower()
+            relative_parts = list(namespace_parts) + [
+                alias_name + '.rs'
+            ]
+            alias_path = os.path.join(
+                self.output_dir,
+                'src',
+                *relative_parts,
+            )
+            alias_directory = os.path.splitext(alias_path)[0]
+            namespace = '::'.join(namespace_parts)
+            existing_content = None
+            if os.path.isdir(alias_directory):
+                raise ValueError(
+                    'Existing directory conflicts with planned legacy '
+                    f"union alias: '{alias_path}'"
+                )
+            if os.path.exists(alias_path):
+                with open(
+                    alias_path,
+                    'r',
+                    encoding='utf-8',
+                ) as alias_file:
+                    existing_content = alias_file.read()
+
+            if len(targets) != 1:
+                if existing_content is not None:
+                    if (
+                        self.is_generated_union_alias(
+                            existing_content,
+                            legacy_name,
+                        )
+                        or self.is_legacy_generated_union(
+                            existing_content,
+                            legacy_name,
+                        )
+                    ):
+                        self.generated_aliases_to_remove.append(
+                            (alias_path, namespace)
+                        )
+                    else:
                         raise ValueError(
-                            'Existing directory conflicts with planned '
+                            'Existing file conflicts with ambiguous legacy '
+                            f"union alias: '{alias_path}'"
+                        )
+                continue
+
+            if len(targets) == 1:
+                union_name = next(iter(targets))
+                qualified_target = self.safe_package(
+                    self.concat_package(namespace, union_name)
+                )
+                add(
+                    namespace_parts + (alias_name,),
+                    'alias',
+                    qualified_target,
+                    f"legacy union alias {legacy_name}",
+                )
+                alias_content = self.union_alias_content(
+                    legacy_name,
+                    qualified_target,
+                )
+                if existing_content is not None:
+                    if (
+                        existing_content != alias_content
+                        and not self.is_generated_union_alias(
+                            existing_content,
+                            legacy_name,
+                        )
+                        and not self.is_legacy_generated_union(
+                            existing_content,
+                            legacy_name,
+                        )
+                    ):
+                        raise ValueError(
+                            'Existing file conflicts with planned '
                             f"legacy union alias: '{alias_path}'"
                         )
-                    if os.path.exists(alias_path):
-                        with open(
-                            alias_path,
-                            'r',
-                            encoding='utf-8',
-                        ) as alias_file:
-                            existing_content = alias_file.read()
-                        if (
-                            existing_content != alias_content
-                            and not self.is_generated_union_alias(
-                                existing_content,
-                                legacy_name,
-                            )
-                        ):
-                            raise ValueError(
-                                'Existing file conflicts with planned '
-                                f"legacy union alias: '{alias_path}'"
-                            )
-                    self.planned_alias_contents[alias_path] = alias_content
+                self.planned_alias_contents[alias_path] = alias_content
 
         source_paths = list(planned)
         add(

--- a/avrotize/avrotorust.py
+++ b/avrotize/avrotorust.py
@@ -24,6 +24,7 @@ class AvroToRust:
         self.output_dir = os.getcwd()
         self.generated_types_avro_namespace: Dict[str, str] = {}
         self.generated_types_rust_package: Dict[str, str] = {}
+        self.generated_union_fields: Dict[str, List[Dict]] = {}
         self.avro_named_types: Dict[str, Dict] = {}
         self.avro_annotation = False
         self.serde_annotation = False
@@ -96,23 +97,26 @@ class AvroToRust:
         ns = namespace.replace('.', '::').lower()
         type_name = ''
         if isinstance(avro_type, str):
-            qualified_avro_name = (
-                f"{namespace}.{avro_type}"
-                if namespace and '.' not in avro_type else avro_type
-            )
-            named_type = (
-                self.avro_named_types.get(qualified_avro_name)
-                or self.avro_named_types.get(avro_type)
-            )
-            if named_type and named_type.get('type') in ('record', 'enum', 'fixed'):
-                named_namespace = named_type.get('namespace', namespace)
-                rust_namespace = named_namespace.replace('.', '::').lower()
-                rust_name = self.safe_identifier(pascal(named_type['name']))
-                type_name = self.safe_package(
-                    self.concat_package(rust_namespace, rust_name)
-                )
-            else:
+            if is_any_value_type(avro_type):
                 type_name = self.map_primitive_to_rust(avro_type, nullable)
+            else:
+                qualified_avro_name = (
+                    f"{namespace}.{avro_type}"
+                    if namespace and '.' not in avro_type else avro_type
+                )
+                named_type = (
+                    self.avro_named_types.get(qualified_avro_name)
+                    or self.avro_named_types.get(avro_type)
+                )
+                if named_type and named_type.get('type') in ('record', 'enum', 'fixed'):
+                    named_namespace = named_type.get('namespace', namespace)
+                    rust_namespace = named_namespace.replace('.', '::').lower()
+                    rust_name = self.safe_identifier(pascal(named_type['name']))
+                    type_name = self.safe_package(
+                        self.concat_package(rust_namespace, rust_name)
+                    )
+                else:
+                    type_name = self.map_primitive_to_rust(avro_type, nullable)
         elif isinstance(avro_type, list):
             if is_generic_avro_type(avro_type):
                 return 'serde_json::Value' if self.serde_annotation or self.xml_annotation else 'std::collections::HashMap<String, String>'
@@ -386,6 +390,21 @@ class AvroToRust:
             serde_rename = field_name != serde_name
             # Check if this is a generated type (enum, union, or record) where random values may match default
             is_generated_type = field_type in self.generated_types_rust_package or '::' in field_type
+            base_field_type = (
+                field_type[7:-1]
+                if field_type.startswith('Option<') else field_type
+            )
+            avro_union_fields = (
+                self.generated_union_fields.get(base_field_type, [])
+                if self.avro_annotation else []
+            )
+            source_null_index = (
+                field['type'].index('null')
+                if avro_union_fields
+                and isinstance(field['type'], list)
+                and 'null' in field['type']
+                else -1
+            )
             fields.append({
                 'original_name': original_field_name,
                 'json_name': original_field_name,
@@ -398,7 +417,11 @@ class AvroToRust:
                 'serde_rename': serde_rename,
                 'is_optional': field_type.startswith('Option<'),
                 'random_value': self.generate_random_value(field_type),
-                'is_generated_type': is_generated_type
+                'is_generated_type': is_generated_type,
+                'is_avro_union': bool(avro_union_fields),
+                'avro_union_type': base_field_type,
+                'avro_union_fields': avro_union_fields,
+                'avro_null_index': source_null_index,
             })
         
         struct_name = self.safe_identifier(pascal(avro_schema['name']))
@@ -548,7 +571,14 @@ class AvroToRust:
         """Generates a union enum for Rust"""
         ns = namespace.replace('.', '::').lower()
         union_enum_name = pascal(field_name) + 'Union'
-        union_avro_types = [t for t in avro_type if t != 'null']
+        union_avro_branches = [
+            (source_index, avro_branch)
+            for source_index, avro_branch in enumerate(avro_type)
+            if avro_branch != 'null'
+        ]
+        union_avro_types = [
+            avro_branch for _, avro_branch in union_avro_branches
+        ]
         union_types = [
             self.convert_avro_type_to_rust(
                 field_name + "Option" + str(i),
@@ -589,6 +619,7 @@ class AvroToRust:
                 'name': variant_name, 
                 'type': t, 
                 'avro_index': i,
+                'source_avro_index': union_avro_branches[i][0],
                 'random_value': self.generate_random_value(t),
                 'default_value': 'Default::default()',
                 'json_match_predicate': predicate,
@@ -640,6 +671,7 @@ class AvroToRust:
         render_template('avrotorust/dataclass_union.rs.jinja', target_file, **context)
         self.generated_types_avro_namespace[qualified_union_enum_name] = "union"
         self.generated_types_rust_package[qualified_union_enum_name] = "union"
+        self.generated_union_fields[qualified_union_enum_name] = union_fields
         self.write_mod_rs(namespace)
 
         return qualified_union_enum_name

--- a/avrotize/avrotorust.py
+++ b/avrotize/avrotorust.py
@@ -1,6 +1,7 @@
 import json
 import os
 import hashlib
+import re
 from typing import Dict, List, Union
 from avrotize.common import (
     is_generic_avro_type,
@@ -32,6 +33,7 @@ class AvroToRust:
         self.avro_type_fullnames: Dict[int, str] = {}
         self.union_path_identities: Dict[str, str] = {}
         self.union_alias_candidates: Dict[tuple[str, str], List[str]] = {}
+        self.planned_alias_contents: Dict[str, str] = {}
         self.avro_annotation = False
         self.serde_annotation = False
         self.xml_annotation = False
@@ -159,12 +161,6 @@ class AvroToRust:
                         namespace,
                         path=path,
                     )
-                if (
-                    self.avro_annotation
-                    and 'null' in avro_type
-                    and not type_name.startswith('Option<')
-                ):
-                    type_name = f'Option<{type_name}>'
             else:
                 type_name = self.generate_union_enum(
                     field_name,
@@ -596,9 +592,11 @@ class AvroToRust:
             )
             source_null_index = (
                 field['type'].index('null')
-                if avro_union_fields
-                and isinstance(field['type'], list)
+                if isinstance(field['type'], list)
                 and 'null' in field['type']
+                and any(item != 'null' for item in field['type'])
+                and not is_generic_avro_type(field['type'])
+                and not field_type.startswith('Option<')
                 else -1
             )
             avro_decode = (
@@ -862,7 +860,11 @@ class AvroToRust:
                     non_null_types[0],
                     inner_type,
                     namespace,
-                    'value',
+                    (
+                        'value'
+                        if rust_type.startswith('Option<')
+                        else value_expression
+                    ),
                     counter,
                 )
                 null_index = avro_type.index('null')
@@ -870,16 +872,21 @@ class AvroToRust:
                     index for index, item in enumerate(avro_type)
                     if item != 'null'
                 )
-                return f'''match {value_expression} {{
-                    None => apache_avro::types::Value::Union(
-                        {null_index},
-                        Box::new(apache_avro::types::Value::Null),
-                    ),
-                    Some(value) => apache_avro::types::Value::Union(
-                        {value_index},
-                        Box::new({inner_encode}),
-                    ),
-                }}'''
+                if rust_type.startswith('Option<'):
+                    return f'''match {value_expression} {{
+                        None => apache_avro::types::Value::Union(
+                            {null_index},
+                            Box::new(apache_avro::types::Value::Null),
+                        ),
+                        Some(value) => apache_avro::types::Value::Union(
+                            {value_index},
+                            Box::new({inner_encode}),
+                        ),
+                    }}'''
+                return f'''apache_avro::types::Value::Union(
+                    {value_index},
+                    Box::new({inner_encode}),
+                )'''
 
         resolved_type = avro_type
         if isinstance(avro_type, str):
@@ -1056,10 +1063,24 @@ class AvroToRust:
                     index for index, item in enumerate(avro_type)
                     if item != 'null'
                 )
+                if rust_type.startswith('Option<'):
+                    return f'''match {value_expression} {{
+                        apache_avro::types::Value::Union(index, value) => match index {{
+                            {null_index} => None,
+                            {value_index} => Some({inner_decode}),
+                            _ => return Err(format!(
+                                "unsupported Avro optional branch {{}}",
+                                index,
+                            ).into()),
+                        }},
+                        _ => return Err("expected an Avro optional value".into()),
+                    }}'''
                 return f'''match {value_expression} {{
                     apache_avro::types::Value::Union(index, value) => match index {{
-                        {null_index} => None,
-                        {value_index} => Some({inner_decode}),
+                        {null_index} => return Err(
+                            "nullable Avro complex null is unsupported by the generated Rust API".into()
+                        ),
+                        {value_index} => {inner_decode},
                         _ => return Err(format!(
                             "unsupported Avro optional branch {{}}",
                             index,
@@ -1388,7 +1409,7 @@ class AvroToRust:
         }
 
         file_name = self.to_file_name(qualified_union_enum_name)
-        target_file = os.path.join(self.output_dir, "src", file_name + ".rs").lower()
+        target_file = os.path.join(self.output_dir, "src", file_name + ".rs")
         render_template('avrotorust/dataclass_union.rs.jinja', target_file, **context)
         self.generated_types_avro_namespace[qualified_union_enum_name] = "union"
         self.generated_types_rust_package[qualified_union_enum_name] = "union"
@@ -1415,33 +1436,60 @@ class AvroToRust:
                 self.output_dir,
                 'src',
                 self.to_file_name(qualified_alias) + '.rs',
-            ).lower()
+            )
             module_directory = os.path.splitext(target_file)[0]
-            alias_content = (
-                f'pub type {legacy_name} = {unique_targets[0]};\n\n'
-                '#[cfg(test)]\n'
-                'mod tests {\n'
-                '    use super::*;\n\n'
-                '    #[test]\n'
-                '    fn legacy_alias_compiles() {\n'
-                f'        let _ = {legacy_name}::default();\n'
-                '    }\n'
-                '}\n'
+            alias_content = self.union_alias_content(
+                legacy_name,
+                unique_targets[0],
             )
             if os.path.isdir(module_directory):
                 continue
             if os.path.exists(target_file):
                 with open(target_file, 'r', encoding='utf-8') as alias_file:
-                    if alias_file.read() != alias_content:
-                        continue
-                self.generated_types_rust_package[qualified_alias] = 'alias'
-                self.write_mod_rs(namespace)
-                continue
+                    existing_content = alias_file.read()
+                if existing_content == alias_content:
+                    self.generated_types_rust_package[qualified_alias] = 'alias'
+                    self.write_mod_rs(namespace)
+                    continue
             os.makedirs(os.path.dirname(target_file), exist_ok=True)
-            with open(target_file, 'w', encoding='utf-8') as alias_file:
+            temporary_file = target_file + '.tmp'
+            with open(temporary_file, 'w', encoding='utf-8') as alias_file:
                 alias_file.write(alias_content)
+            os.replace(temporary_file, target_file)
             self.generated_types_rust_package[qualified_alias] = 'alias'
             self.write_mod_rs(namespace)
+
+    @staticmethod
+    def union_alias_content(legacy_name: str, target: str) -> str:
+        """Returns the complete generated legacy alias source."""
+        return (
+            f'pub type {legacy_name} = {target};\n\n'
+            '#[cfg(test)]\n'
+            'mod tests {\n'
+            '    use super::*;\n\n'
+            '    #[test]\n'
+            '    fn legacy_alias_compiles() {\n'
+            f'        let _ = {legacy_name}::default();\n'
+            '    }\n'
+            '}\n'
+        )
+
+    @staticmethod
+    def is_generated_union_alias(content: str, legacy_name: str) -> bool:
+        """Checks whether source is a previously generated alias file."""
+        pattern = (
+            rf'^pub type {re.escape(legacy_name)} = '
+            r'crate::[A-Za-z0-9_#:]+;\n\n'
+            r'#\[cfg\(test\)\]\n'
+            r'mod tests \{\n'
+            r'    use super::\*;\n\n'
+            r'    #\[test\]\n'
+            r'    fn legacy_alias_compiles\(\) \{\n'
+            rf'        let _ = {re.escape(legacy_name)}::default\(\);\n'
+            r'    \}\n'
+            r'\}\n$'
+        )
+        return re.fullmatch(pattern, content) is not None
 
     def get_json_shape_signature(
         self,
@@ -1633,6 +1681,8 @@ class AvroToRust:
 
     def write_mod_rs(self, namespace: str):
         """Writes the mod.rs file for a Rust module"""
+        if not namespace:
+            return
         directories = [part.lower() for part in namespace.split('.')]
         for i in range(len(directories)):
             sub_package = '::'.join(directories[:i + 1])
@@ -1722,10 +1772,10 @@ class AvroToRust:
         if not isinstance(schema, list):
             schema = [schema]
         self.index_avro_named_types(schema)
+        self.output_dir = output_dir
         self.validate_rust_generation_plan(schema)
         if not os.path.exists(output_dir):
             os.makedirs(output_dir, exist_ok=True)
-        self.output_dir = output_dir
         for avro_schema in (x for x in schema if isinstance(x, dict)):
             self.generate_class_or_enum(avro_schema)
 
@@ -1745,9 +1795,10 @@ class AvroToRust:
             existing = planned.get(path)
             if existing is not None and existing != description:
                 path_text = '::'.join(path)
+                first, second = sorted((existing, description))
                 raise ValueError(
                     'Rust generation plan has an exact path collision at '
-                    f"'{path_text}': '{existing}' and '{description}'"
+                    f"'{path_text}': '{first}' and '{second}'"
                 )
             planned[path] = description
 
@@ -1789,7 +1840,7 @@ class AvroToRust:
                     if self.avro_annotation:
                         legacy_name = pascal(field_name) + 'Union'
                         alias_candidates.setdefault(
-                            (namespace_parts, legacy_name.lower()),
+                            (namespace_parts, legacy_name),
                             set(),
                         ).add(union_name)
                     for source_index, branch in non_null:
@@ -1870,14 +1921,57 @@ class AvroToRust:
             visit(top_level)
 
         if self.avro_annotation:
-            for (namespace_parts, alias_name), targets in sorted(
+            for (namespace_parts, legacy_name), targets in sorted(
                 alias_candidates.items()
             ):
                 if len(targets) == 1:
+                    union_name = next(iter(targets))
+                    alias_name = legacy_name.lower()
                     add(
                         namespace_parts + (alias_name,),
-                        f"legacy union alias {alias_name}",
+                        f"legacy union alias {legacy_name}",
                     )
+                    namespace = '::'.join(namespace_parts)
+                    qualified_target = self.safe_package(
+                        self.concat_package(namespace, union_name)
+                    )
+                    alias_content = self.union_alias_content(
+                        legacy_name,
+                        qualified_target,
+                    )
+                    relative_parts = list(namespace_parts) + [
+                        alias_name + '.rs'
+                    ]
+                    alias_path = os.path.join(
+                        self.output_dir,
+                        'src',
+                        *relative_parts,
+                    )
+                    alias_directory = os.path.splitext(alias_path)[0]
+                    if os.path.isdir(alias_directory):
+                        raise ValueError(
+                            'Existing directory conflicts with planned '
+                            f"legacy union alias: '{alias_path}'"
+                        )
+                    if os.path.exists(alias_path):
+                        with open(
+                            alias_path,
+                            'r',
+                            encoding='utf-8',
+                        ) as alias_file:
+                            existing_content = alias_file.read()
+                        if (
+                            existing_content != alias_content
+                            and not self.is_generated_union_alias(
+                                existing_content,
+                                legacy_name,
+                            )
+                        ):
+                            raise ValueError(
+                                'Existing file conflicts with planned '
+                                f"legacy union alias: '{alias_path}'"
+                            )
+                    self.planned_alias_contents[alias_path] = alias_content
 
         source_paths = list(planned)
         add(('lib',), 'generated infrastructure lib.rs')
@@ -1898,11 +1992,13 @@ class AvroToRust:
                 other_path[:len(file_path)] == file_path
             ):
                 path_text = '::'.join(file_path)
+                first, second = sorted(
+                    (planned[file_path], planned[other_path])
+                )
                 raise ValueError(
                     'Rust generation plan requires the same path '
                     f"'{path_text}' as both a file and directory: "
-                    f"'{planned[file_path]}' and "
-                    f"'{planned[other_path]}'"
+                    f"'{first}' and '{second}'"
                 )
 
     def convert(self, avro_schema_path: str, output_dir: str):

--- a/avrotize/avrotorust.py
+++ b/avrotize/avrotorust.py
@@ -137,7 +137,17 @@ class AvroToRust:
             non_null_types = [t for t in avro_type if t != 'null']
             if len(non_null_types) == 1:
                 if isinstance(non_null_types[0], str):
-                    type_name = self.map_primitive_to_rust(non_null_types[0], True)
+                    inner_type = self.convert_avro_type_to_rust(
+                        field_name,
+                        non_null_types[0],
+                        namespace,
+                        path=path,
+                    )
+                    type_name = (
+                        inner_type
+                        if inner_type.startswith('Option<')
+                        else f'Option<{inner_type}>'
+                    )
                 else:
                     type_name = self.convert_avro_type_to_rust(
                         field_name,
@@ -1714,10 +1724,11 @@ class AvroToRust:
         """Converts Avro schema to Rust"""
         if not isinstance(schema, list):
             schema = [schema]
+        self.index_avro_named_types(schema)
+        self.validate_rust_type_paths()
         if not os.path.exists(output_dir):
             os.makedirs(output_dir, exist_ok=True)
         self.output_dir = output_dir
-        self.index_avro_named_types(schema)
         for avro_schema in (x for x in schema if isinstance(x, dict)):
             self.generate_class_or_enum(avro_schema)
 
@@ -1725,6 +1736,28 @@ class AvroToRust:
         self.write_cargo_toml()
         self.write_xml_support_rs()
         self.write_lib_rs()
+
+    def validate_rust_type_paths(self):
+        """Rejects canonical Avro names that normalize to one Rust path."""
+        rust_paths = {}
+        for fullname in sorted(self.avro_named_types):
+            node = self.avro_named_types[fullname]
+            if node.get('type') not in ('record', 'enum'):
+                continue
+            namespace, _, short_name = fullname.rpartition('.')
+            rust_name = self.safe_identifier(pascal(short_name))
+            normalized_path = (
+                tuple(part.lower() for part in namespace.split('.'))
+                + (rust_name.lower(),)
+            )
+            existing = rust_paths.get(normalized_path)
+            if existing is not None and existing != fullname:
+                path_text = '::'.join(str(part) for part in normalized_path)
+                raise ValueError(
+                    'Avro named types normalize to the same Rust path '
+                    f"'{path_text}': '{existing}' and '{fullname}'"
+                )
+            rust_paths[normalized_path] = fullname
 
     def convert(self, avro_schema_path: str, output_dir: str):
         """Converts Avro schema to Rust"""

--- a/avrotize/avrotorust.py
+++ b/avrotize/avrotorust.py
@@ -1,5 +1,6 @@
 import json
 import os
+import hashlib
 from typing import Dict, List, Union
 from avrotize.common import (
     is_generic_avro_type,
@@ -27,7 +28,9 @@ class AvroToRust:
         self.generated_union_fields: Dict[str, List[Dict]] = {}
         self.generated_struct_avro_test_values: Dict[str, List[str]] = {}
         self.avro_named_types: Dict[str, Dict] = {}
-        self.current_record_name = ''
+        self.avro_short_names: Dict[str, List[str]] = {}
+        self.avro_type_fullnames: Dict[int, str] = {}
+        self.union_path_identities: Dict[str, str] = {}
         self.avro_annotation = False
         self.serde_annotation = False
         self.xml_annotation = False
@@ -94,7 +97,14 @@ class AvroToRust:
         """Concatenates package and name using a double colon separator"""
         return f"crate::{package.lower()}::{name.lower()}::{name}" if package else name
 
-    def convert_avro_type_to_rust(self, field_name: str, avro_type: Union[str, Dict, List], namespace: str, nullable: bool = False) -> str:
+    def convert_avro_type_to_rust(
+        self,
+        field_name: str,
+        avro_type: Union[str, Dict, List],
+        namespace: str,
+        nullable: bool = False,
+        path=None,
+    ) -> str:
         """Converts Avro type to Rust type"""
         ns = namespace.replace('.', '::').lower()
         type_name = ''
@@ -102,18 +112,14 @@ class AvroToRust:
             if is_any_value_type(avro_type):
                 type_name = self.map_primitive_to_rust(avro_type, nullable)
             else:
-                qualified_avro_name = (
-                    f"{namespace}.{avro_type}"
-                    if namespace and '.' not in avro_type else avro_type
-                )
-                named_type = (
-                    self.avro_named_types.get(qualified_avro_name)
-                    or self.avro_named_types.get(avro_type)
-                )
+                named_type = self.resolve_avro_named_type(avro_type, namespace)
                 if named_type and named_type.get('type') in ('record', 'enum', 'fixed'):
-                    named_namespace = named_type.get('namespace', namespace)
+                    named_fullname = self.avro_type_fullnames[id(named_type)]
+                    named_namespace = named_fullname.rpartition('.')[0]
                     rust_namespace = named_namespace.replace('.', '::').lower()
-                    rust_name = self.safe_identifier(pascal(named_type['name']))
+                    rust_name = self.safe_identifier(
+                        pascal(named_fullname.rsplit('.', 1)[-1])
+                    )
                     type_name = self.safe_package(
                         self.concat_package(rust_namespace, rust_name)
                     )
@@ -124,15 +130,15 @@ class AvroToRust:
                 return 'serde_json::Value' if self.serde_annotation or self.xml_annotation else 'std::collections::HashMap<String, String>'
             non_null_types = [t for t in avro_type if t != 'null']
             if len(non_null_types) == 1:
-                # Rust apache-avro has a bug in the union type handling, so we need to swap the types
-                # if the first type is not null
-                if avro_type[0] != 'null':
-                    avro_type[1] = avro_type[0]
-                    avro_type[0] = 'null'
                 if isinstance(non_null_types[0], str):
                     type_name = self.map_primitive_to_rust(non_null_types[0], True)
                 else:
-                    type_name = self.convert_avro_type_to_rust(field_name, non_null_types[0], namespace)
+                    type_name = self.convert_avro_type_to_rust(
+                        field_name,
+                        non_null_types[0],
+                        namespace,
+                        path=path,
+                    )
                 if (
                     self.avro_annotation
                     and 'null' in avro_type
@@ -140,20 +146,39 @@ class AvroToRust:
                 ):
                     type_name = f'Option<{type_name}>'
             else:
-                type_name = self.generate_union_enum(field_name, avro_type, namespace)
+                type_name = self.generate_union_enum(
+                    field_name,
+                    avro_type,
+                    namespace,
+                    path=path,
+                )
                 if self.avro_annotation and 'null' in avro_type:
                     type_name = f'Option<{type_name}>'
         elif isinstance(avro_type, dict):
             if avro_type['type'] in ['record', 'enum']:
-                type_name = self.generate_class_or_enum(avro_type, namespace)
+                type_name = self.generate_class_or_enum(
+                    avro_type,
+                    namespace,
+                    path=path,
+                )
             elif avro_type['type'] == 'fixed' or avro_type['type'] == 'bytes' and 'logicalType' in avro_type:
                 if avro_type['logicalType'] == 'decimal':
                     return 'f64'
             elif avro_type['type'] == 'array':
-                item_type = self.convert_avro_type_to_rust(field_name, avro_type['items'], namespace)
+                item_type = self.convert_avro_type_to_rust(
+                    field_name,
+                    avro_type['items'],
+                    namespace,
+                    path=(path or []) + [('array', 'items')],
+                )
                 return f"Vec<{item_type}>"
             elif avro_type['type'] == 'map':
-                values_type = self.convert_avro_type_to_rust(field_name, avro_type['values'], namespace)
+                values_type = self.convert_avro_type_to_rust(
+                    field_name,
+                    avro_type['values'],
+                    namespace,
+                    path=(path or []) + [('map', 'values')],
+                )
                 return f"std::collections::HashMap<String, {values_type}>"
             elif 'logicalType' in avro_type:
                 if avro_type['logicalType'] == 'date':
@@ -165,22 +190,82 @@ class AvroToRust:
                 elif avro_type['logicalType'] == 'uuid':
                     return 'uuid::Uuid'
             else:
-                type_name = self.convert_avro_type_to_rust(field_name, avro_type['type'], namespace)
+                type_name = self.convert_avro_type_to_rust(
+                    field_name,
+                    avro_type['type'],
+                    namespace,
+                    path=path,
+                )
         if type_name:
             return type_name
         return 'serde_json::Value' if self.serde_annotation or self.xml_annotation else 'std::collections::HashMap<String, String>'
 
-    def generate_class_or_enum(self, avro_schema: Dict, parent_namespace: str = '') -> str:
+    def generate_class_or_enum(
+        self,
+        avro_schema: Dict,
+        parent_namespace: str = '',
+        path=None,
+    ) -> str:
         """Generates a Rust struct or enum from an Avro schema"""
-        namespace = avro_schema.get('namespace', parent_namespace).lower()
+        fullname, namespace, _ = self.canonical_avro_name(
+            avro_schema['name'],
+            avro_schema.get('namespace', parent_namespace),
+        )
+        namespace = namespace.lower()
+        type_path = path or [('record', fullname)]
         if avro_schema['type'] == 'record':
-            return self.generate_struct(avro_schema, namespace)
+            return self.generate_struct(avro_schema, namespace, type_path)
         elif avro_schema['type'] == 'enum':
             return self.generate_enum(avro_schema, namespace)
         return 'serde_json::Value'
 
+    @staticmethod
+    def canonical_avro_name(name: str, namespace: str = ''):
+        """Returns Avro fullname, namespace, and short name."""
+        if '.' in name:
+            fullname = name
+            resolved_namespace, _, short_name = name.rpartition('.')
+            return fullname, resolved_namespace, short_name
+        fullname = f'{namespace}.{name}' if namespace else name
+        return fullname, namespace, name
+
+    def resolve_avro_named_type(self, name: str, namespace: str = ''):
+        """Resolves a named reference using Avro namespace rules."""
+        if '.' in name:
+            return self.avro_named_types.get(name)
+        contextual_name = f'{namespace}.{name}' if namespace else name
+        if contextual_name in self.avro_named_types:
+            return self.avro_named_types[contextual_name]
+        candidates = self.avro_short_names.get(name, [])
+        if len(candidates) == 1:
+            return self.avro_named_types[candidates[0]]
+        return None
+
+    def union_name_from_path(self, path) -> str:
+        """Builds a collision-proof Rust union name from typed path segments."""
+        segment_codes = {
+            'record': 'R',
+            'field': 'F',
+            'branch': 'B',
+            'array': 'A',
+            'map': 'M',
+        }
+        framed = []
+        for segment_type, value in path:
+            encoded = str(value).encode('utf-8').hex()
+            framed.append(
+                f'{segment_codes[segment_type]}{len(encoded)}X{encoded}'
+            )
+        identity = ''.join(framed)
+        digest = hashlib.sha256(identity.encode('ascii')).hexdigest()
+        existing = self.union_path_identities.get(digest)
+        if existing is not None and existing != identity:
+            raise RuntimeError('SHA-256 collision in generated Rust union identity')
+        self.union_path_identities[digest] = identity
+        return 'UnionPath' + digest
+
     def index_avro_named_types(self, node, parent_namespace=''):
-        """Indexes named Avro types so XML validation metadata can follow references."""
+        """Indexes named Avro types by canonical fullname."""
         if isinstance(node, list):
             for item in node:
                 self.index_avro_named_types(item, parent_namespace)
@@ -189,12 +274,17 @@ class AvroToRust:
             return
 
         node_type = node.get('type')
-        namespace = node.get('namespace', parent_namespace)
+        namespace = parent_namespace
         if node_type in ('record', 'enum', 'fixed') and node.get('name'):
-            name = node['name']
-            self.avro_named_types[name] = node
-            if namespace:
-                self.avro_named_types[f"{namespace}.{name}"] = node
+            fullname, namespace, short_name = self.canonical_avro_name(
+                node['name'],
+                node.get('namespace', parent_namespace),
+            )
+            self.avro_named_types[fullname] = node
+            self.avro_type_fullnames[id(node)] = fullname
+            candidates = self.avro_short_names.setdefault(short_name, [])
+            if fullname not in candidates:
+                candidates.append(fullname)
         if node_type == 'record':
             for field in node.get('fields', []):
                 self.index_avro_named_types(field.get('type'), namespace)
@@ -216,15 +306,11 @@ class AvroToRust:
         resolving = set() if resolving is None else resolving
         defined_names = set() if defined_names is None else defined_names
         if isinstance(node, str):
-            qualified_name = f"{namespace}.{node}" if namespace and '.' not in node else node
-            resolved = self.avro_named_types.get(qualified_name) or self.avro_named_types.get(node)
+            resolved = self.resolve_avro_named_type(node, namespace)
             if not resolved:
                 return node
-            resolved_namespace = resolved.get('namespace', namespace)
-            full_name = (
-                f"{resolved_namespace}.{resolved['name']}"
-                if resolved_namespace else resolved['name']
-            )
+            full_name = self.avro_type_fullnames[id(resolved)]
+            resolved_namespace = full_name.rpartition('.')[0]
             if full_name in resolving:
                 return full_name
             if full_name in defined_names:
@@ -251,15 +337,16 @@ class AvroToRust:
 
         result = dict(node)
         node_type = node.get('type')
-        current_namespace = node.get('namespace', namespace)
+        current_namespace = namespace
         current_resolving = resolving
         if node_type in ('record', 'enum', 'fixed') and node.get('name'):
-            if current_namespace and 'namespace' not in result:
-                result['namespace'] = current_namespace
-            full_name = (
-                f"{current_namespace}.{node['name']}"
-                if current_namespace else node['name']
+            full_name, current_namespace, short_name = self.canonical_avro_name(
+                node['name'],
+                node.get('namespace', namespace),
             )
+            result['name'] = short_name
+            if current_namespace:
+                result['namespace'] = current_namespace
             if full_name in defined_names and full_name not in resolving:
                 return full_name
             defined_names.add(full_name)
@@ -320,32 +407,57 @@ class AvroToRust:
         attribute_owners: set[tuple[str, str]] = set()
         visited: set[tuple[int, str]] = set()
 
-        def nested_records(node):
+        def nested_records(node, inherited_namespace=''):
             if isinstance(node, str):
-                resolved = self.avro_named_types.get(node)
+                resolved = self.resolve_avro_named_type(
+                    node,
+                    inherited_namespace,
+                )
                 return [resolved] if resolved and resolved.get('type') == 'record' else []
             if isinstance(node, list):
-                return [record for item in node for record in nested_records(item)]
+                return [
+                    record
+                    for item in node
+                    for record in nested_records(item, inherited_namespace)
+                ]
             if not isinstance(node, dict):
                 return []
             node_type = node.get('type')
             if node_type == 'record':
                 return [node]
             if node_type == 'array':
-                return nested_records(node.get('items'))
+                return nested_records(node.get('items'), inherited_namespace)
             if isinstance(node_type, (dict, list)):
-                return nested_records(node_type)
+                return nested_records(node_type, inherited_namespace)
             return []
 
-        def visit(node, parent_element=None, inherited_namespace=''):
+        def visit(
+            node,
+            parent_element=None,
+            inherited_xml_namespace='',
+            inherited_avro_namespace='',
+        ):
             if isinstance(node, str):
-                resolved = self.avro_named_types.get(node)
+                resolved = self.resolve_avro_named_type(
+                    node,
+                    inherited_avro_namespace,
+                )
                 if resolved:
-                    visit(resolved, parent_element, inherited_namespace)
+                    visit(
+                        resolved,
+                        parent_element,
+                        inherited_xml_namespace,
+                        inherited_avro_namespace,
+                    )
                 return
             if isinstance(node, list):
                 for item in node:
-                    visit(item, parent_element, inherited_namespace)
+                    visit(
+                        item,
+                        parent_element,
+                        inherited_xml_namespace,
+                        inherited_avro_namespace,
+                    )
             elif isinstance(node, dict):
                 node_type = node.get('type')
                 if node_type == 'record':
@@ -353,7 +465,14 @@ class AvroToRust:
                     if visit_key in visited:
                         return
                     visited.add(visit_key)
-                    record_namespace = node.get('xmlns', inherited_namespace)
+                    _, record_avro_namespace, _ = self.canonical_avro_name(
+                        node['name'],
+                        node.get('namespace', inherited_avro_namespace),
+                    )
+                    record_xml_namespace = node.get(
+                        'xmlns',
+                        inherited_xml_namespace,
+                    )
                     for nested_field in node.get('fields', []):
                         name = xml_wire_name(nested_field['name'], nested_field)
                         if nested_field.get('xmlkind', 'element') == 'attribute':
@@ -367,32 +486,79 @@ class AvroToRust:
                             nested_type = nested_field.get('type')
                             if isinstance(nested_type, dict) and nested_type.get('type') == 'map':
                                 maps.add(name)
-                            records = nested_records(nested_type)
+                            records = nested_records(
+                                nested_type,
+                                record_avro_namespace,
+                            )
                             field_namespaces = {
-                                record.get('xmlns', record_namespace) for record in records
-                            } or {record_namespace}
+                                record.get(
+                                    'xmlns',
+                                    record_xml_namespace,
+                                )
+                                for record in records
+                            } or {record_xml_namespace}
                             namespaces.update((parent, name, namespace) for namespace in field_namespaces)
-                        visit(nested_field.get('type'), name, record_namespace)
+                        visit(
+                            nested_field.get('type'),
+                            name,
+                            record_xml_namespace,
+                            record_avro_namespace,
+                        )
                 elif node_type == 'array':
-                    visit(node.get('items'), parent_element, inherited_namespace)
+                    visit(
+                        node.get('items'),
+                        parent_element,
+                        inherited_xml_namespace,
+                        inherited_avro_namespace,
+                    )
                 elif node_type == 'map':
-                    visit(node.get('values'), parent_element, inherited_namespace)
+                    visit(
+                        node.get('values'),
+                        parent_element,
+                        inherited_xml_namespace,
+                        inherited_avro_namespace,
+                    )
                 elif isinstance(node_type, (dict, list)):
-                    visit(node_type, parent_element, inherited_namespace)
+                    visit(
+                        node_type,
+                        parent_element,
+                        inherited_xml_namespace,
+                        inherited_avro_namespace,
+                    )
 
-        visit(avro_type)
+        initial_avro_namespace = ''
+        if isinstance(avro_type, dict) and avro_type.get('name'):
+            _, initial_avro_namespace, _ = self.canonical_avro_name(
+                avro_type['name'],
+                avro_type.get('namespace', ''),
+            )
+        visit(avro_type, inherited_avro_namespace=initial_avro_namespace)
         return elements, attributes, maps, relationships, namespaces, attribute_owners
 
-    def generate_struct(self, avro_schema: Dict, parent_namespace: str) -> str:
+    def generate_struct(
+        self,
+        avro_schema: Dict,
+        parent_namespace: str,
+        path=None,
+    ) -> str:
         """Generates a Rust struct from an Avro record schema"""
-        struct_name = self.safe_identifier(pascal(avro_schema['name']))
-        previous_record_name = self.current_record_name
-        self.current_record_name = struct_name
+        fullname, parent_namespace, short_name = self.canonical_avro_name(
+            avro_schema['name'],
+            avro_schema.get('namespace', parent_namespace),
+        )
+        struct_name = self.safe_identifier(pascal(short_name))
+        record_path = path or [('record', fullname)]
         fields = []
         for field in avro_schema.get('fields', []):
             original_field_name = field['name']
             field_name = self.safe_identifier(snake(original_field_name))
-            field_type = self.convert_avro_type_to_rust(field_name, field['type'], parent_namespace)
+            field_path = record_path + [('field', original_field_name)]
+            field_type = self.convert_avro_type_to_rust(
+                field_name,
+                field['type'],
+                parent_namespace,
+                path=field_path,
+            )
             xml_name = xml_wire_name(original_field_name, field)
             xml_kind = field.get('xmlkind', 'element')
             serde_name = f"@{xml_name}" if self.xml_annotation and xml_kind == 'attribute' else (
@@ -426,6 +592,16 @@ class AvroToRust:
                 )
                 if self.avro_annotation else ''
             )
+            avro_encode = (
+                self.render_avro_encode_value(
+                    field['type'],
+                    field_type,
+                    parent_namespace,
+                    f'&self.{field_name}',
+                    [0],
+                )
+                if self.avro_annotation else ''
+            )
             fields.append({
                 'original_name': original_field_name,
                 'json_name': original_field_name,
@@ -444,6 +620,7 @@ class AvroToRust:
                 'avro_union_fields': avro_union_fields,
                 'avro_null_index': source_null_index,
                 'avro_decode': avro_decode,
+                'avro_encode': avro_encode,
             })
         
         ns = parent_namespace.replace('.', '::').lower()
@@ -518,7 +695,6 @@ class AvroToRust:
 
         self.generated_types_avro_namespace[qualified_struct_name] = "struct"
         self.generated_types_rust_package[qualified_struct_name] = "struct"
-        self.current_record_name = previous_record_name
 
         return qualified_struct_name
 
@@ -531,7 +707,17 @@ class AvroToRust:
         """Generates deterministic values for every nested Avro union branch."""
         if isinstance(avro_type, list):
             if is_generic_avro_type(avro_type):
-                return []
+                if rust_type != 'serde_json::Value':
+                    return [
+                        'std::iter::once(('
+                        '"key".to_string(), '
+                        '"value".to_string())).collect()'
+                    ]
+                return [
+                    'serde_json::json!("value")',
+                    'serde_json::json!(true)',
+                    'serde_json::json!({"key": "value"})',
+                ]
             non_null_types = [item for item in avro_type if item != 'null']
             if len(non_null_types) > 1:
                 union_type = (
@@ -574,13 +760,8 @@ class AvroToRust:
         if isinstance(avro_type, str):
             if is_any_value_type(avro_type):
                 return []
-            qualified_name = (
-                f'{namespace}.{avro_type}'
-                if namespace and '.' not in avro_type else avro_type
-            )
             resolved_type = (
-                self.avro_named_types.get(qualified_name)
-                or self.avro_named_types.get(avro_type)
+                self.resolve_avro_named_type(avro_type, namespace)
                 or avro_type
             )
 
@@ -614,6 +795,170 @@ class AvroToRust:
                 ]
         return []
 
+    def render_avro_encode_value(
+        self,
+        avro_type,
+        rust_type: str,
+        namespace: str,
+        value_expression: str,
+        counter: List[int],
+    ) -> str:
+        """Renders recursive Rust encoding with explicit Avro union indexes."""
+        counter[0] += 1
+        suffix = counter[0]
+
+        if isinstance(avro_type, list):
+            if is_generic_avro_type(avro_type):
+                standalone_schema = self.inline_avro_references(
+                    avro_type,
+                    namespace,
+                )
+                schema_literal = json.dumps(json.dumps(standalone_schema))
+                return (
+                    f'apache_avro::to_value({value_expression})?.resolve('
+                    '&apache_avro::Schema::parse_str('
+                    f'{schema_literal})?)?'
+                )
+            non_null_types = [item for item in avro_type if item != 'null']
+            if len(non_null_types) > 1:
+                union_type = (
+                    rust_type[7:-1]
+                    if rust_type.startswith('Option<') else rust_type
+                )
+                union_fields = self.generated_union_fields.get(union_type, [])
+                branch_types = [item for item in avro_type if item != 'null']
+                arms = []
+                for union_field, branch_type in zip(
+                    union_fields,
+                    branch_types,
+                ):
+                    inner_encode = self.render_avro_encode_value(
+                        branch_type,
+                        union_field['type'],
+                        namespace,
+                        'value',
+                        counter,
+                    )
+                    arms.append(
+                        f'''{union_type}::{union_field["name"]}(value) =>
+                            apache_avro::types::Value::Union(
+                                {union_field["source_avro_index"]},
+                                Box::new({inner_encode}),
+                            )'''
+                    )
+                arms_text = ',\n'.join(arms)
+                if rust_type.startswith('Option<'):
+                    null_index = avro_type.index('null')
+                    return f'''match {value_expression} {{
+                        None => apache_avro::types::Value::Union(
+                            {null_index},
+                            Box::new(apache_avro::types::Value::Null),
+                        ),
+                        Some(value) => match value {{
+                            {arms_text},
+                        }},
+                    }}'''
+                return f'''match {value_expression} {{
+                    {arms_text},
+                }}'''
+
+            if len(non_null_types) == 1:
+                inner_type = (
+                    rust_type[7:-1]
+                    if rust_type.startswith('Option<') else rust_type
+                )
+                inner_encode = self.render_avro_encode_value(
+                    non_null_types[0],
+                    inner_type,
+                    namespace,
+                    'value',
+                    counter,
+                )
+                null_index = avro_type.index('null')
+                value_index = next(
+                    index for index, item in enumerate(avro_type)
+                    if item != 'null'
+                )
+                return f'''match {value_expression} {{
+                    None => apache_avro::types::Value::Union(
+                        {null_index},
+                        Box::new(apache_avro::types::Value::Null),
+                    ),
+                    Some(value) => apache_avro::types::Value::Union(
+                        {value_index},
+                        Box::new({inner_encode}),
+                    ),
+                }}'''
+
+        resolved_type = avro_type
+        if isinstance(avro_type, str):
+            if is_any_value_type(avro_type):
+                return f'apache_avro::to_value({value_expression})?'
+            if avro_type == 'bytes':
+                return (
+                    'apache_avro::types::Value::Bytes('
+                    f'({value_expression}).clone())'
+                )
+            resolved_type = (
+                self.resolve_avro_named_type(avro_type, namespace)
+                or avro_type
+            )
+
+        if isinstance(resolved_type, dict):
+            node_type = resolved_type.get('type')
+            if node_type == 'bytes' and 'logicalType' not in resolved_type:
+                return (
+                    'apache_avro::types::Value::Bytes('
+                    f'({value_expression}).clone())'
+                )
+            if node_type == 'fixed':
+                return (
+                    'apache_avro::types::Value::Fixed('
+                    f'{resolved_type["size"]}, ({value_expression}).clone())'
+                )
+            if node_type == 'record':
+                return f'({value_expression}).to_avro_value()?'
+            if node_type == 'array':
+                inner_type = rust_type[4:-1]
+                item_name = f'item_{suffix}'
+                values_name = f'values_{suffix}'
+                inner_encode = self.render_avro_encode_value(
+                    resolved_type['items'],
+                    inner_type,
+                    namespace,
+                    item_name,
+                    counter,
+                )
+                return f'''{{
+                    let mut {values_name} = Vec::with_capacity(
+                        ({value_expression}).len()
+                    );
+                    for {item_name} in ({value_expression}).iter() {{
+                        {values_name}.push({inner_encode});
+                    }}
+                    apache_avro::types::Value::Array({values_name})
+                }}'''
+            if node_type == 'map':
+                inner_type = rust_type.split(', ', 1)[1][:-1]
+                item_name = f'item_{suffix}'
+                values_name = f'values_{suffix}'
+                inner_encode = self.render_avro_encode_value(
+                    resolved_type['values'],
+                    inner_type,
+                    namespace,
+                    item_name,
+                    counter,
+                )
+                return f'''{{
+                    let mut {values_name} = std::collections::HashMap::new();
+                    for (key, {item_name}) in ({value_expression}).iter() {{
+                        {values_name}.insert(key.clone(), {inner_encode});
+                    }}
+                    apache_avro::types::Value::Map({values_name})
+                }}'''
+
+        return f'apache_avro::to_value({value_expression})?'
+
     def render_avro_decode_value(
         self,
         avro_type,
@@ -628,6 +973,34 @@ class AvroToRust:
 
         if isinstance(avro_type, list):
             if is_generic_avro_type(avro_type):
+                if rust_type != 'serde_json::Value':
+                    return f'''match {value_expression} {{
+                        apache_avro::types::Value::Union(_, value) => {{
+                            match value.as_ref() {{
+                                apache_avro::types::Value::Map(items) => {{
+                                    let mut result = std::collections::HashMap::new();
+                                    for (key, item) in items {{
+                                        let item = match item {{
+                                            apache_avro::types::Value::Union(_, inner) =>
+                                                inner.as_ref(),
+                                            other => other,
+                                        }};
+                                        result.insert(
+                                            key.clone(),
+                                            apache_avro::from_value(item)?,
+                                        );
+                                    }}
+                                    result
+                                }},
+                                _ => return Err(
+                                    "expected an Avro map for generic value".into()
+                                ),
+                            }}
+                        }},
+                        _ => return Err(
+                            "expected an Avro union for generic value".into()
+                        ),
+                    }}'''
                 return f'apache_avro::from_value({value_expression})?'
             non_null_types = [item for item in avro_type if item != 'null']
             if len(non_null_types) > 1:
@@ -695,18 +1068,28 @@ class AvroToRust:
         if isinstance(avro_type, str):
             if is_any_value_type(avro_type):
                 return f'apache_avro::from_value({value_expression})?'
-            qualified_name = (
-                f'{namespace}.{avro_type}'
-                if namespace and '.' not in avro_type else avro_type
-            )
+            if avro_type == 'bytes':
+                return f'''match {value_expression} {{
+                    apache_avro::types::Value::Bytes(bytes) => bytes.clone(),
+                    _ => return Err("expected an Avro bytes value".into()),
+                }}'''
             resolved_type = (
-                self.avro_named_types.get(qualified_name)
-                or self.avro_named_types.get(avro_type)
+                self.resolve_avro_named_type(avro_type, namespace)
                 or avro_type
             )
 
         if isinstance(resolved_type, dict):
             node_type = resolved_type.get('type')
+            if node_type == 'bytes' and 'logicalType' not in resolved_type:
+                return f'''match {value_expression} {{
+                    apache_avro::types::Value::Bytes(bytes) => bytes.clone(),
+                    _ => return Err("expected an Avro bytes value".into()),
+                }}'''
+            if node_type == 'fixed':
+                return f'''match {value_expression} {{
+                    apache_avro::types::Value::Fixed(_, bytes) => bytes.clone(),
+                    _ => return Err("expected an Avro fixed value".into()),
+                }}'''
             if node_type == 'record':
                 return f'{rust_type}::from_avro_value({value_expression})?'
             if node_type == 'array':
@@ -811,7 +1194,11 @@ class AvroToRust:
             'value': xml_enum_wire_value(symbol, avro_schema) if self.xml_annotation else symbol,
             'json_value': symbol,
         } for symbol in avro_schema.get('symbols', [])]
-        enum_name = self.safe_identifier(pascal(avro_schema['name']))
+        _, parent_namespace, short_name = self.canonical_avro_name(
+            avro_schema['name'],
+            avro_schema.get('namespace', parent_namespace),
+        )
+        enum_name = self.safe_identifier(pascal(short_name))
         ns = parent_namespace.replace('.', '::').lower()
         qualified_enum_name = self.safe_package(self.concat_package(ns, enum_name))
         
@@ -846,14 +1233,19 @@ class AvroToRust:
 
         return qualified_enum_name
 
-    def generate_union_enum(self, field_name: str, avro_type: List, namespace: str) -> str:
+    def generate_union_enum(
+        self,
+        field_name: str,
+        avro_type: List,
+        namespace: str,
+        path=None,
+    ) -> str:
         """Generates a union enum for Rust"""
         ns = namespace.replace('.', '::').lower()
-        union_owner = (
-            f'Record{len(self.current_record_name)}{self.current_record_name}'
-            if self.avro_annotation else ''
+        union_enum_name = (
+            self.union_name_from_path(path or [('field', field_name)])
+            if self.avro_annotation else pascal(field_name) + 'Union'
         )
-        union_enum_name = union_owner + pascal(field_name) + 'Union'
         union_avro_branches = [
             (source_index, avro_branch)
             for source_index, avro_branch in enumerate(avro_type)
@@ -867,8 +1259,9 @@ class AvroToRust:
                 field_name + "Option" + str(i),
                 avro_branch,
                 namespace,
+                path=(path or []) + [('branch', str(source_index))],
             )
-            for i, avro_branch in enumerate(union_avro_types)
+            for i, (source_index, avro_branch) in enumerate(union_avro_branches)
         ]
         avro_schema_str = json.dumps(
             self.inline_avro_references(union_avro_types, namespace)
@@ -886,9 +1279,13 @@ class AvroToRust:
         union_fields = []
         for i, t in enumerate(union_types):
             predicate = self.get_is_json_match_clause(field_name, t, for_union=True)
+            predicate_key = self.get_json_shape_signature(
+                union_avro_types[i],
+                namespace,
+            )
             # Mark if this is the first variant with this predicate structure
-            is_first_with_predicate = predicate not in seen_predicates
-            seen_predicates.add(predicate)
+            is_first_with_predicate = predicate_key not in seen_predicates
+            seen_predicates.add(predicate_key)
             
             # Deduplicate variant names
             variant_name = pascal(t.rsplit('::',1)[-1])
@@ -904,6 +1301,13 @@ class AvroToRust:
                 'avro_index': i,
                 'source_avro_index': union_avro_branches[i][0],
                 'avro_decode': self.render_avro_decode_value(
+                    union_avro_types[i],
+                    t,
+                    namespace,
+                    'value',
+                    [0],
+                ),
+                'avro_encode': self.render_avro_encode_value(
                     union_avro_types[i],
                     t,
                     namespace,
@@ -965,6 +1369,93 @@ class AvroToRust:
         self.write_mod_rs(namespace)
 
         return qualified_union_enum_name
+
+    def get_json_shape_signature(
+        self,
+        avro_type,
+        namespace: str,
+        resolving=None,
+    ):
+        """Returns a stable structural signature for untagged JSON matching."""
+        resolving = () if resolving is None else resolving
+        if isinstance(avro_type, str):
+            resolved = self.resolve_avro_named_type(avro_type, namespace)
+            if resolved:
+                fullname = self.avro_type_fullnames[id(resolved)]
+                if fullname in resolving:
+                    return ('ref', resolving.index(fullname))
+                return self.get_json_shape_signature(
+                    resolved,
+                    fullname.rpartition('.')[0],
+                    resolving,
+                )
+            if avro_type in ('int', 'long'):
+                return 'integer'
+            if avro_type in ('float', 'double'):
+                return 'number'
+            return avro_type
+        if isinstance(avro_type, list):
+            return (
+                'union',
+                tuple(
+                    self.get_json_shape_signature(
+                        item,
+                        namespace,
+                        resolving,
+                    )
+                    for item in avro_type
+                ),
+            )
+        if not isinstance(avro_type, dict):
+            return str(avro_type)
+        node_type = avro_type.get('type')
+        if node_type == 'record':
+            fullname, record_namespace, _ = self.canonical_avro_name(
+                avro_type['name'],
+                avro_type.get('namespace', namespace),
+            )
+            if fullname in resolving:
+                return ('ref', resolving.index(fullname))
+            nested_resolving = resolving + (fullname,)
+            return (
+                'record',
+                tuple(
+                    (
+                        field['name'],
+                        self.get_json_shape_signature(
+                            field['type'],
+                            record_namespace,
+                            nested_resolving,
+                        ),
+                    )
+                    for field in avro_type.get('fields', [])
+                ),
+            )
+        if node_type == 'enum':
+            return 'string'
+        if node_type == 'array':
+            return (
+                'array',
+                self.get_json_shape_signature(
+                    avro_type['items'],
+                    namespace,
+                    resolving,
+                ),
+            )
+        if node_type == 'map':
+            return (
+                'map',
+                self.get_json_shape_signature(
+                    avro_type['values'],
+                    namespace,
+                    resolving,
+                ),
+            )
+        return self.get_json_shape_signature(
+            node_type,
+            namespace,
+            resolving,
+        )
 
     def to_file_name(self, qualified_name):
         """Converts a qualified union enum name to a file name"""

--- a/avrotize/avrotorust/dataclass_enum.rs.jinja
+++ b/avrotize/avrotorust/dataclass_enum.rs.jinja
@@ -3,7 +3,7 @@ use lazy_static::lazy_static;
 use apache_avro::Schema;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
-use std::io::Write;
+use std::io::{Read, Write};
 {%- endif %}
 {%- if serde_annotation or avro_annotation or xml_annotation %}
 use serde::{self,Serialize, Deserialize};
@@ -53,6 +53,29 @@ impl Serialize for {{ enum_name }} {
 {%- endif %}
 
 {%- if avro_annotation %}
+const MAX_AVRO_DATA_SIZE: usize = 16 * 1024 * 1024;
+
+fn decode_avro_data(
+    data: &[u8],
+    gzip: bool,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    if data.len() > MAX_AVRO_DATA_SIZE {
+        return Err("input exceeds the generated data size limit".into());
+    }
+    if !gzip {
+        return Ok(data.to_vec());
+    }
+    let decoder = GzDecoder::new(data);
+    let mut result = Vec::new();
+    decoder
+        .take((MAX_AVRO_DATA_SIZE + 1) as u64)
+        .read_to_end(&mut result)?;
+    if result.len() > MAX_AVRO_DATA_SIZE {
+        return Err("decompressed input exceeds the generated data size limit".into());
+    }
+    Ok(result)
+}
+
 lazy_static! {
     /// The static Avro schema as a parsed object
     pub static ref SCHEMA: Schema = Schema::parse_str({{ avro_schema }}).unwrap();
@@ -94,14 +117,7 @@ impl {{ enum_name }} {
             return Err(format!("unsupported media type: {}", media_type).into());
         }
 
-        let data = if gzip {
-            let mut decoder = GzDecoder::new(data.as_ref());
-            let mut decompressed_data = Vec::new();
-            std::io::copy(&mut decoder, &mut decompressed_data)?;
-            decompressed_data
-        } else {
-            data.as_ref().to_vec()
-        };
+        let data = decode_avro_data(data.as_ref(), gzip)?;
         let value = apache_avro::from_avro_datum(&SCHEMA, &mut &data[..], None)?;
         Ok(apache_avro::from_value(&value)?)
     }

--- a/avrotize/avrotorust/dataclass_enum.rs.jinja
+++ b/avrotize/avrotorust/dataclass_enum.rs.jinja
@@ -1,6 +1,9 @@
 {%- if avro_annotation %}
 use lazy_static::lazy_static;
 use apache_avro::Schema;
+use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
+use std::io::Write;
 {%- endif %}
 {%- if serde_annotation or avro_annotation or xml_annotation %}
 use serde::{self,Serialize, Deserialize};
@@ -58,6 +61,46 @@ lazy_static! {
 
 {%- if serde_annotation or avro_annotation or xml_annotation %}
 impl {{ enum_name }} {
+    {%- if avro_annotation %}
+    /// Serializes the enum to Avro binary data.
+    pub fn to_byte_array(&self, content_type: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        let media_type = content_type.split(';').next().unwrap_or("");
+        if !media_type.starts_with("avro/binary") &&
+           !media_type.starts_with("application/vnd.apache.avro+avro") {
+            return Err(format!("unsupported media type: {}", media_type).into());
+        }
+
+        let value = apache_avro::to_value(self)?.resolve(&SCHEMA)?;
+        let result = apache_avro::to_avro_datum(&SCHEMA, value)?;
+        if media_type.ends_with("+gzip") {
+            let mut encoder = GzEncoder::new(Vec::new(), flate2::Compression::default());
+            encoder.write_all(&result)?;
+            return Ok(encoder.finish()?);
+        }
+        Ok(result)
+    }
+
+    /// Deserializes the enum from Avro binary data.
+    pub fn from_data(data: impl AsRef<[u8]>, content_type: &str) -> Result<Self, Box<dyn std::error::Error>> {
+        let media_type = content_type.split(';').next().unwrap_or("");
+        if !media_type.starts_with("avro/binary") &&
+           !media_type.starts_with("application/vnd.apache.avro+avro") {
+            return Err(format!("unsupported media type: {}", media_type).into());
+        }
+
+        let data = if media_type.ends_with("+gzip") {
+            let mut decoder = GzDecoder::new(data.as_ref());
+            let mut decompressed_data = Vec::new();
+            std::io::copy(&mut decoder, &mut decompressed_data)?;
+            decompressed_data
+        } else {
+            data.as_ref().to_vec()
+        };
+        let value = apache_avro::from_avro_datum(&SCHEMA, &mut &data[..], None)?;
+        Ok(apache_avro::from_value(&value)?)
+    }
+    {%- endif %}
+
     pub fn is_json_match(node: &serde_json::Value) -> bool {
         return node.is_string();
     }
@@ -87,15 +130,31 @@ mod tests {
     use super::*;
     use rand::Rng;
 
-    {%- if serde_annotation or xml_annotation %}
+    {%- if serde_annotation or avro_annotation or xml_annotation %}
     #[test]
     fn test_serialize_deserialize_{{ enum_name.lower() }}() {
         {%- for symbol in symbols %}
         let instance = {{ enum_name }}::{{ symbol.name }};
+        {%- if serde_annotation or xml_annotation %}
         let json_bytes = serde_json::to_vec(&instance).unwrap();
         let deserialized_instance: {{ enum_name }} = serde_json::from_slice(&json_bytes).unwrap();
         assert_eq!(instance, deserialized_instance);
+        {%- endif %}
+        {%- if avro_annotation %}
+        let avro_bytes = instance.to_byte_array("avro/binary").unwrap();
+        let deserialized_instance = {{ enum_name }}::from_data(&avro_bytes, "avro/binary").unwrap();
+        assert_eq!(instance, deserialized_instance);
+        {%- endif %}
         {%- endfor %}
+    }
+    {%- endif %}
+
+    {%- if avro_annotation %}
+    #[test]
+    fn test_rejects_invalid_content_type_{{ enum_name.lower() }}() {
+        let instance = {{ enum_name }}::default();
+        assert!(instance.to_byte_array("text/plain").is_err());
+        assert!({{ enum_name }}::from_data([], "text/plain").is_err());
     }
     {%- endif %}
 

--- a/avrotize/avrotorust/dataclass_enum.rs.jinja
+++ b/avrotize/avrotorust/dataclass_enum.rs.jinja
@@ -65,14 +65,17 @@ impl {{ enum_name }} {
     /// Serializes the enum to Avro binary data.
     pub fn to_byte_array(&self, content_type: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
         let media_type = content_type.split(';').next().unwrap_or("");
-        if !media_type.starts_with("avro/binary") &&
-           !media_type.starts_with("application/vnd.apache.avro+avro") {
+        let (base_media_type, gzip) = media_type
+            .strip_suffix("+gzip")
+            .map_or((media_type, false), |base| (base, true));
+        if base_media_type != "avro/binary" &&
+           base_media_type != "application/vnd.apache.avro+avro" {
             return Err(format!("unsupported media type: {}", media_type).into());
         }
 
         let value = apache_avro::to_value(self)?.resolve(&SCHEMA)?;
         let result = apache_avro::to_avro_datum(&SCHEMA, value)?;
-        if media_type.ends_with("+gzip") {
+        if gzip {
             let mut encoder = GzEncoder::new(Vec::new(), flate2::Compression::default());
             encoder.write_all(&result)?;
             return Ok(encoder.finish()?);
@@ -83,12 +86,15 @@ impl {{ enum_name }} {
     /// Deserializes the enum from Avro binary data.
     pub fn from_data(data: impl AsRef<[u8]>, content_type: &str) -> Result<Self, Box<dyn std::error::Error>> {
         let media_type = content_type.split(';').next().unwrap_or("");
-        if !media_type.starts_with("avro/binary") &&
-           !media_type.starts_with("application/vnd.apache.avro+avro") {
+        let (base_media_type, gzip) = media_type
+            .strip_suffix("+gzip")
+            .map_or((media_type, false), |base| (base, true));
+        if base_media_type != "avro/binary" &&
+           base_media_type != "application/vnd.apache.avro+avro" {
             return Err(format!("unsupported media type: {}", media_type).into());
         }
 
-        let data = if media_type.ends_with("+gzip") {
+        let data = if gzip {
             let mut decoder = GzDecoder::new(data.as_ref());
             let mut decompressed_data = Vec::new();
             std::io::copy(&mut decoder, &mut decompressed_data)?;
@@ -144,6 +150,9 @@ mod tests {
         let avro_bytes = instance.to_byte_array("avro/binary").unwrap();
         let deserialized_instance = {{ enum_name }}::from_data(&avro_bytes, "avro/binary").unwrap();
         assert_eq!(instance, deserialized_instance);
+        let avro_gzip_bytes = instance.to_byte_array("avro/binary+gzip").unwrap();
+        let deserialized_gzip_instance = {{ enum_name }}::from_data(&avro_gzip_bytes, "avro/binary+gzip").unwrap();
+        assert_eq!(instance, deserialized_gzip_instance);
         {%- endif %}
         {%- endfor %}
     }
@@ -155,6 +164,11 @@ mod tests {
         let instance = {{ enum_name }}::default();
         assert!(instance.to_byte_array("text/plain").is_err());
         assert!({{ enum_name }}::from_data([], "text/plain").is_err());
+        assert!(instance.to_byte_array("avro/binary-invalid").is_err());
+        assert!(instance.to_byte_array("application/vnd.apache.avro+avroevil").is_err());
+        assert!({{ enum_name }}::from_data([], "avro/binary-invalid").is_err());
+        assert!({{ enum_name }}::from_data([], "application/vnd.apache.avro+avroevil").is_err());
+        assert!({{ enum_name }}::from_data([0, 1], "avro/binary+gzip").is_err());
     }
     {%- endif %}
 

--- a/avrotize/avrotorust/dataclass_struct.rs.jinja
+++ b/avrotize/avrotorust/dataclass_struct.rs.jinja
@@ -348,6 +348,8 @@ mod tests {
         {%- elif field.type in ["i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64", "f32", "f64", "isize", "usize"] %}
         // Skip default comparison for numeric types as random values can legitimately be 0
         let _ = instance.{{ field.name }};
+        {%- elif field.type == "()" %}
+        let _ = instance.{{ field.name }};
         {%- elif field.type != "bool" %}
         assert!(instance.{{ field.name }} != {{ field.type }}::default()); // Check that {{ field.name }} is not default
         {%- endif %}
@@ -401,6 +403,31 @@ mod tests {
             "avro/binary",
         ).unwrap();
         assert_eq!(union_instance, deserialized_union_instance);
+        {%- endfor %}
+        {%- for field in fields %}
+        {%- if field.is_avro_union and field.avro_null_index >= 0 %}
+        let mut null_value = instance.to_avro_value().unwrap();
+        if let apache_avro::types::Value::Record(fields) = &mut null_value {
+            let (_, value) = fields
+                .iter_mut()
+                .find(|(name, _)| name == "{{ field.original_name }}")
+                .unwrap();
+            *value = apache_avro::types::Value::Union(
+                {{ field.avro_null_index }},
+                Box::new(apache_avro::types::Value::Null),
+            );
+        }
+        let null_bytes = apache_avro::to_avro_datum(&SCHEMA, null_value).unwrap();
+        let null_error = {{ struct_name }}::from_data(
+            &null_bytes,
+            "avro/binary",
+        ).unwrap_err();
+        assert!(
+            null_error.to_string().contains(
+                "nullable Avro union null is unsupported"
+            )
+        );
+        {%- endif %}
         {%- endfor %}
         {%- endif %}
         {%- if xml_annotation %}

--- a/avrotize/avrotorust/dataclass_struct.rs.jinja
+++ b/avrotize/avrotorust/dataclass_struct.rs.jinja
@@ -333,6 +333,17 @@ mod tests {
         let avro_gzip_bytes = instance.to_byte_array("avro/binary+gzip").unwrap();
         let deserialized_avro_gzip_instance: {{ struct_name }} = {{ struct_name }}::from_data(&avro_gzip_bytes, "avro/binary+gzip").unwrap();
         assert_eq!(instance, deserialized_avro_gzip_instance);
+        {%- if fields | selectattr("is_optional") | list | length > 0 %}
+        let mut nullable_instance = {{ struct_name }}::generate_random_instance();
+        {%- for field in fields %}
+        {%- if field.is_optional %}
+        nullable_instance.{{ field.name }} = None;
+        {%- endif %}
+        {%- endfor %}
+        let nullable_avro_bytes = nullable_instance.to_byte_array("avro/binary").unwrap();
+        let deserialized_nullable_instance = {{ struct_name }}::from_data(&nullable_avro_bytes, "avro/binary").unwrap();
+        assert_eq!(nullable_instance, deserialized_nullable_instance);
+        {%- endif %}
         {%- endif %}
         {%- if xml_annotation %}
         // Test XML serialization and deserialization

--- a/avrotize/avrotorust/dataclass_struct.rs.jinja
+++ b/avrotize/avrotorust/dataclass_struct.rs.jinja
@@ -112,6 +112,31 @@ lazy_static! {
 {%- endif %}
 
 impl {{ struct_name }} {
+{%- if avro_annotation %}
+    pub(crate) fn from_avro_value(
+        value: &apache_avro::types::Value,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let apache_avro::types::Value::Record(record_fields) = value else {
+            return Err("expected an Avro record value".into());
+        };
+        let record_fields: std::collections::HashMap<_, _> = record_fields
+            .iter()
+            .map(|(name, value)| (name.as_str(), value))
+            .collect();
+        Ok(Self {
+            {%- for field in fields %}
+            {{ field.name }}: {
+                let field_value = record_fields
+                    .get("{{ field.original_name }}")
+                    .copied()
+                    .ok_or("missing Avro field: {{ field.original_name }}")?;
+                {{ field.avro_decode }}
+            },
+            {%- endfor %}
+        })
+    }
+{%- endif %}
+
 {%- if serde_annotation or avro_annotation or xml_annotation %}
    /// Serializes the struct to a byte array based on the provided content type
     pub fn to_byte_array(&self, content_type: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
@@ -244,54 +269,7 @@ impl {{ struct_name }} {
         if media_type.starts_with("avro/binary") || 
            media_type.starts_with("application/vnd.apache.avro+avro") {
             let value = apache_avro::from_avro_datum(&SCHEMA, &mut &data[..], None)?;
-            {%- if fields | selectattr("is_avro_union") | list | length > 0 %}
-            let apache_avro::types::Value::Record(record_fields) = value else {
-                return Err("expected an Avro record value".into());
-            };
-            let mut record_fields: std::collections::HashMap<_, _> =
-                record_fields.into_iter().collect();
-            return Ok(Self {
-                {%- for field in fields %}
-                {{ field.name }}: {
-                    let field_value = record_fields
-                        .remove("{{ field.original_name }}")
-                        .ok_or("missing Avro field: {{ field.original_name }}")?;
-                    {%- if field.is_avro_union %}
-                    match field_value {
-                        apache_avro::types::Value::Union(index, value) => match index {
-                            {%- if field.avro_null_index >= 0 %}
-                            {{ field.avro_null_index }} => None,
-                            {%- endif %}
-                            {%- for union_field in field.avro_union_fields %}
-                            {{ union_field.source_avro_index }} => {
-                                {%- if field.is_optional %}Some({%- endif %}
-                                {{ field.avro_union_type }}::from_avro_branch(
-                                    {{ union_field.avro_index }},
-                                    &value,
-                                )?
-                                {%- if field.is_optional %}){%- endif %}
-                            },
-                            {%- endfor %}
-                            _ => return Err(
-                                format!(
-                                    "unsupported Avro union branch {} for field {{ field.original_name }}",
-                                    index,
-                                ).into()
-                            ),
-                        },
-                        _ => return Err(
-                            "expected an Avro union for field {{ field.original_name }}".into()
-                        ),
-                    }
-                    {%- else %}
-                    apache_avro::from_value(&field_value)?
-                    {%- endif %}
-                },
-                {%- endfor %}
-            });
-            {%- else %}
-            return Ok(apache_avro::from_value(&value)?);
-            {%- endif %}
+            return Self::from_avro_value(&value);
         }
         {%- endif %}
         Err(format!("unsupported media type: {}", media_type).into())
@@ -392,24 +370,14 @@ mod tests {
         let deserialized_nullable_instance = {{ struct_name }}::from_data(&nullable_avro_bytes, "avro/binary").unwrap();
         assert_eq!(nullable_instance, deserialized_nullable_instance);
         {%- endif %}
-        {%- for field in fields %}
-        {%- if field.is_avro_union %}
-        {%- for union_field in field.avro_union_fields %}
-        let mut union_instance = {{ struct_name }}::generate_random_instance();
-        union_instance.{{ field.name }} =
-            {%- if field.is_optional %} Some({%- endif %}
-            {{ field.avro_union_type }}::{{ union_field.name }}(
-                {{ union_field.random_value }}
-            )
-            {%- if field.is_optional %}){%- endif %};
+        {%- for avro_test_instance in avro_test_instances %}
+        let union_instance = {{ avro_test_instance }};
         let union_avro_bytes = union_instance.to_byte_array("avro/binary").unwrap();
         let deserialized_union_instance = {{ struct_name }}::from_data(
             &union_avro_bytes,
             "avro/binary",
         ).unwrap();
         assert_eq!(union_instance, deserialized_union_instance);
-        {%- endfor %}
-        {%- endif %}
         {%- endfor %}
         {%- endif %}
         {%- if xml_annotation %}

--- a/avrotize/avrotorust/dataclass_struct.rs.jinja
+++ b/avrotize/avrotorust/dataclass_struct.rs.jinja
@@ -113,6 +113,19 @@ lazy_static! {
 
 impl {{ struct_name }} {
 {%- if avro_annotation %}
+    pub(crate) fn to_avro_value(
+        &self,
+    ) -> Result<apache_avro::types::Value, Box<dyn std::error::Error>> {
+        Ok(apache_avro::types::Value::Record(vec![
+            {%- for field in fields %}
+            (
+                "{{ field.original_name }}".to_string(),
+                {{ field.avro_encode }},
+            ),
+            {%- endfor %}
+        ]))
+    }
+
     pub(crate) fn from_avro_value(
         value: &apache_avro::types::Value,
     ) -> Result<Self, Box<dyn std::error::Error>> {
@@ -163,7 +176,7 @@ impl {{ struct_name }} {
         {%- if avro_annotation %}
         if base_media_type == "avro/binary" ||
            base_media_type == "application/vnd.apache.avro+avro" {
-            let value = apache_avro::to_value(self)?.resolve(&SCHEMA)?;
+            let value = self.to_avro_value()?;
             result = apache_avro::to_avro_datum(&SCHEMA, value)?;
         }
         else {% endif -%}

--- a/avrotize/avrotorust/dataclass_struct.rs.jinja
+++ b/avrotize/avrotorust/dataclass_struct.rs.jinja
@@ -142,6 +142,9 @@ impl {{ struct_name }} {
     pub fn to_byte_array(&self, content_type: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
         let result: Vec<u8>;
         let media_type = content_type.split(';').next().unwrap_or("");
+        let (base_media_type, gzip) = media_type
+            .strip_suffix("+gzip")
+            .map_or((media_type, false), |base| (base, true));
         {%- if serde_annotation %}
         if media_type.starts_with("application/json") {
             result = serde_json::to_vec(self)?;
@@ -158,8 +161,8 @@ impl {{ struct_name }} {
         }
         else {% endif -%}
         {%- if avro_annotation %}
-        if media_type.starts_with("avro/binary") || 
-           media_type.starts_with("application/vnd.apache.avro+avro") {
+        if base_media_type == "avro/binary" ||
+           base_media_type == "application/vnd.apache.avro+avro" {
             let value = apache_avro::to_value(self)?.resolve(&SCHEMA)?;
             result = apache_avro::to_avro_datum(&SCHEMA, value)?;
         }
@@ -167,7 +170,7 @@ impl {{ struct_name }} {
         {
             return Err(format!("unsupported media type: {}", media_type).into())
         }
-        if media_type.ends_with("+gzip") {
+        if gzip {
             let mut encoder = GzEncoder::new(Vec::new(), flate2::Compression::default());
             encoder.write_all(&result)?;
             let gzipresult = encoder.finish()?;
@@ -182,16 +185,19 @@ impl {{ struct_name }} {
     /// Deserializes the struct from a byte array based on the provided content type
     pub fn from_data(data: impl AsRef<[u8]>, content_type: &str) -> Result<Self, Box<dyn std::error::Error>> {
         let media_type = content_type.split(';').next().unwrap_or("");
+        let (base_media_type, gzip) = media_type
+            .strip_suffix("+gzip")
+            .map_or((media_type, false), |base| (base, true));
         {%- if xml_annotation %}
         let is_xml = media_type.starts_with("application/xml") ||
                      media_type.starts_with("text/xml");
         let data = crate::xml_support::decode_data(
             data.as_ref(),
-            media_type.ends_with("+gzip"),
+            gzip,
             is_xml,
         )?;
         {%- else %}
-        let data = if media_type.ends_with("+gzip") {
+        let data = if gzip {
             let mut decoder = GzDecoder::new(data.as_ref());
             let mut decompressed_data = Vec::new();
             std::io::copy(&mut decoder, &mut decompressed_data)?;
@@ -266,8 +272,8 @@ impl {{ struct_name }} {
         }
         {%- endif %}
         {%- if avro_annotation %}
-        if media_type.starts_with("avro/binary") || 
-           media_type.starts_with("application/vnd.apache.avro+avro") {
+        if base_media_type == "avro/binary" ||
+           base_media_type == "application/vnd.apache.avro+avro" {
             let value = apache_avro::from_avro_datum(&SCHEMA, &mut &data[..], None)?;
             return Self::from_avro_value(&value);
         }
@@ -359,6 +365,10 @@ mod tests {
         let avro_gzip_bytes = instance.to_byte_array("avro/binary+gzip").unwrap();
         let deserialized_avro_gzip_instance: {{ struct_name }} = {{ struct_name }}::from_data(&avro_gzip_bytes, "avro/binary+gzip").unwrap();
         assert_eq!(instance, deserialized_avro_gzip_instance);
+        assert!(instance.to_byte_array("avro/binary-invalid").is_err());
+        assert!(instance.to_byte_array("application/vnd.apache.avro+avroevil").is_err());
+        assert!({{ struct_name }}::from_data([], "avro/binary-invalid").is_err());
+        assert!({{ struct_name }}::from_data([], "application/vnd.apache.avro+avroevil").is_err());
         {%- if fields | selectattr("is_optional") | list | length > 0 %}
         let mut nullable_instance = {{ struct_name }}::generate_random_instance();
         {%- for field in fields %}

--- a/avrotize/avrotorust/dataclass_struct.rs.jinja
+++ b/avrotize/avrotorust/dataclass_struct.rs.jinja
@@ -244,7 +244,54 @@ impl {{ struct_name }} {
         if media_type.starts_with("avro/binary") || 
            media_type.starts_with("application/vnd.apache.avro+avro") {
             let value = apache_avro::from_avro_datum(&SCHEMA, &mut &data[..], None)?;
+            {%- if fields | selectattr("is_avro_union") | list | length > 0 %}
+            let apache_avro::types::Value::Record(record_fields) = value else {
+                return Err("expected an Avro record value".into());
+            };
+            let mut record_fields: std::collections::HashMap<_, _> =
+                record_fields.into_iter().collect();
+            return Ok(Self {
+                {%- for field in fields %}
+                {{ field.name }}: {
+                    let field_value = record_fields
+                        .remove("{{ field.original_name }}")
+                        .ok_or("missing Avro field: {{ field.original_name }}")?;
+                    {%- if field.is_avro_union %}
+                    match field_value {
+                        apache_avro::types::Value::Union(index, value) => match index {
+                            {%- if field.avro_null_index >= 0 %}
+                            {{ field.avro_null_index }} => None,
+                            {%- endif %}
+                            {%- for union_field in field.avro_union_fields %}
+                            {{ union_field.source_avro_index }} => {
+                                {%- if field.is_optional %}Some({%- endif %}
+                                {{ field.avro_union_type }}::from_avro_branch(
+                                    {{ union_field.avro_index }},
+                                    &value,
+                                )?
+                                {%- if field.is_optional %}){%- endif %}
+                            },
+                            {%- endfor %}
+                            _ => return Err(
+                                format!(
+                                    "unsupported Avro union branch {} for field {{ field.original_name }}",
+                                    index,
+                                ).into()
+                            ),
+                        },
+                        _ => return Err(
+                            "expected an Avro union for field {{ field.original_name }}".into()
+                        ),
+                    }
+                    {%- else %}
+                    apache_avro::from_value(&field_value)?
+                    {%- endif %}
+                },
+                {%- endfor %}
+            });
+            {%- else %}
             return Ok(apache_avro::from_value(&value)?);
+            {%- endif %}
         }
         {%- endif %}
         Err(format!("unsupported media type: {}", media_type).into())
@@ -313,6 +360,7 @@ mod tests {
     {%- if serde_annotation or avro_annotation or xml_annotation %}
     #[test]
     fn test_serialize_deserialize_{{ struct_name.lower() }}() {
+        let mut rng = rand::thread_rng();
         let instance = {{struct_name}}::generate_random_instance();
         {%- if serde_annotation %}
         // Test JSON serialization and deserialization
@@ -344,6 +392,25 @@ mod tests {
         let deserialized_nullable_instance = {{ struct_name }}::from_data(&nullable_avro_bytes, "avro/binary").unwrap();
         assert_eq!(nullable_instance, deserialized_nullable_instance);
         {%- endif %}
+        {%- for field in fields %}
+        {%- if field.is_avro_union %}
+        {%- for union_field in field.avro_union_fields %}
+        let mut union_instance = {{ struct_name }}::generate_random_instance();
+        union_instance.{{ field.name }} =
+            {%- if field.is_optional %} Some({%- endif %}
+            {{ field.avro_union_type }}::{{ union_field.name }}(
+                {{ union_field.random_value }}
+            )
+            {%- if field.is_optional %}){%- endif %};
+        let union_avro_bytes = union_instance.to_byte_array("avro/binary").unwrap();
+        let deserialized_union_instance = {{ struct_name }}::from_data(
+            &union_avro_bytes,
+            "avro/binary",
+        ).unwrap();
+        assert_eq!(union_instance, deserialized_union_instance);
+        {%- endfor %}
+        {%- endif %}
+        {%- endfor %}
         {%- endif %}
         {%- if xml_annotation %}
         // Test XML serialization and deserialization

--- a/avrotize/avrotorust/dataclass_struct.rs.jinja
+++ b/avrotize/avrotorust/dataclass_struct.rs.jinja
@@ -135,8 +135,8 @@ impl {{ struct_name }} {
         {%- if avro_annotation %}
         if media_type.starts_with("avro/binary") || 
            media_type.starts_with("application/vnd.apache.avro+avro") {
-            let value = apache_avro::to_value(self).unwrap();
-            result = apache_avro::to_avro_datum(&SCHEMA, value).unwrap();
+            let value = apache_avro::to_value(self)?.resolve(&SCHEMA)?;
+            result = apache_avro::to_avro_datum(&SCHEMA, value)?;
         }
         else {% endif -%}
         {
@@ -243,8 +243,8 @@ impl {{ struct_name }} {
         {%- if avro_annotation %}
         if media_type.starts_with("avro/binary") || 
            media_type.starts_with("application/vnd.apache.avro+avro") {
-            let value = apache_avro::from_avro_datum(&SCHEMA, &mut &data[..], None).unwrap();
-            return Ok(apache_avro::from_value(&value).unwrap());
+            let value = apache_avro::from_avro_datum(&SCHEMA, &mut &data[..], None)?;
+            return Ok(apache_avro::from_value(&value)?);
         }
         {%- endif %}
         Err(format!("unsupported media type: {}", media_type).into())

--- a/avrotize/avrotorust/dataclass_struct.rs.jinja
+++ b/avrotize/avrotorust/dataclass_struct.rs.jinja
@@ -405,7 +405,7 @@ mod tests {
         assert_eq!(union_instance, deserialized_union_instance);
         {%- endfor %}
         {%- for field in fields %}
-        {%- if field.is_avro_union and field.avro_null_index >= 0 %}
+        {%- if field.avro_null_index >= 0 %}
         let mut null_value = instance.to_avro_value().unwrap();
         if let apache_avro::types::Value::Record(fields) = &mut null_value {
             let (_, value) = fields
@@ -423,9 +423,7 @@ mod tests {
             "avro/binary",
         ).unwrap_err();
         assert!(
-            null_error.to_string().contains(
-                "nullable Avro union null is unsupported"
-            )
+            null_error.to_string().contains("nullable Avro")
         );
         {%- endif %}
         {%- endfor %}

--- a/avrotize/avrotorust/dataclass_struct.rs.jinja
+++ b/avrotize/avrotorust/dataclass_struct.rs.jinja
@@ -103,7 +103,33 @@ impl Serialize for {{ struct_name }} {
 const XML_NAMESPACE: &str = r#"{{ xml_namespace }}"#;
 {%- endif %}
 
+{% if (serde_annotation or avro_annotation) and not xml_annotation %}
+const MAX_DATA_SIZE: usize = 16 * 1024 * 1024;
+fn decode_data(
+    data: &[u8],
+    gzip: bool,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    use std::io::Read;
+    if data.len() > MAX_DATA_SIZE {
+        return Err("input exceeds the generated data size limit".into());
+    }
+    if !gzip {
+        return Ok(data.to_vec());
+    }
+    let decoder = GzDecoder::new(data);
+    let mut result = Vec::new();
+    decoder
+        .take((MAX_DATA_SIZE + 1) as u64)
+        .read_to_end(&mut result)?;
+    if result.len() > MAX_DATA_SIZE {
+        return Err("decompressed input exceeds the generated data size limit".into());
+    }
+    Ok(result)
+}
+{%- endif %}
+
 {% if avro_annotation %}
+const MAX_AVRO_DECODE_DEPTH: usize = 128;
 lazy_static! {
     /// The static Avro schema as a parsed object
     pub static ref SCHEMA: Schema = Schema::parse_str(
@@ -129,8 +155,19 @@ impl {{ struct_name }} {
     pub(crate) fn from_avro_value(
         value: &apache_avro::types::Value,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        let apache_avro::types::Value::Record(record_fields) = value else {
-            return Err("expected an Avro record value".into());
+        Self::from_avro_value_at(value, 0)
+    }
+
+    pub(crate) fn from_avro_value_at(
+        value: &apache_avro::types::Value,
+        depth: usize,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        if depth > MAX_AVRO_DECODE_DEPTH {
+            return Err("Avro nesting depth exceeds the generated limit".into());
+        }
+        let record_fields = match value {
+            apache_avro::types::Value::Record(fields) => fields,
+            _ => return Err("expected an Avro record value".into()),
         };
         let record_fields: std::collections::HashMap<_, _> = record_fields
             .iter()
@@ -148,6 +185,62 @@ impl {{ struct_name }} {
             {%- endfor %}
         })
     }
+
+    /// Encodes a low-level Avro value, including nullable fields that the
+    /// compatibility-preserving typed Rust model cannot represent.
+    pub fn to_avro_data_value(
+        value: apache_avro::types::Value,
+        content_type: &str,
+    ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        let media_type = content_type.split(';').next().unwrap_or("");
+        let (base_media_type, gzip) = media_type
+            .strip_suffix("+gzip")
+            .map_or((media_type, false), |base| (base, true));
+        if base_media_type != "avro/binary" &&
+           base_media_type != "application/vnd.apache.avro+avro" {
+            return Err(format!("unsupported media type: {}", media_type).into());
+        }
+        let result = apache_avro::to_avro_datum(&SCHEMA, value)?;
+        if gzip {
+            let mut encoder = GzEncoder::new(
+                Vec::new(),
+                flate2::Compression::default(),
+            );
+            encoder.write_all(&result)?;
+            return Ok(encoder.finish()?);
+        }
+        Ok(result)
+    }
+
+    /// Decodes a low-level Avro value without projecting it into the typed
+    /// Rust model. The returned type is part of apache_avro's public API.
+    pub fn from_avro_data_value(
+        data: impl AsRef<[u8]>,
+        content_type: &str,
+    ) -> Result<apache_avro::types::Value, Box<dyn std::error::Error>> {
+        let media_type = content_type.split(';').next().unwrap_or("");
+        let (base_media_type, gzip) = media_type
+            .strip_suffix("+gzip")
+            .map_or((media_type, false), |base| (base, true));
+        if base_media_type != "avro/binary" &&
+           base_media_type != "application/vnd.apache.avro+avro" {
+            return Err(format!("unsupported media type: {}", media_type).into());
+        }
+        {%- if xml_annotation %}
+        let data = crate::xml_support::decode_data(
+            data.as_ref(),
+            gzip,
+            true,
+        )?;
+        {%- else %}
+        let data = decode_data(data.as_ref(), gzip)?;
+        {%- endif %}
+        Ok(apache_avro::from_avro_datum(
+            &SCHEMA,
+            &mut &data[..],
+            None,
+        )?)
+    }
 {%- endif %}
 
 {%- if serde_annotation or avro_annotation or xml_annotation %}
@@ -158,14 +251,29 @@ impl {{ struct_name }} {
         let (base_media_type, gzip) = media_type
             .strip_suffix("+gzip")
             .map_or((media_type, false), |base| (base, true));
+        let supported = false
+            {%- if serde_annotation %}
+            || base_media_type == "application/json"
+            {%- endif %}
+            {%- if xml_annotation %}
+            || base_media_type == "application/xml"
+            || base_media_type == "text/xml"
+            {%- endif %}
+            {%- if avro_annotation %}
+            || base_media_type == "avro/binary"
+            || base_media_type == "application/vnd.apache.avro+avro"
+            {%- endif %};
+        if !supported {
+            return Err(format!("unsupported media type: {}", media_type).into());
+        }
         {%- if serde_annotation %}
-        if media_type.starts_with("application/json") {
+        if base_media_type == "application/json" {
             result = serde_json::to_vec(self)?;
         }
         else {% endif -%}
         {%- if xml_annotation %}
-        if media_type.starts_with("application/xml") ||
-           media_type.starts_with("text/xml") {
+        if base_media_type == "application/xml" ||
+           base_media_type == "text/xml" {
             let xml = quick_xml::se::to_string(self)?;
             result = xml.into_bytes();
             if result.len() > crate::xml_support::MAX_XML_DATA_SIZE {
@@ -201,26 +309,34 @@ impl {{ struct_name }} {
         let (base_media_type, gzip) = media_type
             .strip_suffix("+gzip")
             .map_or((media_type, false), |base| (base, true));
+        let supported = false
+            {%- if serde_annotation %}
+            || base_media_type == "application/json"
+            {%- endif %}
+            {%- if xml_annotation %}
+            || base_media_type == "application/xml"
+            || base_media_type == "text/xml"
+            {%- endif %}
+            {%- if avro_annotation %}
+            || base_media_type == "avro/binary"
+            || base_media_type == "application/vnd.apache.avro+avro"
+            {%- endif %};
+        if !supported {
+            return Err(format!("unsupported media type: {}", media_type).into());
+        }
         {%- if xml_annotation %}
-        let is_xml = media_type.starts_with("application/xml") ||
-                     media_type.starts_with("text/xml");
+        let is_xml = base_media_type == "application/xml" ||
+                     base_media_type == "text/xml";
         let data = crate::xml_support::decode_data(
             data.as_ref(),
             gzip,
-            is_xml,
+            true,
         )?;
         {%- else %}
-        let data = if gzip {
-            let mut decoder = GzDecoder::new(data.as_ref());
-            let mut decompressed_data = Vec::new();
-            std::io::copy(&mut decoder, &mut decompressed_data)?;
-            decompressed_data
-        } else {
-            data.as_ref().to_vec()
-        };
+        let data = decode_data(data.as_ref(), gzip)?;
         {%- endif %}
         {%- if serde_annotation %}
-        if media_type.starts_with("application/json") {
+        if base_media_type == "application/json" {
             let result = serde_json::from_slice(&data)?;
             return Ok(result)
         }
@@ -361,7 +477,7 @@ mod tests {
     fn test_serialize_deserialize_{{ struct_name.lower() }}() {
         let mut rng = rand::thread_rng();
         let instance = {{struct_name}}::generate_random_instance();
-        {%- if serde_annotation %}
+        {%- if serde_annotation and json_round_trip_safe %}
         // Test JSON serialization and deserialization
         let json_bytes = instance.to_byte_array("application/json").unwrap();
         let deserialized_instance: {{ struct_name }} = {{ struct_name }}::from_data(&json_bytes, "application/json").unwrap();
@@ -370,6 +486,14 @@ mod tests {
         let json_gzip_bytes = instance.to_byte_array("application/json+gzip").unwrap();
         let deserialized_gzip_instance: {{ struct_name }} = {{ struct_name }}::from_data(&json_gzip_bytes, "application/json+gzip").unwrap();
         assert_eq!(instance, deserialized_gzip_instance);
+        {%- endif %}
+        {%- if serde_annotation %}
+        assert!(instance.to_byte_array("application/json-invalid").is_err());
+        let invalid_json_media = {{ struct_name }}::from_data(
+            [0x1f, 0x8b],
+            "application/json-invalid+gzip",
+        ).unwrap_err();
+        assert!(invalid_json_media.to_string().contains("unsupported media type"));
         {%- endif %}
         {%- if avro_annotation %}
         // Test Avro serialization and deserialization
@@ -417,7 +541,18 @@ mod tests {
                 Box::new(apache_avro::types::Value::Null),
             );
         }
-        let null_bytes = apache_avro::to_avro_datum(&SCHEMA, null_value).unwrap();
+        let null_bytes = {{ struct_name }}::to_avro_data_value(
+            null_value,
+            "avro/binary",
+        ).unwrap();
+        let nullable_value = {{ struct_name }}::from_avro_data_value(
+            &null_bytes,
+            "avro/binary",
+        ).unwrap();
+        assert!(matches!(
+            nullable_value,
+            apache_avro::types::Value::Record(_)
+        ));
         let null_error = {{ struct_name }}::from_data(
             &null_bytes,
             "avro/binary",
@@ -448,6 +583,12 @@ mod tests {
         let text_xml_bytes = instance.to_byte_array("text/xml").unwrap();
         let deserialized_text_xml_instance = {{ struct_name }}::from_data(&text_xml_bytes, "text/xml").unwrap();
         assert_eq!(instance, deserialized_text_xml_instance);
+        assert!(instance.to_byte_array("application/xml-invalid").is_err());
+        let invalid_xml_media = {{ struct_name }}::from_data(
+            [0x1f, 0x8b],
+            "application/xml-invalid+gzip",
+        ).unwrap_err();
+        assert!(invalid_xml_media.to_string().contains("unsupported media type"));
         let xml_gzip_bytes = instance.to_byte_array("application/xml+gzip").unwrap();
         let deserialized_xml_gzip_instance = {{ struct_name }}::from_data(&xml_gzip_bytes, "application/xml+gzip").unwrap();
         assert_eq!(instance, deserialized_xml_gzip_instance);

--- a/avrotize/avrotorust/dataclass_union.rs.jinja
+++ b/avrotize/avrotorust/dataclass_union.rs.jinja
@@ -19,7 +19,7 @@ pub enum {{ union_enum_name }} {
 
 impl Default for {{ union_enum_name }} {
     fn default() -> Self {
-        return {{ union_enum_name }}::{{ union_fields[0].name }}({{ union_fields[0].default_value }})
+        return {{ union_enum_name }}::{{ default_union_field.name }}({{ default_union_field.default_value }})
     }
 }
 
@@ -102,6 +102,8 @@ impl<'de> Deserialize<'de> for {{ union_enum_name }} {
             {%- elif union_field.type.startswith("std::collections::HashMap<") %}
             {%- set field_type = 'std::collections::HashMap::<'+union_field.type[26:] %}
             let result = {{ field_type }}::deserialize(node).map_err(serde::de::Error::custom)?;
+            {%- elif union_field.type == "()" %}
+            let result = <()>::deserialize(node).map_err(serde::de::Error::custom)?;
             {%-else %}
             let result = {{ union_field.type }}::deserialize(node).map_err(serde::de::Error::custom)?;
             {%-endif %}

--- a/avrotize/avrotorust/dataclass_union.rs.jinja
+++ b/avrotize/avrotorust/dataclass_union.rs.jinja
@@ -183,9 +183,7 @@ impl {{ union_enum_name }} {
         match index {
             {%- for union_field in union_fields %}
             {{ union_field.avro_index }} => Ok(
-                {{ union_enum_name }}::{{ union_field.name }}(
-                    apache_avro::from_value(value)?
-                )
+                {{ union_enum_name }}::{{ union_field.name }}({{ union_field.avro_decode }})
             ),
             {%- endfor %}
             _ => Err(format!("unsupported Avro union branch: {}", index).into()),

--- a/avrotize/avrotorust/dataclass_union.rs.jinja
+++ b/avrotize/avrotorust/dataclass_union.rs.jinja
@@ -176,6 +176,22 @@ fn normalize_xml_text(value: serde_json::Value) -> serde_json::Value {
 
 impl {{ union_enum_name }} {
     {%- if avro_annotation %}
+    pub(crate) fn from_avro_branch(
+        index: u32,
+        value: &apache_avro::types::Value,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        match index {
+            {%- for union_field in union_fields %}
+            {{ union_field.avro_index }} => Ok(
+                {{ union_enum_name }}::{{ union_field.name }}(
+                    apache_avro::from_value(value)?
+                )
+            ),
+            {%- endfor %}
+            _ => Err(format!("unsupported Avro union branch: {}", index).into()),
+        }
+    }
+
     /// Serializes the union to Avro binary data.
     pub fn to_byte_array(&self, content_type: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
         let media_type = content_type.split(';').next().unwrap_or("");
@@ -238,15 +254,8 @@ impl {{ union_enum_name }} {
         };
         let value = apache_avro::from_avro_datum(&SCHEMA, &mut &data[..], None)?;
         match value {
-            apache_avro::types::Value::Union(index, value) => match index {
-                {%- for union_field in union_fields %}
-                {{ union_field.avro_index }} => Ok(
-                    {{ union_enum_name }}::{{ union_field.name }}(
-                        apache_avro::from_value(&value)?
-                    )
-                ),
-                {%- endfor %}
-                _ => Err(format!("unsupported Avro union branch: {}", index).into()),
+            apache_avro::types::Value::Union(index, value) => {
+                Self::from_avro_branch(index, &value)
             },
             _ => Err("expected an Avro union value".into()),
         }

--- a/avrotize/avrotorust/dataclass_union.rs.jinja
+++ b/avrotize/avrotorust/dataclass_union.rs.jinja
@@ -3,7 +3,7 @@ use lazy_static::lazy_static;
 use apache_avro::Schema;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
-use std::io::Write;
+use std::io::{Read, Write};
 {%- endif %}
 {%- if serde_annotation or avro_annotation or xml_annotation %}
 use serde::{self, Serialize, Deserialize};
@@ -24,9 +24,37 @@ impl Default for {{ union_enum_name }} {
 }
 
 {%- if avro_annotation %}
+const MAX_AVRO_DATA_SIZE: usize = 16 * 1024 * 1024;
+
+fn decode_avro_data(
+    data: &[u8],
+    gzip: bool,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    if data.len() > MAX_AVRO_DATA_SIZE {
+        return Err("input exceeds the generated data size limit".into());
+    }
+    if !gzip {
+        return Ok(data.to_vec());
+    }
+    let decoder = GzDecoder::new(data);
+    let mut result = Vec::new();
+    decoder
+        .take((MAX_AVRO_DATA_SIZE + 1) as u64)
+        .read_to_end(&mut result)?;
+    if result.len() > MAX_AVRO_DATA_SIZE {
+        return Err("decompressed input exceeds the generated data size limit".into());
+    }
+    Ok(result)
+}
+
 lazy_static! {
     /// The static Avro schema as a parsed object
     pub static ref SCHEMA: Schema = Schema::parse_str({{ avro_schema }}).unwrap();
+    {%- if source_null_index >= 0 %}
+    pub static ref SOURCE_SCHEMA: Schema = Schema::parse_str(
+        {{ source_avro_schema }}
+    ).unwrap();
+    {%- endif %}
 }
 {%- endif %}
 
@@ -94,6 +122,15 @@ impl<'de> Deserialize<'de> for {{ union_enum_name }} {
             }
         }
         {%- endif %}
+        let match_count = 0usize
+            {%- for union_field in union_fields %}
+            + usize::from({{ union_field.json_match_predicate }})
+            {%- endfor %};
+        if match_count > 1 {
+            return Err(serde::de::Error::custom(
+                "ambiguous JSON union value"
+            ));
+        }
         {%- for union_field in union_fields %}
         if {{ union_field.json_match_predicate }} {
             {%- if union_field.type.startswith("Vec<") %}
@@ -116,14 +153,16 @@ impl<'de> Deserialize<'de> for {{ union_enum_name }} {
 
 {%- if xml_annotation %}
 fn xml_scalar_match_count(value: &serde_json::Value) -> usize {
-    let serde_json::Value::Object(object) = value else {
-        return 0;
+    let object = match value {
+        serde_json::Value::Object(object) => object,
+        _ => return 0,
     };
     if object.len() != 1 {
         return 0;
     }
-    let Some(serde_json::Value::String(text)) = object.get("$text") else {
-        return 0;
+    let text = match object.get("$text") {
+        Some(serde_json::Value::String(text)) => text,
+        _ => return 0,
     };
     0usize
         {%- for union_field in union_fields %}
@@ -155,8 +194,9 @@ fn normalize_xml_value(value: serde_json::Value) -> serde_json::Value {
 }
 
 fn normalize_xml_text(value: serde_json::Value) -> serde_json::Value {
-    let serde_json::Value::String(text) = value else {
-        return normalize_xml_value(value);
+    let text = match value {
+        serde_json::Value::String(text) => text,
+        other => return normalize_xml_value(other),
     };
     if let Ok(value) = text.parse::<bool>() {
         return serde_json::Value::Bool(value);
@@ -181,7 +221,11 @@ impl {{ union_enum_name }} {
     pub(crate) fn from_avro_branch(
         index: u32,
         value: &apache_avro::types::Value,
+        depth: usize,
     ) -> Result<Self, Box<dyn std::error::Error>> {
+        if depth > 128 {
+            return Err("Avro nesting depth exceeds the generated limit".into());
+        }
         match index {
             {%- for union_field in union_fields %}
             {{ union_field.avro_index }} => Ok(
@@ -224,6 +268,7 @@ impl {{ union_enum_name }} {
 
     pub(crate) fn from_avro_source_value(
         value: &apache_avro::types::Value,
+        depth: usize,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         match value {
             apache_avro::types::Value::Union(index, value) => match index {
@@ -231,6 +276,7 @@ impl {{ union_enum_name }} {
                 {{ union_field.source_avro_index }} => Self::from_avro_branch(
                     {{ union_field.avro_index }},
                     value,
+                    depth,
                 ),
                 {%- endfor %}
                 _ => Err(
@@ -240,6 +286,71 @@ impl {{ union_enum_name }} {
             _ => Err("expected an Avro union value".into()),
         }
     }
+
+        {%- if source_null_index >= 0 %}
+        /// Encodes against the original nullable source schema. Pair this
+        /// method with `from_nullable_data`, not the legacy non-null methods.
+        pub fn to_nullable_byte_array(
+            value: Option<&Self>,
+            content_type: &str,
+        ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+            let media_type = content_type.split(';').next().unwrap_or("");
+            let (base_media_type, gzip) = media_type
+                .strip_suffix("+gzip")
+                .map_or((media_type, false), |base| (base, true));
+            if base_media_type != "avro/binary" &&
+               base_media_type != "application/vnd.apache.avro+avro" {
+                return Err(format!("unsupported media type: {}", media_type).into());
+            }
+            let avro_value = match value {
+                Some(value) => value.to_avro_source_value()?,
+                None => apache_avro::types::Value::Union(
+                    {{ source_null_index }},
+                    Box::new(apache_avro::types::Value::Null),
+                ),
+            };
+            let result = apache_avro::to_avro_datum(
+                &SOURCE_SCHEMA,
+                avro_value,
+            )?;
+            if gzip {
+                let mut encoder = GzEncoder::new(
+                    Vec::new(),
+                    flate2::Compression::default(),
+                );
+                encoder.write_all(&result)?;
+                return Ok(encoder.finish()?);
+            }
+            Ok(result)
+        }
+
+        /// Decodes data written against the original nullable source schema.
+        pub fn from_nullable_data(
+            data: impl AsRef<[u8]>,
+            content_type: &str,
+        ) -> Result<Option<Self>, Box<dyn std::error::Error>> {
+            let media_type = content_type.split(';').next().unwrap_or("");
+            let (base_media_type, gzip) = media_type
+                .strip_suffix("+gzip")
+                .map_or((media_type, false), |base| (base, true));
+            if base_media_type != "avro/binary" &&
+               base_media_type != "application/vnd.apache.avro+avro" {
+                return Err(format!("unsupported media type: {}", media_type).into());
+            }
+            let data = decode_avro_data(data.as_ref(), gzip)?;
+            let value = apache_avro::from_avro_datum(
+                &SOURCE_SCHEMA,
+                &mut &data[..],
+                None,
+            )?;
+            match value {
+                apache_avro::types::Value::Union(index, value)
+                    if index == {{ source_null_index }} =>
+                    Ok(None),
+                other => Ok(Some(Self::from_avro_source_value(&other, 0)?)),
+            }
+        }
+        {%- endif %}
 
     /// Serializes the union to Avro binary data.
     pub fn to_byte_array(&self, content_type: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
@@ -273,18 +384,11 @@ impl {{ union_enum_name }} {
             return Err(format!("unsupported media type: {}", media_type).into());
         }
 
-        let data = if gzip {
-            let mut decoder = GzDecoder::new(data.as_ref());
-            let mut decompressed_data = Vec::new();
-            std::io::copy(&mut decoder, &mut decompressed_data)?;
-            decompressed_data
-        } else {
-            data.as_ref().to_vec()
-        };
+        let data = decode_avro_data(data.as_ref(), gzip)?;
         let value = apache_avro::from_avro_datum(&SCHEMA, &mut &data[..], None)?;
         match value {
             apache_avro::types::Value::Union(index, value) => {
-                Self::from_avro_branch(index, &value)
+                Self::from_avro_branch(index, &value, 0)
             },
             _ => Err("expected an Avro union value".into()),
         }
@@ -306,7 +410,7 @@ impl {{ union_enum_name }} {
 
 #[cfg(test)]
 impl {{ union_enum_name }} {
-{%- set unique_fields = union_fields | selectattr('is_first_with_predicate') | list %}
+{%- set json_safe_fields = union_fields | selectattr('json_round_trip_safe') | list %}
 {%- set xml_safe_fields = union_fields | selectattr('xml_safe_for_random') | list %}
     pub fn generate_random_instance() -> {{ union_enum_name }} {
         let mut rng = rand::thread_rng();
@@ -318,10 +422,10 @@ impl {{ union_enum_name }} {
             {%- endfor %}
             _ => panic!("Invalid random index generated"),
         }
-        {%- elif serde_annotation and unique_fields | length < union_fields | length %}
+        {%- elif serde_annotation and json_safe_fields | length > 0 and json_safe_fields | length < union_fields | length %}
         // Only pick from variants with unique JSON structures to ensure round-trip works
-        match rand::Rng::gen_range(&mut rng, 0..{{ unique_fields | length }}) {
-            {%- for union_field in unique_fields %}
+        match rand::Rng::gen_range(&mut rng, 0..{{ json_safe_fields | length }}) {
+            {%- for union_field in json_safe_fields %}
             {{ loop.index0 }} => {{ union_enum_name }}::{{ union_field.name }}({{ union_field.random_value }}),
             {%- endfor %}
             _ => panic!("Invalid random index generated"),
@@ -341,13 +445,42 @@ impl {{ union_enum_name }} {
 mod tests {
     use super::*;
 
+    {%- if avro_annotation and source_null_index >= 0 %}
+    #[test]
+    fn test_nullable_avro_{{ union_enum_name.lower() }}() {
+        let null_bytes = {{ union_enum_name }}::to_nullable_byte_array(
+            None,
+            "avro/binary",
+        ).unwrap();
+        assert_eq!(
+            {{ union_enum_name }}::from_nullable_data(
+                &null_bytes,
+                "avro/binary",
+            ).unwrap(),
+            None,
+        );
+        let instance = {{ union_enum_name }}::default();
+        let value_bytes = {{ union_enum_name }}::to_nullable_byte_array(
+            Some(&instance),
+            "avro/binary+gzip",
+        ).unwrap();
+        assert_eq!(
+            {{ union_enum_name }}::from_nullable_data(
+                &value_bytes,
+                "avro/binary+gzip",
+            ).unwrap(),
+            Some(instance),
+        );
+    }
+    {%- endif %}
+
     {%- if serde_annotation or avro_annotation %}
     #[test]
     fn test_serialize_deserialize_{{ union_enum_name.lower() }}() {
         let mut rng = rand::thread_rng();
         {%- for union_field in union_fields %}
         let instance = {{ union_enum_name }}::{{ union_field.name }}({{ union_field.random_value }});
-        {%- if serde_annotation and union_field.is_first_with_predicate %}
+        {%- if serde_annotation and union_field.json_round_trip_safe %}
         let json_bytes = serde_json::to_vec(&instance).unwrap();
         let deserialized_instance: {{ union_enum_name }} = serde_json::from_slice(&json_bytes).unwrap();
         assert_eq!(instance, deserialized_instance);
@@ -377,6 +510,24 @@ mod tests {
         assert!({{ union_enum_name }}::from_data([], "avro/binary-invalid").is_err());
         assert!({{ union_enum_name }}::from_data([], "application/vnd.apache.avro+avroevil").is_err());
         assert!({{ union_enum_name }}::from_data([0, 1], "avro/binary+gzip").is_err());
+    }
+    {%- endif %}
+
+    {%- if serde_annotation and ambiguous_json_field %}
+    #[test]
+    fn test_rejects_ambiguous_json_{{ union_enum_name.lower() }}() {
+        let mut rng = rand::thread_rng();
+        let instance = {{ union_enum_name }}::{{ ambiguous_json_field.name }}(
+            {{ ambiguous_json_field.random_value }}
+        );
+        let json_bytes = serde_json::to_vec(&instance).unwrap();
+        let result = serde_json::from_slice::<{{ union_enum_name }}>(
+            &json_bytes
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains(
+            "ambiguous JSON union value"
+        ));
     }
     {%- endif %}
 

--- a/avrotize/avrotorust/dataclass_union.rs.jinja
+++ b/avrotize/avrotorust/dataclass_union.rs.jinja
@@ -207,6 +207,40 @@ impl {{ union_enum_name }} {
         })
     }
 
+    pub(crate) fn to_avro_source_value(
+        &self,
+    ) -> Result<apache_avro::types::Value, Box<dyn std::error::Error>> {
+        Ok(match self {
+            {%- for union_field in union_fields %}
+            {{ union_enum_name }}::{{ union_field.name }}(value) => {
+                apache_avro::types::Value::Union(
+                    {{ union_field.source_avro_index }},
+                    Box::new({{ union_field.avro_encode }}),
+                )
+            },
+            {%- endfor %}
+        })
+    }
+
+    pub(crate) fn from_avro_source_value(
+        value: &apache_avro::types::Value,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        match value {
+            apache_avro::types::Value::Union(index, value) => match index {
+                {%- for union_field in union_fields %}
+                {{ union_field.source_avro_index }} => Self::from_avro_branch(
+                    {{ union_field.avro_index }},
+                    value,
+                ),
+                {%- endfor %}
+                _ => Err(
+                    "nullable Avro union null is unsupported by the generated Rust union API".into()
+                ),
+            },
+            _ => Err("expected an Avro union value".into()),
+        }
+    }
+
     /// Serializes the union to Avro binary data.
     pub fn to_byte_array(&self, content_type: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
         let media_type = content_type.split(';').next().unwrap_or("");

--- a/avrotize/avrotorust/dataclass_union.rs.jinja
+++ b/avrotize/avrotorust/dataclass_union.rs.jinja
@@ -179,8 +179,11 @@ impl {{ union_enum_name }} {
     /// Serializes the union to Avro binary data.
     pub fn to_byte_array(&self, content_type: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
         let media_type = content_type.split(';').next().unwrap_or("");
-        if !media_type.starts_with("avro/binary") &&
-           !media_type.starts_with("application/vnd.apache.avro+avro") {
+        let (base_media_type, gzip) = media_type
+            .strip_suffix("+gzip")
+            .map_or((media_type, false), |base| (base, true));
+        if base_media_type != "avro/binary" &&
+           base_media_type != "application/vnd.apache.avro+avro" {
             return Err(format!("unsupported media type: {}", media_type).into());
         }
 
@@ -206,7 +209,7 @@ impl {{ union_enum_name }} {
             {%- endfor %}
         };
         let result = apache_avro::to_avro_datum(&SCHEMA, value)?;
-        if media_type.ends_with("+gzip") {
+        if gzip {
             let mut encoder = GzEncoder::new(Vec::new(), flate2::Compression::default());
             encoder.write_all(&result)?;
             return Ok(encoder.finish()?);
@@ -217,12 +220,15 @@ impl {{ union_enum_name }} {
     /// Deserializes the union from Avro binary data.
     pub fn from_data(data: impl AsRef<[u8]>, content_type: &str) -> Result<Self, Box<dyn std::error::Error>> {
         let media_type = content_type.split(';').next().unwrap_or("");
-        if !media_type.starts_with("avro/binary") &&
-           !media_type.starts_with("application/vnd.apache.avro+avro") {
+        let (base_media_type, gzip) = media_type
+            .strip_suffix("+gzip")
+            .map_or((media_type, false), |base| (base, true));
+        if base_media_type != "avro/binary" &&
+           base_media_type != "application/vnd.apache.avro+avro" {
             return Err(format!("unsupported media type: {}", media_type).into());
         }
 
-        let data = if media_type.ends_with("+gzip") {
+        let data = if gzip {
             let mut decoder = GzDecoder::new(data.as_ref());
             let mut decompressed_data = Vec::new();
             std::io::copy(&mut decoder, &mut decompressed_data)?;
@@ -314,6 +320,9 @@ mod tests {
         let avro_bytes = instance.to_byte_array("avro/binary").unwrap();
         let deserialized_instance = {{ union_enum_name }}::from_data(&avro_bytes, "avro/binary").unwrap();
         assert_eq!(instance, deserialized_instance);
+        let avro_gzip_bytes = instance.to_byte_array("avro/binary+gzip").unwrap();
+        let deserialized_gzip_instance = {{ union_enum_name }}::from_data(&avro_gzip_bytes, "avro/binary+gzip").unwrap();
+        assert_eq!(instance, deserialized_gzip_instance);
         {%- endif %}
         {%- endfor %}
     }
@@ -325,6 +334,11 @@ mod tests {
         let instance = {{ union_enum_name }}::default();
         assert!(instance.to_byte_array("text/plain").is_err());
         assert!({{ union_enum_name }}::from_data([], "text/plain").is_err());
+        assert!(instance.to_byte_array("avro/binary-invalid").is_err());
+        assert!(instance.to_byte_array("application/vnd.apache.avro+avroevil").is_err());
+        assert!({{ union_enum_name }}::from_data([], "avro/binary-invalid").is_err());
+        assert!({{ union_enum_name }}::from_data([], "application/vnd.apache.avro+avroevil").is_err());
+        assert!({{ union_enum_name }}::from_data([0, 1], "avro/binary+gzip").is_err());
     }
     {%- endif %}
 

--- a/avrotize/avrotorust/dataclass_union.rs.jinja
+++ b/avrotize/avrotorust/dataclass_union.rs.jinja
@@ -190,6 +190,21 @@ impl {{ union_enum_name }} {
         }
     }
 
+    pub(crate) fn to_avro_value(
+        &self,
+    ) -> Result<apache_avro::types::Value, Box<dyn std::error::Error>> {
+        Ok(match self {
+            {%- for union_field in union_fields %}
+            {{ union_enum_name }}::{{ union_field.name }}(value) => {
+                apache_avro::types::Value::Union(
+                    {{ union_field.avro_index }},
+                    Box::new({{ union_field.avro_encode }}),
+                )
+            },
+            {%- endfor %}
+        })
+    }
+
     /// Serializes the union to Avro binary data.
     pub fn to_byte_array(&self, content_type: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
         let media_type = content_type.split(';').next().unwrap_or("");
@@ -201,27 +216,7 @@ impl {{ union_enum_name }} {
             return Err(format!("unsupported media type: {}", media_type).into());
         }
 
-        let value = match self {
-            {%- for union_field in union_fields %}
-            {{ union_enum_name }}::{{ union_field.name }}(value) => {
-                let branch_schema = match &*SCHEMA {
-                    Schema::Union(schema) => &schema.variants()[{{ union_field.avro_index }}],
-                    _ => return Err("expected an Avro union schema".into()),
-                };
-                let schemata = match &*SCHEMA {
-                    Schema::Union(schema) => schema.variants().iter().collect(),
-                    _ => return Err("expected an Avro union schema".into()),
-                };
-                apache_avro::types::Value::Union(
-                    {{ union_field.avro_index }},
-                    Box::new(
-                        apache_avro::to_value(value)?
-                            .resolve_schemata(branch_schema, schemata)?
-                    ),
-                )
-            },
-            {%- endfor %}
-        };
+        let value = self.to_avro_value()?;
         let result = apache_avro::to_avro_datum(&SCHEMA, value)?;
         if gzip {
             let mut encoder = GzEncoder::new(Vec::new(), flate2::Compression::default());

--- a/avrotize/avrotorust/dataclass_union.rs.jinja
+++ b/avrotize/avrotorust/dataclass_union.rs.jinja
@@ -19,7 +19,7 @@ pub enum {{ union_enum_name }} {
 
 impl Default for {{ union_enum_name }} {
     fn default() -> Self {
-        return {{ union_enum_name }}::{{ default_union_field.name }}({{ default_union_field.default_value }})
+        return {{ union_enum_name }}::{{ union_fields[0].name }}({{ union_fields[0].default_value }})
     }
 }
 

--- a/avrotize/avrotorust/dataclass_union.rs.jinja
+++ b/avrotize/avrotorust/dataclass_union.rs.jinja
@@ -1,3 +1,10 @@
+{%- if avro_annotation %}
+use lazy_static::lazy_static;
+use apache_avro::Schema;
+use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
+use std::io::Write;
+{%- endif %}
 {%- if serde_annotation or avro_annotation or xml_annotation %}
 use serde::{self, Serialize, Deserialize};
 {%- endif %}
@@ -15,6 +22,13 @@ impl Default for {{ union_enum_name }} {
         return {{ union_enum_name }}::{{ union_fields[0].name }}({{ union_fields[0].default_value }})
     }
 }
+
+{%- if avro_annotation %}
+lazy_static! {
+    /// The static Avro schema as a parsed object
+    pub static ref SCHEMA: Schema = Schema::parse_str({{ avro_schema }}).unwrap();
+}
+{%- endif %}
 
 {% if serde_annotation or avro_annotation or xml_annotation %}
 impl Serialize for {{ union_enum_name }} {
@@ -161,6 +175,78 @@ fn normalize_xml_text(value: serde_json::Value) -> serde_json::Value {
 {%- endif %}
 
 impl {{ union_enum_name }} {
+    {%- if avro_annotation %}
+    /// Serializes the union to Avro binary data.
+    pub fn to_byte_array(&self, content_type: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        let media_type = content_type.split(';').next().unwrap_or("");
+        if !media_type.starts_with("avro/binary") &&
+           !media_type.starts_with("application/vnd.apache.avro+avro") {
+            return Err(format!("unsupported media type: {}", media_type).into());
+        }
+
+        let value = match self {
+            {%- for union_field in union_fields %}
+            {{ union_enum_name }}::{{ union_field.name }}(value) => {
+                let branch_schema = match &*SCHEMA {
+                    Schema::Union(schema) => &schema.variants()[{{ union_field.avro_index }}],
+                    _ => return Err("expected an Avro union schema".into()),
+                };
+                let schemata = match &*SCHEMA {
+                    Schema::Union(schema) => schema.variants().iter().collect(),
+                    _ => return Err("expected an Avro union schema".into()),
+                };
+                apache_avro::types::Value::Union(
+                    {{ union_field.avro_index }},
+                    Box::new(
+                        apache_avro::to_value(value)?
+                            .resolve_schemata(branch_schema, schemata)?
+                    ),
+                )
+            },
+            {%- endfor %}
+        };
+        let result = apache_avro::to_avro_datum(&SCHEMA, value)?;
+        if media_type.ends_with("+gzip") {
+            let mut encoder = GzEncoder::new(Vec::new(), flate2::Compression::default());
+            encoder.write_all(&result)?;
+            return Ok(encoder.finish()?);
+        }
+        Ok(result)
+    }
+
+    /// Deserializes the union from Avro binary data.
+    pub fn from_data(data: impl AsRef<[u8]>, content_type: &str) -> Result<Self, Box<dyn std::error::Error>> {
+        let media_type = content_type.split(';').next().unwrap_or("");
+        if !media_type.starts_with("avro/binary") &&
+           !media_type.starts_with("application/vnd.apache.avro+avro") {
+            return Err(format!("unsupported media type: {}", media_type).into());
+        }
+
+        let data = if media_type.ends_with("+gzip") {
+            let mut decoder = GzDecoder::new(data.as_ref());
+            let mut decompressed_data = Vec::new();
+            std::io::copy(&mut decoder, &mut decompressed_data)?;
+            decompressed_data
+        } else {
+            data.as_ref().to_vec()
+        };
+        let value = apache_avro::from_avro_datum(&SCHEMA, &mut &data[..], None)?;
+        match value {
+            apache_avro::types::Value::Union(index, value) => match index {
+                {%- for union_field in union_fields %}
+                {{ union_field.avro_index }} => Ok(
+                    {{ union_enum_name }}::{{ union_field.name }}(
+                        apache_avro::from_value(&value)?
+                    )
+                ),
+                {%- endfor %}
+                _ => Err(format!("unsupported Avro union branch: {}", index).into()),
+            },
+            _ => Err("expected an Avro union value".into()),
+        }
+    }
+    {%- endif %}
+
     pub fn is_json_match(node: &serde_json::Value) -> bool {
         return{%- for predicate in json_match_predicates %}
         {{ predicate }}{%if not loop.last%}||{%endif%}
@@ -211,20 +297,34 @@ impl {{ union_enum_name }} {
 mod tests {
     use super::*;
 
-    {%- if serde_annotation %}
+    {%- if serde_annotation or avro_annotation %}
     #[test]
     fn test_serialize_deserialize_{{ union_enum_name.lower() }}() {
         let mut rng = rand::thread_rng();
         {%- for union_field in union_fields %}
-        {%- if union_field.is_first_with_predicate %}
         let instance = {{ union_enum_name }}::{{ union_field.name }}({{ union_field.random_value }});
+        {%- if serde_annotation and union_field.is_first_with_predicate %}
         let json_bytes = serde_json::to_vec(&instance).unwrap();
         let deserialized_instance: {{ union_enum_name }} = serde_json::from_slice(&json_bytes).unwrap();
         assert_eq!(instance, deserialized_instance);
-        {%- else %}
-        // Skip {{ union_field.name }} - structurally identical to earlier variant, would deserialize as first match
+        {%- elif serde_annotation %}
+        // Skip JSON round-trip: structurally identical to an earlier variant.
+        {%- endif %}
+        {%- if avro_annotation %}
+        let avro_bytes = instance.to_byte_array("avro/binary").unwrap();
+        let deserialized_instance = {{ union_enum_name }}::from_data(&avro_bytes, "avro/binary").unwrap();
+        assert_eq!(instance, deserialized_instance);
         {%- endif %}
         {%- endfor %}
+    }
+    {%- endif %}
+
+    {%- if avro_annotation %}
+    #[test]
+    fn test_rejects_invalid_content_type_{{ union_enum_name.lower() }}() {
+        let instance = {{ union_enum_name }}::default();
+        assert!(instance.to_byte_array("text/plain").is_err());
+        assert!({{ union_enum_name }}::from_data([], "text/plain").is_err());
     }
     {%- endif %}
 

--- a/avrotize/rust/xml_support.rs.jinja
+++ b/avrotize/rust/xml_support.rs.jinja
@@ -101,8 +101,14 @@ fn validate_root_child(
 ) -> Result<bool, Box<dyn std::error::Error>> {
     let local_name = start.local_name();
     let local_name = std::str::from_utf8(local_name.as_ref())?;
-    let Some((_, repeatable, map)) = fields.iter().find(|(name, _, _)| *name == local_name) else {
-        return Err(invalid_data(format!("unknown XML element: {local_name}")));
+    let (_, repeatable, map) = match fields
+        .iter()
+        .find(|(name, _, _)| *name == local_name)
+    {
+        Some(field) => field,
+        None => return Err(invalid_data(format!(
+            "unknown XML element: {local_name}"
+        ))),
     };
     if !repeatable && !seen.insert(local_name.to_string()) {
         return Err(invalid_data(format!("duplicate XML element: {local_name}")));

--- a/test/avsc/rust-anyvalue-reference.avsc
+++ b/test/avsc/rust-anyvalue-reference.avsc
@@ -1,0 +1,24 @@
+[
+    {
+        "type": "record",
+        "name": "AnyValue",
+        "namespace": "avrotize",
+        "fields": [
+            {
+                "name": "value",
+                "type": "string"
+            }
+        ]
+    },
+    {
+        "type": "record",
+        "name": "AnyValueHolder",
+        "namespace": "issue406.anyvalue",
+        "fields": [
+            {
+                "name": "payload",
+                "type": "avrotize.AnyValue"
+            }
+        ]
+    }
+]

--- a/test/avsc/rust-enum-annotation.avsc
+++ b/test/avsc/rust-enum-annotation.avsc
@@ -1,0 +1,9 @@
+{
+    "type": "enum",
+    "name": "Status",
+    "namespace": "issue406.enum_only",
+    "symbols": [
+        "READY",
+        "ACTIVE"
+    ]
+}

--- a/test/avsc/rust-multitype-annotations.avsc
+++ b/test/avsc/rust-multitype-annotations.avsc
@@ -67,13 +67,13 @@
             {
                 "name": "choice",
                 "type": [
-                    "issue406.multitype.Simple",
+                    "Simple",
                     "issue406.multitype.Wrapper"
                 ]
             },
             {
                 "name": "primary",
-                "type": "issue406.multitype.Simple"
+                "type": "Simple"
             },
             {
                 "name": "secondary",

--- a/test/avsc/rust-multitype-annotations.avsc
+++ b/test/avsc/rust-multitype-annotations.avsc
@@ -232,5 +232,55 @@
                 ]
             }
         ]
+    },
+    {
+        "type": "record",
+        "name": "SoloUnion",
+        "namespace": "issue406.multitype",
+        "fields": [
+            {
+                "name": "value",
+                "type": "string"
+            }
+        ]
+    },
+    {
+        "type": "record",
+        "name": "AliasCarrier",
+        "namespace": "issue406.multitype",
+        "fields": [
+            {
+                "name": "solo",
+                "type": [
+                    "long",
+                    "int"
+                ]
+            }
+        ]
+    },
+    {
+        "type": "record",
+        "name": "Nested",
+        "namespace": "issue406.multitype.FooUnion",
+        "fields": [
+            {
+                "name": "value",
+                "type": "string"
+            }
+        ]
+    },
+    {
+        "type": "record",
+        "name": "AliasNamespaceCarrier",
+        "namespace": "issue406.multitype",
+        "fields": [
+            {
+                "name": "foo",
+                "type": [
+                    "long",
+                    "int"
+                ]
+            }
+        ]
     }
 ]

--- a/test/avsc/rust-multitype-annotations.avsc
+++ b/test/avsc/rust-multitype-annotations.avsc
@@ -80,5 +80,61 @@
                 "type": "issue406.multitype.Simple"
             }
         ]
+    },
+    {
+        "type": "record",
+        "name": "CollisionOne",
+        "namespace": "issue406.multitype",
+        "fields": [
+            {
+                "name": "choice",
+                "type": [
+                    "long",
+                    "int"
+                ]
+            }
+        ]
+    },
+    {
+        "type": "record",
+        "name": "CollisionTwo",
+        "namespace": "issue406.multitype",
+        "fields": [
+            {
+                "name": "choice",
+                "type": [
+                    "string",
+                    "boolean"
+                ]
+            }
+        ]
+    },
+    {
+        "type": "record",
+        "name": "Foo",
+        "namespace": "issue406.multitype",
+        "fields": [
+            {
+                "name": "barBaz",
+                "type": [
+                    "long",
+                    "int"
+                ]
+            }
+        ]
+    },
+    {
+        "type": "record",
+        "name": "FooBar",
+        "namespace": "issue406.multitype",
+        "fields": [
+            {
+                "name": "baz",
+                "type": [
+                    "string",
+                    "boolean"
+                ]
+            }
+        ]
     }
 ]

--- a/test/avsc/rust-multitype-annotations.avsc
+++ b/test/avsc/rust-multitype-annotations.avsc
@@ -232,55 +232,5 @@
                 ]
             }
         ]
-    },
-    {
-        "type": "record",
-        "name": "SoloUnion",
-        "namespace": "issue406.multitype",
-        "fields": [
-            {
-                "name": "value",
-                "type": "string"
-            }
-        ]
-    },
-    {
-        "type": "record",
-        "name": "AliasCarrier",
-        "namespace": "issue406.multitype",
-        "fields": [
-            {
-                "name": "solo",
-                "type": [
-                    "long",
-                    "int"
-                ]
-            }
-        ]
-    },
-    {
-        "type": "record",
-        "name": "Nested",
-        "namespace": "issue406.multitype.FooUnion",
-        "fields": [
-            {
-                "name": "value",
-                "type": "string"
-            }
-        ]
-    },
-    {
-        "type": "record",
-        "name": "AliasNamespaceCarrier",
-        "namespace": "issue406.multitype",
-        "fields": [
-            {
-                "name": "foo",
-                "type": [
-                    "long",
-                    "int"
-                ]
-            }
-        ]
     }
 ]

--- a/test/avsc/rust-multitype-annotations.avsc
+++ b/test/avsc/rust-multitype-annotations.avsc
@@ -136,5 +136,101 @@
                 ]
             }
         ]
+    },
+    {
+        "type": "record",
+        "name": "SyntheticPaths",
+        "namespace": "issue406.multitype",
+        "fields": [
+            {
+                "name": "items",
+                "type": {
+                    "type": "array",
+                    "items": [
+                        "long",
+                        "int"
+                    ]
+                }
+            },
+            {
+                "name": "itemsArrayItems",
+                "type": [
+                    "string",
+                    "boolean"
+                ]
+            },
+            {
+                "name": "entries",
+                "type": {
+                    "type": "map",
+                    "values": [
+                        "long",
+                        "int"
+                    ]
+                }
+            },
+            {
+                "name": "entriesMapValues",
+                "type": [
+                    "string",
+                    "boolean"
+                ]
+            },
+            {
+                "name": "branch",
+                "type": [
+                    {
+                        "type": "array",
+                        "items": [
+                            "long",
+                            "int"
+                        ]
+                    },
+                    {
+                        "type": "map",
+                        "values": [
+                            "string",
+                            "boolean"
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "type": "record",
+        "name": "TwinA",
+        "namespace": "issue406.multitype",
+        "fields": [
+            {
+                "name": "value",
+                "type": "string"
+            }
+        ]
+    },
+    {
+        "type": "record",
+        "name": "TwinB",
+        "namespace": "issue406.multitype",
+        "fields": [
+            {
+                "name": "value",
+                "type": "string"
+            }
+        ]
+    },
+    {
+        "type": "record",
+        "name": "TwinHolder",
+        "namespace": "issue406.multitype",
+        "fields": [
+            {
+                "name": "choice",
+                "type": [
+                    "TwinA",
+                    "TwinB"
+                ]
+            }
+        ]
     }
 ]

--- a/test/avsc/rust-multitype-annotations.avsc
+++ b/test/avsc/rust-multitype-annotations.avsc
@@ -1,0 +1,84 @@
+[
+    {
+        "type": "enum",
+        "name": "Standalone",
+        "namespace": "issue406.multitype",
+        "symbols": [
+            "FIRST",
+            "SECOND"
+        ]
+    },
+    {
+        "type": "record",
+        "name": "Simple",
+        "namespace": "issue406.multitype",
+        "fields": [
+            {
+                "name": "value",
+                "type": "string"
+            }
+        ]
+    },
+    {
+        "type": "record",
+        "name": "Alternate",
+        "namespace": "issue406.multitype",
+        "fields": [
+            {
+                "name": "count",
+                "type": "long"
+            }
+        ]
+    },
+    {
+        "type": "record",
+        "name": "Wrapper",
+        "namespace": "issue406.multitype",
+        "fields": [
+            {
+                "name": "simple",
+                "type": "issue406.multitype.Simple"
+            }
+        ]
+    },
+    {
+        "type": "record",
+        "name": "Composite",
+        "namespace": "issue406.multitype",
+        "fields": [
+            {
+                "name": "kind",
+                "type": {
+                    "type": "enum",
+                    "name": "InlineKind",
+                    "symbols": [
+                        "TEXT",
+                        "NUMBER"
+                    ]
+                }
+            },
+            {
+                "name": "value",
+                "type": [
+                    "string",
+                    "long"
+                ]
+            },
+            {
+                "name": "choice",
+                "type": [
+                    "issue406.multitype.Simple",
+                    "issue406.multitype.Wrapper"
+                ]
+            },
+            {
+                "name": "primary",
+                "type": "issue406.multitype.Simple"
+            },
+            {
+                "name": "secondary",
+                "type": "issue406.multitype.Simple"
+            }
+        ]
+    }
+]

--- a/test/avsc/rust-named-reference-resolution.avsc
+++ b/test/avsc/rust-named-reference-resolution.avsc
@@ -1,7 +1,7 @@
 [
     {
         "type": "record",
-        "name": "left.Item",
+        "name": "Left.Item",
         "fields": [
             {
                 "name": "leftValue",
@@ -11,7 +11,7 @@
     },
     {
         "type": "record",
-        "name": "right.Item",
+        "name": "Right.Item",
         "fields": [
             {
                 "name": "rightValue",
@@ -21,7 +21,7 @@
     },
     {
         "type": "record",
-        "name": "right.Holder",
+        "name": "Right.Holder",
         "fields": [
             {
                 "name": "local",
@@ -29,7 +29,7 @@
             },
             {
                 "name": "foreign",
-                "type": "left.Item"
+                "type": "Left.Item"
             }
         ]
     }

--- a/test/avsc/rust-named-reference-resolution.avsc
+++ b/test/avsc/rust-named-reference-resolution.avsc
@@ -1,0 +1,36 @@
+[
+    {
+        "type": "record",
+        "name": "left.Item",
+        "fields": [
+            {
+                "name": "leftValue",
+                "type": "string"
+            }
+        ]
+    },
+    {
+        "type": "record",
+        "name": "right.Item",
+        "fields": [
+            {
+                "name": "rightValue",
+                "type": "long"
+            }
+        ]
+    },
+    {
+        "type": "record",
+        "name": "right.Holder",
+        "fields": [
+            {
+                "name": "local",
+                "type": "Item"
+            },
+            {
+                "name": "foreign",
+                "type": "left.Item"
+            }
+        ]
+    }
+]

--- a/test/avsc/rust-root-types.avsc
+++ b/test/avsc/rust-root-types.avsc
@@ -1,0 +1,38 @@
+[
+    {
+        "type": "record",
+        "name": "RootRecord",
+        "fields": [
+            {
+                "name": "value",
+                "type": "string"
+            },
+            {
+                "name": "kind",
+                "type": "RootEnum"
+            },
+            {
+                "name": "nothing",
+                "type": [
+                    "null"
+                ]
+            },
+            {
+                "name": "choice",
+                "type": [
+                    "null",
+                    "string",
+                    "long"
+                ]
+            }
+        ]
+    },
+    {
+        "type": "enum",
+        "name": "RootEnum",
+        "symbols": [
+            "FIRST",
+            "SECOND"
+        ]
+    }
+]

--- a/test/avsc/rust-union-annotation.avsc
+++ b/test/avsc/rust-union-annotation.avsc
@@ -16,6 +16,14 @@
                 "long",
                 "int"
             ]
+        },
+        {
+            "name": "nullable",
+            "type": [
+                "null",
+                "string",
+                "long"
+            ]
         }
     ]
 }

--- a/test/avsc/rust-union-annotation.avsc
+++ b/test/avsc/rust-union-annotation.avsc
@@ -77,6 +77,24 @@
                     "items": "string"
                 }
             ]
+        },
+        {
+            "name": "payload",
+            "type": "bytes"
+        },
+        {
+            "name": "binaryChoice",
+            "type": [
+                "bytes",
+                "string"
+            ]
+        },
+        {
+            "name": "reverseOptional",
+            "type": [
+                "string",
+                "null"
+            ]
         }
     ]
 }

--- a/test/avsc/rust-union-annotation.avsc
+++ b/test/avsc/rust-union-annotation.avsc
@@ -37,6 +37,14 @@
                             "long",
                             "int"
                         ]
+                    },
+                    {
+                        "name": "nestedFixed",
+                        "type": {
+                            "type": "fixed",
+                            "name": "NestedFixedTen",
+                            "size": 10
+                        }
                     }
                 ]
             }
@@ -94,6 +102,40 @@
             "type": [
                 "string",
                 "null"
+            ]
+        },
+        {
+            "name": "directFixed",
+            "type": {
+                "type": "fixed",
+                "name": "DirectFixedTen",
+                "size": 10
+            }
+        },
+        {
+            "name": "fixedRef",
+            "type": "issue406.union_only.DirectFixedTen"
+        },
+        {
+            "name": "fixedChoice",
+            "type": [
+                {
+                    "type": "fixed",
+                    "name": "UnionFixedTen",
+                    "size": 10
+                },
+                "string"
+            ]
+        },
+        {
+            "name": "optionalFixed",
+            "type": [
+                "null",
+                {
+                    "type": "fixed",
+                    "name": "OptionalFixedSixteen",
+                    "size": 16
+                }
             ]
         }
     ]

--- a/test/avsc/rust-union-annotation.avsc
+++ b/test/avsc/rust-union-annotation.avsc
@@ -113,6 +113,41 @@
             ]
         },
         {
+            "name": "optionalNamedRecord",
+            "type": [
+                "null",
+                "OptionalInlineRecord"
+            ]
+        },
+        {
+            "name": "optionalQualifiedNamedRecord",
+            "type": [
+                "null",
+                "issue406.union_only.OptionalInlineRecord"
+            ]
+        },
+        {
+            "name": "optionalNamedEnum",
+            "type": [
+                "null",
+                {
+                    "type": "enum",
+                    "name": "OptionalNamedEnum",
+                    "symbols": [
+                        "FIRST",
+                        "SECOND"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "optionalNamedEnumRef",
+            "type": [
+                "null",
+                "OptionalNamedEnum"
+            ]
+        },
+        {
             "name": "payload",
             "type": "bytes"
         },

--- a/test/avsc/rust-union-annotation.avsc
+++ b/test/avsc/rust-union-annotation.avsc
@@ -1,0 +1,21 @@
+{
+    "type": "record",
+    "name": "UnionHolder",
+    "namespace": "issue406.union_only",
+    "fields": [
+        {
+            "name": "value",
+            "type": [
+                "string",
+                "long"
+            ]
+        },
+        {
+            "name": "numeric",
+            "type": [
+                "long",
+                "int"
+            ]
+        }
+    ]
+}

--- a/test/avsc/rust-union-annotation.avsc
+++ b/test/avsc/rust-union-annotation.avsc
@@ -87,6 +87,32 @@
             ]
         },
         {
+            "name": "optionalMap",
+            "type": [
+                "null",
+                {
+                    "type": "map",
+                    "values": "string"
+                }
+            ]
+        },
+        {
+            "name": "optionalInlineRecord",
+            "type": [
+                "null",
+                {
+                    "type": "record",
+                    "name": "OptionalInlineRecord",
+                    "fields": [
+                        {
+                            "name": "value",
+                            "type": "string"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
             "name": "payload",
             "type": "bytes"
         },

--- a/test/avsc/rust-union-annotation.avsc
+++ b/test/avsc/rust-union-annotation.avsc
@@ -24,6 +24,59 @@
                 "string",
                 "long"
             ]
+        },
+        {
+            "name": "nested",
+            "type": {
+                "type": "record",
+                "name": "NestedHolder",
+                "fields": [
+                    {
+                        "name": "numeric",
+                        "type": [
+                            "long",
+                            "int"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "optionalNested",
+            "type": [
+                "null",
+                "issue406.union_only.NestedHolder"
+            ]
+        },
+        {
+            "name": "arrayValues",
+            "type": {
+                "type": "array",
+                "items": [
+                    "long",
+                    "int"
+                ]
+            }
+        },
+        {
+            "name": "mapValues",
+            "type": {
+                "type": "map",
+                "values": [
+                    "long",
+                    "int"
+                ]
+            }
+        },
+        {
+            "name": "optionalArray",
+            "type": [
+                "null",
+                {
+                    "type": "array",
+                    "items": "string"
+                }
+            ]
         }
     ]
 }

--- a/test/avsc/rust-union-annotation.avsc
+++ b/test/avsc/rust-union-annotation.avsc
@@ -117,6 +117,20 @@
             "type": "issue406.union_only.DirectFixedTen"
         },
         {
+            "name": "optionalFixedRef",
+            "type": [
+                "null",
+                "DirectFixedTen"
+            ]
+        },
+        {
+            "name": "optionalQualifiedFixedRef",
+            "type": [
+                "null",
+                "issue406.union_only.DirectFixedTen"
+            ]
+        },
+        {
             "name": "fixedChoice",
             "type": [
                 {

--- a/test/avsc/rust-union-annotation.avsc
+++ b/test/avsc/rust-union-annotation.avsc
@@ -131,6 +131,48 @@
             ]
         },
         {
+            "name": "nullFirst",
+            "type": [
+                "null",
+                {
+                    "type": "array",
+                    "items": [
+                        "long",
+                        "int"
+                    ]
+                },
+                "string"
+            ]
+        },
+        {
+            "name": "nullMiddle",
+            "type": [
+                {
+                    "type": "array",
+                    "items": [
+                        "long",
+                        "int"
+                    ]
+                },
+                "null",
+                "string"
+            ]
+        },
+        {
+            "name": "nullLast",
+            "type": [
+                {
+                    "type": "array",
+                    "items": [
+                        "long",
+                        "int"
+                    ]
+                },
+                "string",
+                "null"
+            ]
+        },
+        {
             "name": "fixedChoice",
             "type": [
                 {

--- a/test/test_avrotorust.py
+++ b/test/test_avrotorust.py
@@ -106,13 +106,14 @@ class TestAvroToRust(unittest.TestCase):
         self.assert_module_scoped_schemas(
             rust_path,
             {
-                "issue406/union_only/numericunion.rs",
-                "issue406/union_only/arrayvaluesunion.rs",
-                "issue406/union_only/mapvaluesunion.rs",
+                "issue406/union_only/record11unionholdernumericunion.rs",
+                "issue406/union_only/record11unionholderarrayvaluesunion.rs",
+                "issue406/union_only/record11unionholdermapvaluesunion.rs",
                 "issue406/union_only/nestedholder.rs",
-                "issue406/union_only/nullableunion.rs",
+                "issue406/union_only/record12nestedholdernumericunion.rs",
+                "issue406/union_only/record11unionholdernullableunion.rs",
                 "issue406/union_only/unionholder.rs",
-                "issue406/union_only/valueunion.rs",
+                "issue406/union_only/record11unionholdervalueunion.rs",
             },
         )
         union_holder_path = os.path.join(
@@ -125,7 +126,7 @@ class TestAvroToRust(unittest.TestCase):
         with open(union_holder_path, "r", encoding="utf-8") as generated_file:
             avro_source = generated_file.read()
         self.assertIn(
-            "pub nullable: Option<crate::issue406::union_only::nullableunion::NullableUnion>",
+            "pub nullable: Option<crate::issue406::union_only::record11unionholdernullableunion::Record11UnionHolderNullableUnion>",
             avro_source,
         )
 
@@ -162,12 +163,20 @@ class TestAvroToRust(unittest.TestCase):
             rust_path,
             {
                 "issue406/multitype/alternate.rs",
+                "issue406/multitype/collisionone.rs",
+                "issue406/multitype/record12collisiononechoiceunion.rs",
+                "issue406/multitype/collisiontwo.rs",
+                "issue406/multitype/record12collisiontwochoiceunion.rs",
                 "issue406/multitype/composite.rs",
-                "issue406/multitype/choiceunion.rs",
+                "issue406/multitype/record9compositechoiceunion.rs",
+                "issue406/multitype/foo.rs",
+                "issue406/multitype/record3foobarbazunion.rs",
+                "issue406/multitype/foobar.rs",
+                "issue406/multitype/record6foobarbazunion.rs",
                 "issue406/multitype/inlinekind.rs",
                 "issue406/multitype/simple.rs",
                 "issue406/multitype/standalone.rs",
-                "issue406/multitype/valueunion.rs",
+                "issue406/multitype/record9compositevalueunion.rs",
                 "issue406/multitype/wrapper.rs",
             },
         )

--- a/test/test_avrotorust.py
+++ b/test/test_avrotorust.py
@@ -87,6 +87,90 @@ class TestAvroToRust(unittest.TestCase):
             str(signature_a),
         )
         self.assertEqual(signature_a, signature_b)
+
+    def test_named_type_resolution_requires_current_namespace(self):
+        """Do not resolve unqualified names from unrelated namespaces."""
+        converter = AvroToRust()
+        left = {
+            "type": "record",
+            "name": "Item",
+            "namespace": "Left",
+            "fields": [],
+        }
+        converter.index_avro_named_types(left)
+        self.assertIsNone(
+            converter.resolve_avro_named_type("Item", "Right")
+        )
+        self.assertIs(
+            left,
+            converter.resolve_avro_named_type("Left.Item", "Right"),
+        )
+
+    def test_logical_fixed_mapping_is_preserved(self):
+        """Keep the existing decimal fixed mapping while fixing plain fixed."""
+        converter = AvroToRust()
+        self.assertEqual(
+            "f64",
+            converter.convert_avro_type_to_rust(
+                "amount",
+                {
+                    "type": "fixed",
+                    "name": "Amount",
+                    "size": 8,
+                    "logicalType": "decimal",
+                    "precision": 12,
+                    "scale": 2,
+                },
+                "issue406.fixed",
+            ),
+        )
+
+    def test_rust_module_output_is_hash_seed_deterministic(self):
+        """Sort generated module declarations independently of hash seed."""
+        outputs = []
+        fixture = os.path.join(
+            os.getcwd(),
+            "test",
+            "avsc",
+            "rust-multitype-annotations.avsc",
+        )
+        for seed in ("1", "8675309"):
+            rust_path = os.path.join(
+                tempfile.gettempdir(),
+                "avrotize",
+                f"rust-determinism-{seed}",
+            )
+            if os.path.exists(rust_path):
+                shutil.rmtree(rust_path, ignore_errors=True)
+            env = os.environ.copy()
+            env["PYTHONHASHSEED"] = seed
+            subprocess.check_call(
+                [
+                    sys.executable,
+                    "-c",
+                    (
+                        "from avrotize.avrotorust import convert_avro_to_rust; "
+                        f"convert_avro_to_rust(r'{fixture}', r'{rust_path}', "
+                        "package_name='rust-determinism', "
+                        "avro_annotation=True, serde_annotation=True)"
+                    ),
+                ],
+                env=env,
+            )
+            module_files = {}
+            for root, _, files in os.walk(os.path.join(rust_path, "src")):
+                for file_name in files:
+                    if file_name not in ("mod.rs", "lib.rs"):
+                        continue
+                    file_path = os.path.join(root, file_name)
+                    relative = os.path.relpath(
+                        file_path,
+                        os.path.join(rust_path, "src"),
+                    )
+                    with open(file_path, "rb") as module_file:
+                        module_files[relative] = module_file.read()
+            outputs.append(module_files)
+        self.assertEqual(outputs[0], outputs[1])
     
     def run_convert_to_rust(
         self,
@@ -198,7 +282,7 @@ class TestAvroToRust(unittest.TestCase):
         rust_path = self.run_convert_to_rust("rust-union-annotation", True, True)
         self.assert_module_scoped_schemas(
             rust_path,
-            expected_count=9,
+            expected_count=10,
             required_modules={
                 "issue406/union_only/nestedholder.rs",
                 "issue406/union_only/unionholder.rs",
@@ -215,9 +299,45 @@ class TestAvroToRust(unittest.TestCase):
             avro_source = generated_file.read()
         self.assertRegex(
             avro_source,
-            r"pub nullable: Option<crate::issue406::union_only::"
-            r"union[a-z0-9]+::Union[A-Za-z0-9]+>",
+            r"pub nullable: crate::issue406::union_only::"
+            r"union[a-z0-9]+::Union[A-Za-z0-9]+,",
         )
+        legacy_alias_path = os.path.join(
+            rust_path,
+            "src",
+            "issue406",
+            "union_only",
+            "nullableunion.rs",
+        )
+        self.assertTrue(os.path.exists(legacy_alias_path))
+        integration_dir = os.path.join(rust_path, "tests")
+        os.makedirs(integration_dir, exist_ok=True)
+        with open(
+            os.path.join(integration_dir, "legacy_union_api.rs"),
+            "w",
+            encoding="utf-8",
+        ) as legacy_test:
+            legacy_test.write(
+                "use rust_union_annotation::issue406::union_only::{\n"
+                "    nullableunion::NullableUnion,\n"
+                "    unionholder::UnionHolder,\n"
+                "};\n\n"
+                "#[test]\n"
+                "fn legacy_avro_union_api_compiles() {\n"
+                "    let holder = UnionHolder {\n"
+                "        nullable: NullableUnion::Null(()),\n"
+                "        ..Default::default()\n"
+                "    };\n"
+                "    assert!(matches!(holder.nullable, NullableUnion::Null(())));\n"
+                "}\n"
+            )
+        assert subprocess.check_call(
+            ['cargo', 'test'],
+            cwd=rust_path,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+            timeout=self.CARGO_TIMEOUT,
+        ) == 0
 
         legacy_field = (
             "pub nullable: "
@@ -250,16 +370,20 @@ class TestAvroToRust(unittest.TestCase):
         rust_path = self.run_convert_to_rust("rust-multitype-annotations", True, True)
         schema_modules = self.assert_module_scoped_schemas(
             rust_path,
-            expected_count=28,
+            expected_count=34,
             required_modules={
                 "issue406/multitype/alternate.rs",
+                "issue406/multitype/aliascarrier.rs",
+                "issue406/multitype/aliasnamespacecarrier.rs",
                 "issue406/multitype/collisionone.rs",
                 "issue406/multitype/collisiontwo.rs",
                 "issue406/multitype/composite.rs",
                 "issue406/multitype/foo.rs",
+                "issue406/multitype/foounion/nested.rs",
                 "issue406/multitype/foobar.rs",
                 "issue406/multitype/inlinekind.rs",
                 "issue406/multitype/simple.rs",
+                "issue406/multitype/solounion.rs",
                 "issue406/multitype/standalone.rs",
                 "issue406/multitype/syntheticpaths.rs",
                 "issue406/multitype/twina.rs",
@@ -272,7 +396,27 @@ class TestAvroToRust(unittest.TestCase):
             module for module in schema_modules
             if os.path.basename(module).startswith("union")
         }
-        self.assertEqual(14, len(union_modules))
+        self.assertEqual(16, len(union_modules))
+        solo_union_path = os.path.join(
+            rust_path,
+            "src",
+            "issue406",
+            "multitype",
+            "solounion.rs",
+        )
+        with open(solo_union_path, "r", encoding="utf-8") as generated_file:
+            self.assertIn("pub struct SoloUnion", generated_file.read())
+        self.assertFalse(
+            os.path.isfile(
+                os.path.join(
+                    rust_path,
+                    "src",
+                    "issue406",
+                    "multitype",
+                    "foounion.rs",
+                )
+            )
+        )
 
     def test_convert_named_reference_resolution_to_rust(self):
         """Resolve dotted names and duplicate short names by namespace."""

--- a/test/test_avrotorust.py
+++ b/test/test_avrotorust.py
@@ -650,6 +650,151 @@ class TestAvroToRust(unittest.TestCase):
         )
         self.assertFalse(os.path.exists(alias_path))
 
+    def test_stale_alias_does_not_delete_new_named_type(self):
+        """Keep a current named type that occupies a stale alias path."""
+        rust_path = os.path.join(
+            tempfile.gettempdir(),
+            "avrotize",
+            "rust-alias-to-named",
+        )
+        if os.path.exists(rust_path):
+            shutil.rmtree(rust_path, ignore_errors=True)
+        first_schema = {
+            "type": "record",
+            "name": "Carrier",
+            "namespace": "n",
+            "fields": [
+                {"name": "choice", "type": ["long", "int"]}
+            ],
+        }
+        convert_avro_schema_to_rust(
+            first_schema,
+            rust_path,
+            package_name="rust-alias-to-named",
+            serde_annotation=True,
+        )
+        alias_path = os.path.join(
+            rust_path,
+            "src",
+            "n",
+            "choiceunion.rs",
+        )
+        self.assertTrue(os.path.isfile(alias_path))
+
+        second_schema = {
+            "type": "record",
+            "name": "ChoiceUnion",
+            "namespace": "n",
+            "fields": [
+                {"name": "value", "type": "string"}
+            ],
+        }
+        convert_avro_schema_to_rust(
+            second_schema,
+            rust_path,
+            package_name="rust-alias-to-named",
+            serde_annotation=True,
+        )
+        with open(alias_path, "r", encoding="utf-8") as named_file:
+            self.assertIn(
+                "pub struct ChoiceUnion",
+                named_file.read(),
+            )
+
+    def test_shared_outer_union_registers_descendant_aliases(self):
+        """Register nested legacy aliases for every shared outer owner."""
+        rust_path = os.path.join(
+            tempfile.gettempdir(),
+            "avrotize",
+            "rust-shared-outer-union",
+        )
+        if os.path.exists(rust_path):
+            shutil.rmtree(rust_path, ignore_errors=True)
+        nested_union = [
+            {
+                "type": "array",
+                "items": ["long", "int"],
+            },
+            "string",
+        ]
+        schema = {
+            "type": "record",
+            "name": "Carrier",
+            "namespace": "n",
+            "fields": [
+                {"name": "foo", "type": nested_union},
+                {"name": "bar", "type": nested_union},
+            ],
+        }
+        convert_avro_schema_to_rust(
+            schema,
+            rust_path,
+            package_name="rust-shared-outer-union",
+            serde_annotation=True,
+        )
+        for alias_name in (
+            "foooption0union.rs",
+            "baroption0union.rs",
+        ):
+            self.assertTrue(
+                os.path.isfile(
+                    os.path.join(
+                        rust_path,
+                        "src",
+                        "n",
+                        alias_name,
+                    )
+                )
+            )
+
+    def test_union_sharing_normalizes_rust_namespace(self):
+        """Match planning and generation namespace normalization."""
+        rust_path = os.path.join(
+            tempfile.gettempdir(),
+            "avrotize",
+            "rust-union-namespace-normalization",
+        )
+        if os.path.exists(rust_path):
+            shutil.rmtree(rust_path, ignore_errors=True)
+        schema = [
+            {
+                "type": "record",
+                "name": "One",
+                "namespace": "N",
+                "fields": [
+                    {"name": "choice", "type": ["long", "int"]}
+                ],
+            },
+            {
+                "type": "record",
+                "name": "Two",
+                "namespace": "n",
+                "fields": [
+                    {"name": "choice", "type": ["long", "int"]}
+                ],
+            },
+        ]
+        convert_avro_schema_to_rust(
+            schema,
+            rust_path,
+            package_name="rust-union-namespace-normalization",
+            serde_annotation=True,
+        )
+        union_files = glob.glob(
+            os.path.join(rust_path, "src", "n", "unionpath*.rs")
+        )
+        self.assertEqual(1, len(union_files))
+        self.assertTrue(
+            os.path.isfile(
+                os.path.join(
+                    rust_path,
+                    "src",
+                    "n",
+                    "choiceunion.rs",
+                )
+            )
+        )
+
     def test_output_parent_path_case_is_preserved(self):
         """Never lowercase caller-provided output directory components."""
         rust_path = os.path.join(
@@ -954,7 +1099,7 @@ class TestAvroToRust(unittest.TestCase):
         rust_path = self.run_convert_to_rust("rust-union-annotation", True, True)
         self.assert_module_scoped_schemas(
             rust_path,
-            expected_count=17,
+            expected_count=12,
             required_modules={
                 "issue406/union_only/nestedholder.rs",
                 "issue406/union_only/unionholder.rs",
@@ -986,6 +1131,28 @@ class TestAvroToRust(unittest.TestCase):
             avro_source,
             r"pub optional_inline_record: crate::issue406::union_only::"
             r"optionalinlinerecord::OptionalInlineRecord",
+        )
+        self.assertRegex(
+            avro_source,
+            r"pub optional_named_record: crate::issue406::union_only::"
+            r"optionalinlinerecord::OptionalInlineRecord",
+        )
+        self.assertRegex(
+            avro_source,
+            r"pub optional_qualified_named_record: "
+            r"crate::issue406::union_only::"
+            r"optionalinlinerecord::OptionalInlineRecord",
+        )
+        self.assertRegex(
+            avro_source,
+            r"pub optional_named_enum: crate::issue406::union_only::"
+            r"optionalnamedenum::OptionalNamedEnum",
+        )
+        self.assertRegex(
+            avro_source,
+            r"pub optional_named_enum_ref: "
+            r"crate::issue406::union_only::"
+            r"optionalnamedenum::OptionalNamedEnum",
         )
         self.assertIn(
             "pub optional_fixed: Vec<u8>",
@@ -1076,7 +1243,7 @@ class TestAvroToRust(unittest.TestCase):
         rust_path = self.run_convert_to_rust("rust-multitype-annotations", True, True)
         schema_modules = self.assert_module_scoped_schemas(
             rust_path,
-            expected_count=28,
+            expected_count=20,
             required_modules={
                 "issue406/multitype/alternate.rs",
                 "issue406/multitype/collisionone.rs",
@@ -1098,7 +1265,7 @@ class TestAvroToRust(unittest.TestCase):
             module for module in schema_modules
             if os.path.basename(module).startswith("union")
         }
-        self.assertEqual(14, len(union_modules))
+        self.assertEqual(6, len(union_modules))
 
     def test_convert_named_reference_resolution_to_rust(self):
         """Resolve dotted names and duplicate short names by namespace."""

--- a/test/test_avrotorust.py
+++ b/test/test_avrotorust.py
@@ -125,6 +125,73 @@ class TestAvroToRust(unittest.TestCase):
             ),
         )
 
+    def test_case_distinct_avro_names_fail_before_output(self):
+        """Reject Avro names that normalize to one Rust module path."""
+        rust_path = os.path.join(
+            tempfile.gettempdir(),
+            "avrotize",
+            "rust-case-collision",
+        )
+        if os.path.exists(rust_path):
+            shutil.rmtree(rust_path, ignore_errors=True)
+        schema = [
+            {
+                "type": "record",
+                "name": "Item",
+                "namespace": "Foo",
+                "fields": [],
+            },
+            {
+                "type": "record",
+                "name": "Item",
+                "namespace": "foo",
+                "fields": [],
+            },
+        ]
+        with self.assertRaisesRegex(
+            ValueError,
+            r"same Rust path.*Foo\.Item.*foo\.Item",
+        ):
+            convert_avro_schema_to_rust(
+                schema,
+                rust_path,
+                package_name="rust-case-collision",
+                avro_annotation=True,
+            )
+        self.assertFalse(os.path.exists(rust_path))
+
+        type_case_path = os.path.join(
+            tempfile.gettempdir(),
+            "avrotize",
+            "rust-type-case-collision",
+        )
+        if os.path.exists(type_case_path):
+            shutil.rmtree(type_case_path, ignore_errors=True)
+        with self.assertRaisesRegex(
+            ValueError,
+            r"same Rust path.*foo\.ITEM.*foo\.Item",
+        ):
+            convert_avro_schema_to_rust(
+                [
+                    {
+                        "type": "record",
+                        "name": "Item",
+                        "namespace": "foo",
+                        "fields": [],
+                    },
+                    {
+                        "type": "record",
+                        "name": "ITEM",
+                        "namespace": "foo",
+                        "fields": [],
+                    },
+                ],
+                type_case_path,
+                package_name="rust-type-case-collision",
+                avro_annotation=True,
+            )
+        self.assertFalse(os.path.exists(type_case_path))
+
     def test_rust_module_output_is_hash_seed_deterministic(self):
         """Sort generated module declarations independently of hash seed."""
         outputs = []

--- a/test/test_avrotorust.py
+++ b/test/test_avrotorust.py
@@ -192,6 +192,77 @@ class TestAvroToRust(unittest.TestCase):
             )
         self.assertFalse(os.path.exists(type_case_path))
 
+    def test_rust_type_file_directory_conflict_fails_before_output(self):
+        """Reject a Rust module path required as both file and directory."""
+        schemas = [
+            {
+                "type": "record",
+                "name": "B",
+                "namespace": "a",
+                "fields": [],
+            },
+            {
+                "type": "record",
+                "name": "C",
+                "namespace": "a.b",
+                "fields": [],
+            },
+        ]
+        for index, schema in enumerate((schemas, list(reversed(schemas)))):
+            rust_path = os.path.join(
+                tempfile.gettempdir(),
+                "avrotize",
+                f"rust-prefix-collision-{index}",
+            )
+            if os.path.exists(rust_path):
+                shutil.rmtree(rust_path, ignore_errors=True)
+            with self.assertRaisesRegex(
+                ValueError,
+                r"both a file and directory.*a\.B.*a\.b\.C",
+            ):
+                convert_avro_schema_to_rust(
+                    schema,
+                    rust_path,
+                    package_name="rust-prefix-collision",
+                    avro_annotation=True,
+                )
+            self.assertFalse(os.path.exists(rust_path))
+
+        root_schemas = [
+            {
+                "type": "record",
+                "name": "B",
+                "fields": [],
+            },
+            {
+                "type": "record",
+                "name": "C",
+                "namespace": "b",
+                "fields": [],
+            },
+        ]
+        for index, schema in enumerate(
+            (root_schemas, list(reversed(root_schemas)))
+        ):
+            rust_path = os.path.join(
+                tempfile.gettempdir(),
+                "avrotize",
+                f"rust-root-prefix-collision-{index}",
+            )
+            if os.path.exists(rust_path):
+                shutil.rmtree(rust_path, ignore_errors=True)
+            with self.assertRaisesRegex(
+                ValueError,
+                r"both a file and directory.*'B'.*'b\.C'",
+            ):
+                convert_avro_schema_to_rust(
+                    schema,
+                    rust_path,
+                    package_name="rust-root-prefix-collision",
+                    avro_annotation=True,
+                )
+            self.assertFalse(os.path.exists(rust_path))
+
     def test_rust_module_output_is_hash_seed_deterministic(self):
         """Sort generated module declarations independently of hash seed."""
         outputs = []

--- a/test/test_avrotorust.py
+++ b/test/test_avrotorust.py
@@ -90,6 +90,11 @@ class TestAvroToRust(unittest.TestCase):
             rust_path,
             {"issue406/enum_only/status.rs"},
         )
+        avro_only_path = self.run_convert_to_rust("rust-enum-annotation", True, False)
+        self.assert_module_scoped_schemas(
+            avro_only_path,
+            {"issue406/enum_only/status.rs"},
+        )
 
     def test_convert_union_avro_annotations_to_rust(self):
         """Compile a union-bearing crate with Avro binary round-trip coverage."""
@@ -98,6 +103,7 @@ class TestAvroToRust(unittest.TestCase):
             rust_path,
             {
                 "issue406/union_only/numericunion.rs",
+                "issue406/union_only/nullableunion.rs",
                 "issue406/union_only/unionholder.rs",
                 "issue406/union_only/valueunion.rs",
             },

--- a/test/test_avrotorust.py
+++ b/test/test_avrotorust.py
@@ -34,6 +34,25 @@ class TestAvroToRust(unittest.TestCase):
         convert_avro_to_rust(avro_path, rust_path, package_name=name, avro_annotation=avro_annotation, serde_annotation=serde_annotation)
         assert subprocess.check_call(
             ['cargo', 'test'], cwd=rust_path, stdout=sys.stdout, stderr=sys.stderr, timeout=self.CARGO_TIMEOUT) == 0
+        return rust_path
+
+    def assert_module_scoped_schemas(self, rust_path: str, expected_modules: set[str]):
+        """Assert each expected generated module owns one module-scoped SCHEMA."""
+        schema_modules = set()
+        for root, _, files in os.walk(os.path.join(rust_path, "src")):
+            for file_name in files:
+                if not file_name.endswith(".rs"):
+                    continue
+                file_path = os.path.join(root, file_name)
+                with open(file_path, "r", encoding="utf-8") as generated_file:
+                    source = generated_file.read()
+                if "pub static ref SCHEMA" not in source:
+                    continue
+                relative_path = os.path.relpath(file_path, os.path.join(rust_path, "src"))
+                schema_modules.add(relative_path.replace(os.sep, "/"))
+                self.assertEqual(1, source.count("pub static ref SCHEMA"))
+                self.assertIn("\nlazy_static! {\n", source)
+        self.assertEqual(expected_modules, schema_modules)
         
     def test_convert_address_avsc_to_rust(self):
         """ Test converting an address.avsc file to Rust """
@@ -63,6 +82,43 @@ class TestAvroToRust(unittest.TestCase):
         self.run_convert_to_rust("telemetry", True, False)
         self.run_convert_to_rust("telemetry", False, True)
         self.run_convert_to_rust("telemetry", False, False)
+
+    def test_convert_enum_avro_annotations_to_rust(self):
+        """Compile an enum-only crate with module-scoped Avro schema support."""
+        rust_path = self.run_convert_to_rust("rust-enum-annotation", True, True)
+        self.assert_module_scoped_schemas(
+            rust_path,
+            {"issue406/enum_only/status.rs"},
+        )
+
+    def test_convert_union_avro_annotations_to_rust(self):
+        """Compile a union-bearing crate with Avro binary round-trip coverage."""
+        rust_path = self.run_convert_to_rust("rust-union-annotation", True, True)
+        self.assert_module_scoped_schemas(
+            rust_path,
+            {
+                "issue406/union_only/numericunion.rs",
+                "issue406/union_only/unionholder.rs",
+                "issue406/union_only/valueunion.rs",
+            },
+        )
+
+    def test_convert_multitype_avro_annotations_to_rust(self):
+        """Compile records, enums, and unions that each define SCHEMA in one crate."""
+        rust_path = self.run_convert_to_rust("rust-multitype-annotations", True, True)
+        self.assert_module_scoped_schemas(
+            rust_path,
+            {
+                "issue406/multitype/alternate.rs",
+                "issue406/multitype/composite.rs",
+                "issue406/multitype/choiceunion.rs",
+                "issue406/multitype/inlinekind.rs",
+                "issue406/multitype/simple.rs",
+                "issue406/multitype/standalone.rs",
+                "issue406/multitype/valueunion.rs",
+                "issue406/multitype/wrapper.rs",
+            },
+        )
 
     def test_convert_jfrog_pipelines_jsons_to_avro_to_rust(self):
         """ Test converting a jfrog-pipelines.json file to Rust """

--- a/test/test_avrotorust.py
+++ b/test/test_avrotorust.py
@@ -228,6 +228,55 @@ class TestAvroToRust(unittest.TestCase):
                 )
             self.assertFalse(os.path.exists(rust_path))
 
+    def test_reserved_rust_module_paths_fail_before_output(self):
+        """Reject named types that collide with generated mod.rs/lib.rs."""
+        schemas = [
+            {
+                "type": "record",
+                "name": "Mod",
+                "namespace": "n",
+                "fields": [],
+            },
+            {
+                "type": "record",
+                "name": "Lib",
+                "fields": [],
+            },
+            {
+                "type": "record",
+                "name": "NestedMod",
+                "namespace": "n.mod",
+                "fields": [],
+            },
+            {
+                "type": "record",
+                "name": "NestedLib",
+                "namespace": "lib.n",
+                "fields": [],
+            },
+        ]
+        cases = [[schema] for schema in schemas]
+        cases.extend((schemas, list(reversed(schemas))))
+        for index, schema in enumerate(cases):
+            rust_path = os.path.join(
+                tempfile.gettempdir(),
+                "avrotize",
+                f"rust-reserved-path-{index}",
+            )
+            if os.path.exists(rust_path):
+                shutil.rmtree(rust_path, ignore_errors=True)
+            with self.assertRaisesRegex(
+                ValueError,
+                r"generated Rust (mod|lib)\.rs",
+            ):
+                convert_avro_schema_to_rust(
+                    schema,
+                    rust_path,
+                    package_name="rust-reserved-path",
+                    avro_annotation=True,
+                )
+            self.assertFalse(os.path.exists(rust_path))
+
         root_schemas = [
             {
                 "type": "record",
@@ -379,6 +428,84 @@ class TestAvroToRust(unittest.TestCase):
         self.run_convert_to_rust("address", True, False)
         self.run_convert_to_rust("address", False, True)
         self.run_convert_to_rust("address", False, False)
+
+    def test_convert_root_types_to_rust(self):
+        """Compile root records and enums in every annotation mode."""
+        for avro_annotation, serde_annotation in (
+            (False, False),
+            (False, True),
+            (True, False),
+            (True, True),
+        ):
+            rust_path = self.run_convert_to_rust(
+                "rust-root-types",
+                avro_annotation,
+                serde_annotation,
+            )
+            with open(
+                os.path.join(rust_path, "src", "lib.rs"),
+                "r",
+                encoding="utf-8",
+            ) as lib_file:
+                source = lib_file.read()
+            self.assertIn("pub mod rootrecord;", source)
+            self.assertIn("pub mod rootenum;", source)
+            if avro_annotation:
+                self.assertIn("pub mod choiceunion;", source)
+                integration_dir = os.path.join(rust_path, "tests")
+                os.makedirs(integration_dir, exist_ok=True)
+                with open(
+                    os.path.join(
+                        integration_dir,
+                        "legacy_root_union_api.rs",
+                    ),
+                    "w",
+                    encoding="utf-8",
+                ) as legacy_test:
+                    legacy_test.write(
+                        "use rust_root_types::{\n"
+                        "    choiceunion::ChoiceUnion,\n"
+                        "    rootrecord::RootRecord,\n"
+                        "};\n\n"
+                        "#[test]\n"
+                        "fn legacy_root_union_api_compiles() {\n"
+                        "    let record = RootRecord {\n"
+                        "        choice: ChoiceUnion::String("
+                        "\"value\".into()),\n"
+                        "        ..Default::default()\n"
+                        "    };\n"
+                        "    assert!(matches!("
+                        "record.choice, ChoiceUnion::String(_)));\n"
+                        "}\n"
+                    )
+                assert subprocess.check_call(
+                    ['cargo', 'test'],
+                    cwd=rust_path,
+                    stdout=sys.stdout,
+                    stderr=sys.stderr,
+                    timeout=self.CARGO_TIMEOUT,
+                ) == 0
+                convert_avro_to_rust(
+                    os.path.join(
+                        os.getcwd(),
+                        "test",
+                        "avsc",
+                        "rust-root-types.avsc",
+                    ),
+                    rust_path,
+                    package_name="rust-root-types",
+                    avro_annotation=True,
+                    serde_annotation=serde_annotation,
+                )
+                with open(
+                    os.path.join(rust_path, "src", "lib.rs"),
+                    "r",
+                    encoding="utf-8",
+                ) as regenerated_lib:
+                    self.assertIn(
+                        "pub mod choiceunion;",
+                        regenerated_lib.read(),
+                    )
         
     def test_convert_twotypeunion_avsc_to_rust(self):
         """ Test converting an twotypeunion.avsc file to Rust """
@@ -463,10 +590,10 @@ class TestAvroToRust(unittest.TestCase):
                 "#[test]\n"
                 "fn legacy_avro_union_api_compiles() {\n"
                 "    let holder = UnionHolder {\n"
-                "        nullable: NullableUnion::Null(()),\n"
+                "        nullable: NullableUnion::String(\"value\".into()),\n"
                 "        ..Default::default()\n"
                 "    };\n"
-                "    assert!(matches!(holder.nullable, NullableUnion::Null(())));\n"
+                "    assert!(matches!(holder.nullable, NullableUnion::String(_)));\n"
                 "}\n"
             )
         assert subprocess.check_call(

--- a/test/test_avrotorust.py
+++ b/test/test_avrotorust.py
@@ -795,6 +795,112 @@ class TestAvroToRust(unittest.TestCase):
             )
         )
 
+    def test_recursive_shared_union_metadata_is_complete(self):
+        """Round-trip recursive shared unions after metadata completion."""
+        schema = {
+            "type": "record",
+            "name": "RecursiveHolder",
+            "namespace": "issue406.recursive_shared",
+            "fields": [
+                {
+                    "name": "root",
+                    "type": [
+                        {
+                            "type": "record",
+                            "name": "Branch",
+                            "fields": [
+                                {"name": "value", "type": "string"},
+                                {
+                                    "name": "children",
+                                    "type": {
+                                        "type": "array",
+                                        "items": ["Branch", "string"],
+                                    },
+                                },
+                            ],
+                        },
+                        "string",
+                    ],
+                }
+            ],
+        }
+        for serde_annotation in (False, True):
+            rust_path = os.path.join(
+                tempfile.gettempdir(),
+                "avrotize",
+                "rust-recursive-shared"
+                f"{'-serde' if serde_annotation else ''}",
+            )
+            if os.path.exists(rust_path):
+                shutil.rmtree(rust_path, ignore_errors=True)
+            convert_avro_schema_to_rust(
+                schema,
+                rust_path,
+                package_name="recursive-shared",
+                avro_annotation=True,
+                serde_annotation=serde_annotation,
+            )
+            union_files = glob.glob(
+                os.path.join(
+                    rust_path,
+                    "src",
+                    "issue406",
+                    "recursive_shared",
+                    "unionpath*.rs",
+                )
+            )
+            self.assertEqual(1, len(union_files))
+            with open(
+                union_files[0],
+                "r",
+                encoding="utf-8",
+            ) as union_file:
+                source = union_file.read()
+            self.assertRegex(
+                source,
+                r"from_avro_branch[\s\S]+0 => Ok\([\s\S]+1 => Ok\(",
+            )
+            self.assertNotIn("match self {\n        })", source)
+
+            integration_dir = os.path.join(rust_path, "tests")
+            os.makedirs(integration_dir, exist_ok=True)
+            with open(
+                os.path.join(integration_dir, "recursive_union.rs"),
+                "w",
+                encoding="utf-8",
+            ) as integration_test:
+                integration_test.write(
+                    "use recursive_shared::issue406::recursive_shared::{\n"
+                    "    branch::Branch,\n"
+                    "    childrenunion::ChildrenUnion,\n"
+                    "    recursiveholder::RecursiveHolder,\n"
+                    "    rootunion::RootUnion,\n"
+                    "};\n\n"
+                    "#[test]\n"
+                    "fn recursive_union_round_trip() {\n"
+                    "    let branch = Branch {\n"
+                    "        value: \"root\".into(),\n"
+                    "        children: vec!["
+                    "ChildrenUnion::String(\"leaf\".into())],\n"
+                    "    };\n"
+                    "    let instance = RecursiveHolder {\n"
+                    "        root: RootUnion::Branch(branch),\n"
+                    "    };\n"
+                    "    let bytes = instance.to_byte_array("
+                    "\"avro/binary\").unwrap();\n"
+                    "    let decoded = RecursiveHolder::from_data("
+                    "&bytes, \"avro/binary\").unwrap();\n"
+                    "    assert_eq!(instance, decoded);\n"
+                    "}\n"
+                )
+            assert subprocess.check_call(
+                ['cargo', 'test', '--test', 'recursive_union'],
+                cwd=rust_path,
+                stdout=sys.stdout,
+                stderr=sys.stderr,
+                timeout=self.CARGO_TIMEOUT,
+            ) == 0
+
     def test_output_parent_path_case_is_preserved(self):
         """Never lowercase caller-provided output directory components."""
         rust_path = os.path.join(

--- a/test/test_avrotorust.py
+++ b/test/test_avrotorust.py
@@ -165,6 +165,25 @@ class TestAvroToRust(unittest.TestCase):
             },
         )
 
+    def test_convert_anyvalue_reference_to_rust_default(self):
+        """Keep AnyValue mapped to serde_json::Value even when it is indexed."""
+        rust_path = self.run_convert_to_rust(
+            "rust-anyvalue-reference",
+            False,
+            False,
+        )
+        holder_path = os.path.join(
+            rust_path,
+            "src",
+            "issue406",
+            "anyvalue",
+            "anyvalueholder.rs",
+        )
+        with open(holder_path, "r", encoding="utf-8") as generated_file:
+            source = generated_file.read()
+        self.assertIn("pub payload: serde_json::Value", source)
+        self.assertNotIn("crate::avrotize::anyvalue::AnyValue", source)
+
     def test_convert_jfrog_pipelines_jsons_to_avro_to_rust(self):
         """ Test converting a jfrog-pipelines.json file to Rust """
         cwd = getcwd()        

--- a/test/test_avrotorust.py
+++ b/test/test_avrotorust.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import shutil
 import subprocess
@@ -169,7 +170,7 @@ class TestAvroToRust(unittest.TestCase):
             shutil.rmtree(type_case_path, ignore_errors=True)
         with self.assertRaisesRegex(
             ValueError,
-            r"exact path collision.*foo\.Item.*foo\.ITEM",
+            r"exact path collision.*foo\.ITEM.*foo\.Item",
         ):
             convert_avro_schema_to_rust(
                 [
@@ -418,6 +419,103 @@ class TestAvroToRust(unittest.TestCase):
             avro_annotation=False,
         )
         self.assertTrue(os.path.exists(collision_path))
+
+    def test_generated_alias_is_replaced_on_regeneration(self):
+        """Atomically replace stale generated aliases after a moved field."""
+        rust_path = os.path.join(
+            tempfile.gettempdir(),
+            "avrotize",
+            "rust-alias-regeneration",
+        )
+        if os.path.exists(rust_path):
+            shutil.rmtree(rust_path, ignore_errors=True)
+
+        def schema(record_name):
+            return {
+                "type": "record",
+                "name": record_name,
+                "namespace": "n",
+                "fields": [
+                    {
+                        "name": "choice",
+                        "type": ["long", "int"],
+                    }
+                ],
+            }
+
+        convert_avro_schema_to_rust(
+            schema("First"),
+            rust_path,
+            package_name="rust-alias-regeneration",
+            avro_annotation=True,
+        )
+        alias_path = os.path.join(
+            rust_path,
+            "src",
+            "n",
+            "choiceunion.rs",
+        )
+        with open(alias_path, "r", encoding="utf-8") as alias_file:
+            first_content = alias_file.read()
+        convert_avro_schema_to_rust(
+            schema("Second"),
+            rust_path,
+            package_name="rust-alias-regeneration",
+            avro_annotation=True,
+        )
+        with open(alias_path, "r", encoding="utf-8") as alias_file:
+            second_content = alias_file.read()
+        self.assertNotEqual(first_content, second_content)
+        self.assertNotIn(".tmp", os.listdir(os.path.dirname(alias_path)))
+
+        with open(alias_path, "w", encoding="utf-8") as alias_file:
+            alias_file.write(
+                first_content + "\n// user-owned customization\n"
+            )
+        with self.assertRaisesRegex(
+            ValueError,
+            r"Existing file conflicts with planned legacy union alias",
+        ):
+            convert_avro_schema_to_rust(
+                schema("Third"),
+                rust_path,
+                package_name="rust-alias-regeneration",
+                avro_annotation=True,
+            )
+
+    def test_output_parent_path_case_is_preserved(self):
+        """Never lowercase caller-provided output directory components."""
+        rust_path = os.path.join(
+            tempfile.gettempdir(),
+            "AvrotizeCaseSensitiveParent",
+            "GeneratedRust",
+        )
+        if os.path.exists(rust_path):
+            shutil.rmtree(
+                os.path.dirname(rust_path),
+                ignore_errors=True,
+            )
+        convert_avro_schema_to_rust(
+            {
+                "type": "record",
+                "name": "Carrier",
+                "namespace": "n",
+                "fields": [
+                    {
+                        "name": "choice",
+                        "type": ["long", "int"],
+                    }
+                ],
+            },
+            rust_path,
+            package_name="rust-case-sensitive-parent",
+            avro_annotation=True,
+        )
+        self.assertTrue(os.path.isfile(os.path.join(rust_path, "Cargo.toml")))
+        union_files = glob.glob(
+            os.path.join(rust_path, "src", "n", "unionpath*.rs")
+        )
+        self.assertEqual(1, len(union_files))
 
         root_schemas = [
             {
@@ -689,7 +787,7 @@ class TestAvroToRust(unittest.TestCase):
         rust_path = self.run_convert_to_rust("rust-union-annotation", True, True)
         self.assert_module_scoped_schemas(
             rust_path,
-            expected_count=16,
+            expected_count=17,
             required_modules={
                 "issue406/union_only/nestedholder.rs",
                 "issue406/union_only/unionholder.rs",
@@ -708,6 +806,23 @@ class TestAvroToRust(unittest.TestCase):
             avro_source,
             r"pub nullable: crate::issue406::union_only::"
             r"union[a-z0-9]+::Union[A-Za-z0-9]+,",
+        )
+        self.assertIn(
+            "pub optional_array: Vec<String>",
+            avro_source,
+        )
+        self.assertIn(
+            "pub optional_map: std::collections::HashMap<String, String>",
+            avro_source,
+        )
+        self.assertRegex(
+            avro_source,
+            r"pub optional_inline_record: crate::issue406::union_only::"
+            r"optionalinlinerecord::OptionalInlineRecord",
+        )
+        self.assertIn(
+            "pub optional_fixed: Vec<u8>",
+            avro_source,
         )
         legacy_alias_path = os.path.join(
             rust_path,

--- a/test/test_avrotorust.py
+++ b/test/test_avrotorust.py
@@ -14,6 +14,7 @@ sys.path.append(project_root)
 
 
 from avrotize.avrotorust import (
+    AvroToRust,
     convert_avro_schema_to_rust,
     convert_avro_to_rust,
 )
@@ -26,21 +27,107 @@ class TestAvroToRust(unittest.TestCase):
     
     # Timeout in seconds for cargo commands
     CARGO_TIMEOUT = 300
+
+    def test_avro_union_path_identity_is_typed_and_bounded(self):
+        """Keep structural union identities distinct and filesystem-safe."""
+        converter = AvroToRust()
+        array_path = [
+            ('record', 'n.' + ('R' * 80)),
+            ('field', 'items'),
+            ('array', 'items'),
+        ]
+        real_field_path = [
+            ('record', 'n.' + ('R' * 80)),
+            ('field', 'itemsArrayItems'),
+        ]
+        branch_map_path = array_path + [
+            ('branch', '1'),
+            ('map', 'values'),
+        ]
+        identities = {
+            converter.union_name_from_path(array_path),
+            converter.union_name_from_path(real_field_path),
+            converter.union_name_from_path(branch_map_path),
+        }
+        self.assertEqual(3, len(identities))
+        self.assertTrue(all(len(identity) < 100 for identity in identities))
+
+    def test_recursive_named_type_shape_signature(self):
+        """Bound structural JSON matching for recursive named records."""
+        converter = AvroToRust()
+        def recursive_node(name):
+            return {
+                "type": "record",
+                "name": name,
+                "namespace": "issue406.recursive",
+                "fields": [
+                    {
+                        "name": "children",
+                        "type": {
+                            "type": "array",
+                            "items": name,
+                        },
+                    }
+                ],
+            }
+
+        node_a = recursive_node("NodeA")
+        node_b = recursive_node("NodeB")
+        converter.index_avro_named_types([node_a, node_b])
+        signature_a = converter.get_json_shape_signature(
+            node_a,
+            "issue406.recursive",
+        )
+        signature_b = converter.get_json_shape_signature(
+            node_b,
+            "issue406.recursive",
+        )
+        self.assertIn(
+            "('ref', 0)",
+            str(signature_a),
+        )
+        self.assertEqual(signature_a, signature_b)
     
-    def run_convert_to_rust(self, name:str, avro_annotation:bool=False, serde_annotation:bool=False):
+    def run_convert_to_rust(
+        self,
+        name: str,
+        avro_annotation: bool = False,
+        serde_annotation: bool = False,
+        xml_annotation: bool = False,
+    ):
         """ Test converting an avsc file to Rust and compiling/testing it """
         cwd = os.getcwd()        
         avro_path = os.path.join(cwd, "test", "avsc", f"{name}.avsc")
-        rust_path = os.path.join(tempfile.gettempdir(), "avrotize", f"{name}-rs{'' if not avro_annotation else '-avro'}{'' if not serde_annotation else '-serde'}")
+        rust_path = os.path.join(
+            tempfile.gettempdir(),
+            "avrotize",
+            f"{name}-rs"
+            f"{'' if not avro_annotation else '-avro'}"
+            f"{'' if not serde_annotation else '-serde'}"
+            f"{'' if not xml_annotation else '-xml'}",
+        )
         if os.path.exists(rust_path):
             shutil.rmtree(rust_path, ignore_errors=True)
         os.makedirs(rust_path, exist_ok=True)        
-        convert_avro_to_rust(avro_path, rust_path, package_name=name, avro_annotation=avro_annotation, serde_annotation=serde_annotation)
+        convert_avro_to_rust(
+            avro_path,
+            rust_path,
+            package_name=name,
+            avro_annotation=avro_annotation,
+            serde_annotation=serde_annotation,
+            xml_annotation=xml_annotation,
+        )
         assert subprocess.check_call(
             ['cargo', 'test'], cwd=rust_path, stdout=sys.stdout, stderr=sys.stderr, timeout=self.CARGO_TIMEOUT) == 0
         return rust_path
 
-    def assert_module_scoped_schemas(self, rust_path: str, expected_modules: set[str]):
+    def assert_module_scoped_schemas(
+        self,
+        rust_path: str,
+        expected_modules: set[str] | None = None,
+        expected_count: int | None = None,
+        required_modules: set[str] | None = None,
+    ):
         """Assert each expected generated module owns one module-scoped SCHEMA."""
         schema_modules = set()
         for root, _, files in os.walk(os.path.join(rust_path, "src")):
@@ -56,7 +143,13 @@ class TestAvroToRust(unittest.TestCase):
                 schema_modules.add(relative_path.replace(os.sep, "/"))
                 self.assertEqual(1, source.count("pub static ref SCHEMA"))
                 self.assertIn("\nlazy_static! {\n", source)
-        self.assertEqual(expected_modules, schema_modules)
+        if expected_modules is not None:
+            self.assertEqual(expected_modules, schema_modules)
+        if expected_count is not None:
+            self.assertEqual(expected_count, len(schema_modules))
+        if required_modules is not None:
+            self.assertTrue(required_modules <= schema_modules)
+        return schema_modules
         
     def test_convert_address_avsc_to_rust(self):
         """ Test converting an address.avsc file to Rust """
@@ -105,15 +198,10 @@ class TestAvroToRust(unittest.TestCase):
         rust_path = self.run_convert_to_rust("rust-union-annotation", True, True)
         self.assert_module_scoped_schemas(
             rust_path,
-            {
-                "issue406/union_only/record11unionholdernumericunion.rs",
-                "issue406/union_only/record11unionholderarrayvaluesunion.rs",
-                "issue406/union_only/record11unionholdermapvaluesunion.rs",
+            expected_count=9,
+            required_modules={
                 "issue406/union_only/nestedholder.rs",
-                "issue406/union_only/record12nestedholdernumericunion.rs",
-                "issue406/union_only/record11unionholdernullableunion.rs",
                 "issue406/union_only/unionholder.rs",
-                "issue406/union_only/record11unionholdervalueunion.rs",
             },
         )
         union_holder_path = os.path.join(
@@ -125,9 +213,10 @@ class TestAvroToRust(unittest.TestCase):
         )
         with open(union_holder_path, "r", encoding="utf-8") as generated_file:
             avro_source = generated_file.read()
-        self.assertIn(
-            "pub nullable: Option<crate::issue406::union_only::record11unionholdernullableunion::Record11UnionHolderNullableUnion>",
+        self.assertRegex(
             avro_source,
+            r"pub nullable: Option<crate::issue406::union_only::"
+            r"union[a-z0-9]+::Union[A-Za-z0-9]+>",
         )
 
         legacy_field = (
@@ -159,26 +248,54 @@ class TestAvroToRust(unittest.TestCase):
     def test_convert_multitype_avro_annotations_to_rust(self):
         """Compile records, enums, and unions that each define SCHEMA in one crate."""
         rust_path = self.run_convert_to_rust("rust-multitype-annotations", True, True)
-        self.assert_module_scoped_schemas(
+        schema_modules = self.assert_module_scoped_schemas(
             rust_path,
-            {
+            expected_count=28,
+            required_modules={
                 "issue406/multitype/alternate.rs",
                 "issue406/multitype/collisionone.rs",
-                "issue406/multitype/record12collisiononechoiceunion.rs",
                 "issue406/multitype/collisiontwo.rs",
-                "issue406/multitype/record12collisiontwochoiceunion.rs",
                 "issue406/multitype/composite.rs",
-                "issue406/multitype/record9compositechoiceunion.rs",
                 "issue406/multitype/foo.rs",
-                "issue406/multitype/record3foobarbazunion.rs",
                 "issue406/multitype/foobar.rs",
-                "issue406/multitype/record6foobarbazunion.rs",
                 "issue406/multitype/inlinekind.rs",
                 "issue406/multitype/simple.rs",
                 "issue406/multitype/standalone.rs",
-                "issue406/multitype/record9compositevalueunion.rs",
+                "issue406/multitype/syntheticpaths.rs",
+                "issue406/multitype/twina.rs",
+                "issue406/multitype/twinb.rs",
+                "issue406/multitype/twinholder.rs",
                 "issue406/multitype/wrapper.rs",
             },
+        )
+        union_modules = {
+            module for module in schema_modules
+            if os.path.basename(module).startswith("union")
+        }
+        self.assertEqual(14, len(union_modules))
+
+    def test_convert_named_reference_resolution_to_rust(self):
+        """Resolve dotted names and duplicate short names by namespace."""
+        rust_path = self.run_convert_to_rust(
+            "rust-named-reference-resolution",
+            True,
+            True,
+        )
+        holder_path = os.path.join(
+            rust_path,
+            "src",
+            "right",
+            "holder.rs",
+        )
+        with open(holder_path, "r", encoding="utf-8") as generated_file:
+            source = generated_file.read()
+        self.assertIn("pub local: crate::right::item::Item", source)
+        self.assertIn("pub foreign: crate::left::item::Item", source)
+        self.run_convert_to_rust(
+            "rust-named-reference-resolution",
+            True,
+            True,
+            True,
         )
 
     def test_convert_anyvalue_reference_to_rust_default(self):
@@ -202,38 +319,40 @@ class TestAvroToRust(unittest.TestCase):
 
     def test_convert_generic_anyvalue_union_to_rust(self):
         """Compile Avro decoding for the generic AnyValue union."""
-        rust_path = os.path.join(
-            tempfile.gettempdir(),
-            "avrotize",
-            "rust-generic-anyvalue-rs-avro-serde",
-        )
-        if os.path.exists(rust_path):
-            shutil.rmtree(rust_path, ignore_errors=True)
-        schema = {
-            "type": "record",
-            "name": "GenericHolder",
-            "namespace": "issue406.generic",
-            "fields": [
-                {
-                    "name": "payload",
-                    "type": generic_type(),
-                }
-            ],
-        }
-        convert_avro_schema_to_rust(
-            schema,
-            rust_path,
-            package_name="rust-generic-anyvalue",
-            avro_annotation=True,
-            serde_annotation=True,
-        )
-        assert subprocess.check_call(
-            ['cargo', 'test'],
-            cwd=rust_path,
-            stdout=sys.stdout,
-            stderr=sys.stderr,
-            timeout=self.CARGO_TIMEOUT,
-        ) == 0
+        for serde_annotation in (True, False):
+            rust_path = os.path.join(
+                tempfile.gettempdir(),
+                "avrotize",
+                "rust-generic-anyvalue-rs-avro"
+                f"{'-serde' if serde_annotation else ''}",
+            )
+            if os.path.exists(rust_path):
+                shutil.rmtree(rust_path, ignore_errors=True)
+            schema = {
+                "type": "record",
+                "name": "GenericHolder",
+                "namespace": "issue406.generic",
+                "fields": [
+                    {
+                        "name": "payload",
+                        "type": generic_type(),
+                    }
+                ],
+            }
+            convert_avro_schema_to_rust(
+                schema,
+                rust_path,
+                package_name="rust-generic-anyvalue",
+                avro_annotation=True,
+                serde_annotation=serde_annotation,
+            )
+            assert subprocess.check_call(
+                ['cargo', 'test'],
+                cwd=rust_path,
+                stdout=sys.stdout,
+                stderr=sys.stderr,
+                timeout=self.CARGO_TIMEOUT,
+            ) == 0
 
     def test_convert_jfrog_pipelines_jsons_to_avro_to_rust(self):
         """ Test converting a jfrog-pipelines.json file to Rust """

--- a/test/test_avrotorust.py
+++ b/test/test_avrotorust.py
@@ -13,7 +13,11 @@ project_root = os.path.dirname(os.path.dirname(current_script_path))
 sys.path.append(project_root)
 
 
-from avrotize.avrotorust import convert_avro_to_rust
+from avrotize.avrotorust import (
+    convert_avro_schema_to_rust,
+    convert_avro_to_rust,
+)
+from avrotize.common import generic_type
 from avrotize.jsonstoavro import convert_jsons_to_avro
 import pytest
 
@@ -103,6 +107,9 @@ class TestAvroToRust(unittest.TestCase):
             rust_path,
             {
                 "issue406/union_only/numericunion.rs",
+                "issue406/union_only/arrayvaluesunion.rs",
+                "issue406/union_only/mapvaluesunion.rs",
+                "issue406/union_only/nestedholder.rs",
                 "issue406/union_only/nullableunion.rs",
                 "issue406/union_only/unionholder.rs",
                 "issue406/union_only/valueunion.rs",
@@ -183,6 +190,41 @@ class TestAvroToRust(unittest.TestCase):
             source = generated_file.read()
         self.assertIn("pub payload: serde_json::Value", source)
         self.assertNotIn("crate::avrotize::anyvalue::AnyValue", source)
+
+    def test_convert_generic_anyvalue_union_to_rust(self):
+        """Compile Avro decoding for the generic AnyValue union."""
+        rust_path = os.path.join(
+            tempfile.gettempdir(),
+            "avrotize",
+            "rust-generic-anyvalue-rs-avro-serde",
+        )
+        if os.path.exists(rust_path):
+            shutil.rmtree(rust_path, ignore_errors=True)
+        schema = {
+            "type": "record",
+            "name": "GenericHolder",
+            "namespace": "issue406.generic",
+            "fields": [
+                {
+                    "name": "payload",
+                    "type": generic_type(),
+                }
+            ],
+        }
+        convert_avro_schema_to_rust(
+            schema,
+            rust_path,
+            package_name="rust-generic-anyvalue",
+            avro_annotation=True,
+            serde_annotation=True,
+        )
+        assert subprocess.check_call(
+            ['cargo', 'test'],
+            cwd=rust_path,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+            timeout=self.CARGO_TIMEOUT,
+        ) == 0
 
     def test_convert_jfrog_pipelines_jsons_to_avro_to_rust(self):
         """ Test converting a jfrog-pipelines.json file to Rust """

--- a/test/test_avrotorust.py
+++ b/test/test_avrotorust.py
@@ -108,6 +108,45 @@ class TestAvroToRust(unittest.TestCase):
                 "issue406/union_only/valueunion.rs",
             },
         )
+        union_holder_path = os.path.join(
+            rust_path,
+            "src",
+            "issue406",
+            "union_only",
+            "unionholder.rs",
+        )
+        with open(union_holder_path, "r", encoding="utf-8") as generated_file:
+            avro_source = generated_file.read()
+        self.assertIn(
+            "pub nullable: Option<crate::issue406::union_only::nullableunion::NullableUnion>",
+            avro_source,
+        )
+
+        legacy_field = (
+            "pub nullable: "
+            "crate::issue406::union_only::nullableunion::NullableUnion"
+        )
+        for serde_annotation in (False, True):
+            compatible_path = self.run_convert_to_rust(
+                "rust-union-annotation",
+                False,
+                serde_annotation,
+            )
+            compatible_holder_path = os.path.join(
+                compatible_path,
+                "src",
+                "issue406",
+                "union_only",
+                "unionholder.rs",
+            )
+            with open(
+                compatible_holder_path,
+                "r",
+                encoding="utf-8",
+            ) as generated_file:
+                compatible_source = generated_file.read()
+            self.assertIn(legacy_field, compatible_source)
+            self.assertNotIn("pub nullable: Option<", compatible_source)
 
     def test_convert_multitype_avro_annotations_to_rust(self):
         """Compile records, enums, and unions that each define SCHEMA in one crate."""

--- a/test/test_avrotorust.py
+++ b/test/test_avrotorust.py
@@ -89,6 +89,54 @@ class TestAvroToRust(unittest.TestCase):
         )
         self.assertEqual(signature_a, signature_b)
 
+    def test_json_union_subset_records_reject_ambiguity(self):
+        """Reject a record branch also accepted by a subset-field matcher."""
+        rust_path = os.path.join(
+            tempfile.gettempdir(),
+            "avrotize",
+            "rust-json-subset-record-union",
+        )
+        if os.path.exists(rust_path):
+            shutil.rmtree(rust_path, ignore_errors=True)
+        schema = [
+            {
+                "type": "record",
+                "name": "Base",
+                "namespace": "n",
+                "fields": [{"name": "value", "type": "string"}],
+            },
+            {
+                "type": "record",
+                "name": "Extended",
+                "namespace": "n",
+                "fields": [
+                    {"name": "value", "type": "string"},
+                    {"name": "detail", "type": "string"},
+                ],
+            },
+            {
+                "type": "record",
+                "name": "Holder",
+                "namespace": "n",
+                "fields": [
+                    {"name": "choice", "type": ["Base", "Extended"]}
+                ],
+            },
+        ]
+        convert_avro_schema_to_rust(
+            schema,
+            rust_path,
+            package_name="rust-json-subset-record-union",
+            serde_annotation=True,
+        )
+        assert subprocess.check_call(
+            ['cargo', 'test'],
+            cwd=rust_path,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+            timeout=self.CARGO_TIMEOUT,
+        ) == 0
+
     def test_named_type_resolution_requires_current_namespace(self):
         """Do not resolve unqualified names from unrelated namespaces."""
         converter = AvroToRust()
@@ -834,6 +882,55 @@ class TestAvroToRust(unittest.TestCase):
             )
         )
 
+    def test_nullable_union_identity_preserves_trailing_null_schema(self):
+        """Do not reuse a non-null union target for a nullable source schema."""
+        rust_path = os.path.join(
+            tempfile.gettempdir(),
+            "avrotize",
+            "rust-nullable-union-identity",
+        )
+        if os.path.exists(rust_path):
+            shutil.rmtree(rust_path, ignore_errors=True)
+        schema = {
+            "type": "record",
+            "name": "Carrier",
+            "namespace": "n",
+            "fields": [
+                {"name": "plain", "type": ["string", "long"]},
+                {
+                    "name": "nullable",
+                    "type": ["string", "long", "null"],
+                },
+            ],
+        }
+        convert_avro_schema_to_rust(
+            schema,
+            rust_path,
+            package_name="rust-nullable-union-identity",
+            avro_annotation=True,
+        )
+        union_files = glob.glob(
+            os.path.join(rust_path, "src", "n", "unionpath*.rs")
+        )
+        self.assertEqual(2, len(union_files))
+        generated_sources = []
+        for union_file in union_files:
+            with open(union_file, "r", encoding="utf-8") as generated_file:
+                generated_sources.append(generated_file.read())
+        nullable_sources = [
+            source for source in generated_sources
+            if "pub static ref SOURCE_SCHEMA" in source
+        ]
+        self.assertEqual(1, len(nullable_sources))
+        self.assertIn(
+            "pub fn to_nullable_byte_array(",
+            nullable_sources[0],
+        )
+        self.assertIn(
+            "pub fn from_nullable_data(",
+            nullable_sources[0],
+        )
+
     def test_recursive_shared_union_metadata_is_complete(self):
         """Round-trip recursive shared unions after metadata completion."""
         schema = {
@@ -900,6 +997,50 @@ class TestAvroToRust(unittest.TestCase):
                 r"from_avro_branch[\s\S]+0 => Ok\([\s\S]+1 => Ok\(",
             )
             self.assertNotIn("match self {\n        })", source)
+            holder_path = os.path.join(
+                rust_path,
+                "src",
+                "issue406",
+                "recursive_shared",
+                "recursiveholder.rs",
+            )
+            with open(
+                holder_path,
+                "a",
+                encoding="utf-8",
+            ) as holder_file:
+                holder_file.write(
+                    "\n#[cfg(test)]\n"
+                    "mod recursive_depth_test {\n"
+                    "    use super::*;\n"
+                    "    use apache_avro::types::Value;\n\n"
+                    "    #[test]\n"
+                    "    fn recursive_union_depth_is_bounded() {\n"
+                    "        let mut branch = Value::Record(vec![\n"
+                    "            (\"value\".into(), Value::String("
+                    "\"leaf\".into())),\n"
+                    "            (\"children\".into(), Value::Array(vec![])),\n"
+                    "        ]);\n"
+                    "        for _ in 0..130 {\n"
+                    "            branch = Value::Record(vec![\n"
+                    "                (\"value\".into(), Value::String("
+                    "\"node\".into())),\n"
+                    "                (\"children\".into(), Value::Array(vec![\n"
+                    "                    Value::Union(0, Box::new(branch)),\n"
+                    "                ])),\n"
+                    "            ]);\n"
+                    "        }\n"
+                    "        let value = Value::Record(vec![\n"
+                    "            (\"root\".into(), "
+                    "Value::Union(0, Box::new(branch))),\n"
+                    "        ]);\n"
+                    "        let error = RecursiveHolder::from_avro_value("
+                    "&value).unwrap_err();\n"
+                    "        assert!(error.to_string().contains("
+                    "\"nesting depth\"));\n"
+                    "    }\n"
+                    "}\n"
+                )
 
             integration_dir = os.path.join(rust_path, "tests")
             os.makedirs(integration_dir, exist_ok=True)
@@ -933,7 +1074,7 @@ class TestAvroToRust(unittest.TestCase):
                     "}\n"
                 )
             assert subprocess.check_call(
-                ['cargo', 'test', '--test', 'recursive_union'],
+                ['cargo', 'test'],
                 cwd=rust_path,
                 stdout=sys.stdout,
                 stderr=sys.stderr,
@@ -1017,6 +1158,32 @@ class TestAvroToRust(unittest.TestCase):
             os.path.join(rust_path, "src", "n", "unionpath*.rs")
         )
         self.assertEqual(1, len(union_files))
+
+    def test_generated_paths_cannot_escape_output(self):
+        """Reject traversal components before creating output."""
+        rust_path = os.path.join(
+            tempfile.gettempdir(),
+            "avrotize",
+            "rust-path-escape",
+        )
+        if os.path.exists(rust_path):
+            shutil.rmtree(rust_path, ignore_errors=True)
+        with self.assertRaisesRegex(
+            ValueError,
+            r"invalid generated Rust path component",
+        ):
+            convert_avro_schema_to_rust(
+                {
+                    "type": "record",
+                    "name": "Carrier",
+                    "namespace": "../escape",
+                    "fields": [],
+                },
+                rust_path,
+                package_name="rust-path-escape",
+                avro_annotation=True,
+            )
+        self.assertFalse(os.path.exists(rust_path))
 
         root_schemas = [
             {
@@ -1282,6 +1449,37 @@ class TestAvroToRust(unittest.TestCase):
             avro_only_path,
             {"issue406/enum_only/status.rs"},
         )
+        integration_dir = os.path.join(rust_path, "tests")
+        os.makedirs(integration_dir, exist_ok=True)
+        with open(
+            os.path.join(integration_dir, "gzip_limit.rs"),
+            "w",
+            encoding="utf-8",
+        ) as gzip_test:
+            gzip_test.write(
+                "use rust_enum_annotation::issue406::enum_only::"
+                "status::Status;\n"
+                "use flate2::write::GzEncoder;\n"
+                "use std::io::Write;\n"
+                "#[test]\n"
+                "fn gzip_limit_is_enforced() {\n"
+                "    let mut encoder = GzEncoder::new("
+                "Vec::new(), flate2::Compression::default());\n"
+                "    encoder.write_all(&vec![0u8; 16 * 1024 * 1024 + 1])"
+                ".unwrap();\n"
+                "    let bomb = encoder.finish().unwrap();\n"
+                "    let error = Status::from_data("
+                "&bomb, \"avro/binary+gzip\").unwrap_err();\n"
+                "    assert!(error.to_string().contains(\"size limit\"));\n"
+                "}\n"
+            )
+        assert subprocess.check_call(
+            ['cargo', 'test', '--test', 'gzip_limit'],
+            cwd=rust_path,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+            timeout=self.CARGO_TIMEOUT,
+        ) == 0
 
     def test_convert_union_avro_annotations_to_rust(self):
         """Compile a union-bearing crate with Avro binary round-trip coverage."""
@@ -1370,6 +1568,8 @@ class TestAvroToRust(unittest.TestCase):
                 "    nullableunion::NullableUnion,\n"
                 "    unionholder::UnionHolder,\n"
                 "};\n\n"
+                "use flate2::write::GzEncoder;\n"
+                "use std::io::Write;\n\n"
                 "#[test]\n"
                 "fn legacy_avro_union_api_compiles() {\n"
                 "    let holder = UnionHolder {\n"
@@ -1380,6 +1580,20 @@ class TestAvroToRust(unittest.TestCase):
                 "    let _ = NullFirstoption1Union::default();\n"
                 "    let _ = NullMiddleoption0Union::default();\n"
                 "    let _ = NullLastoption0Union::default();\n"
+                "}\n"
+                "\n#[test]\n"
+                "fn gzip_limit_is_enforced() {\n"
+                "    let mut encoder = GzEncoder::new(\n"
+                "        Vec::new(), flate2::Compression::default());\n"
+                "    encoder.write_all(&vec![0u8; 16 * 1024 * 1024 + 1])"
+                ".unwrap();\n"
+                "    let bomb = encoder.finish().unwrap();\n"
+                "    let error = UnionHolder::from_data(\n"
+                "        &bomb, \"avro/binary+gzip\").unwrap_err();\n"
+                "    assert!(error.to_string().contains(\"size limit\"));\n"
+                "    let error = NullableUnion::from_nullable_data(\n"
+                "        &bomb, \"avro/binary+gzip\").unwrap_err();\n"
+                "    assert!(error.to_string().contains(\"size limit\"));\n"
                 "}\n"
             )
         assert subprocess.check_call(
@@ -1455,6 +1669,21 @@ class TestAvroToRust(unittest.TestCase):
             if os.path.basename(module).startswith("union")
         }
         self.assertEqual(6, len(union_modules))
+        self.run_convert_to_rust(
+            "rust-multitype-annotations",
+            True,
+            False,
+        )
+        self.run_convert_to_rust(
+            "rust-multitype-annotations",
+            False,
+            True,
+        )
+        self.run_convert_to_rust(
+            "rust-multitype-annotations",
+            False,
+            False,
+        )
 
     def test_convert_named_reference_resolution_to_rust(self):
         """Resolve dotted names and duplicate short names by namespace."""

--- a/test/test_avrotorust.py
+++ b/test/test_avrotorust.py
@@ -283,6 +283,45 @@ class TestAvroToRust(unittest.TestCase):
                 )
             self.assertFalse(os.path.exists(rust_path))
 
+    def test_xml_support_path_conflicts_fail_before_output(self):
+        """Reserve the generated XML helper module before writes."""
+        conflict = {
+            "type": "record",
+            "name": "Carrier",
+            "namespace": "xml_support",
+            "fields": [],
+        }
+        safe = {
+            "type": "record",
+            "name": "Other",
+            "namespace": "n",
+            "fields": [],
+        }
+        cases = (
+            [conflict],
+            [safe, conflict],
+            [conflict, safe],
+        )
+        for index, schema in enumerate(cases):
+            rust_path = os.path.join(
+                tempfile.gettempdir(),
+                "avrotize",
+                f"rust-xml-support-conflict-{index}",
+            )
+            if os.path.exists(rust_path):
+                shutil.rmtree(rust_path, ignore_errors=True)
+            with self.assertRaisesRegex(
+                ValueError,
+                r"(xml_support|xmlsupport)",
+            ):
+                convert_avro_schema_to_rust(
+                    schema,
+                    rust_path,
+                    package_name="rust-xml-support-conflict",
+                    xml_annotation=True,
+                )
+            self.assertFalse(os.path.exists(rust_path))
+
     def test_generated_union_and_alias_paths_fail_before_output(self):
         """Preflight generated union and legacy alias path collisions."""
         converter = AvroToRust()
@@ -895,6 +934,50 @@ class TestAvroToRust(unittest.TestCase):
                 )
             assert subprocess.check_call(
                 ['cargo', 'test', '--test', 'recursive_union'],
+                cwd=rust_path,
+                stdout=sys.stdout,
+                stderr=sys.stderr,
+                timeout=self.CARGO_TIMEOUT,
+            ) == 0
+
+    def test_same_converter_generates_complete_independent_outputs(self):
+        """Reset run-scoped caches between outputs on one converter."""
+        schema = {
+            "type": "record",
+            "name": "Carrier",
+            "namespace": "issue406.reuse",
+            "fields": [
+                {
+                    "name": "choice",
+                    "type": ["long", "int"],
+                }
+            ],
+        }
+        converter = AvroToRust()
+        converter.base_package = "rust-reuse"
+        converter.avro_annotation = True
+        converter.serde_annotation = True
+        for index in range(2):
+            rust_path = os.path.join(
+                tempfile.gettempdir(),
+                "avrotize",
+                f"rust-reuse-{index}",
+            )
+            if os.path.exists(rust_path):
+                shutil.rmtree(rust_path, ignore_errors=True)
+            converter.convert_schema(schema, rust_path)
+            union_files = glob.glob(
+                os.path.join(
+                    rust_path,
+                    "src",
+                    "issue406",
+                    "reuse",
+                    "unionpath*.rs",
+                )
+            )
+            self.assertEqual(1, len(union_files))
+            assert subprocess.check_call(
+                ['cargo', 'test'],
                 cwd=rust_path,
                 stdout=sys.stdout,
                 stderr=sys.stderr,

--- a/test/test_avrotorust.py
+++ b/test/test_avrotorust.py
@@ -420,6 +420,39 @@ class TestAvroToRust(unittest.TestCase):
         )
         self.assertTrue(os.path.exists(collision_path))
 
+        symbol_collision_path = os.path.join(
+            tempfile.gettempdir(),
+            "avrotize",
+            "rust-plan-symbol-collision",
+        )
+        if os.path.exists(symbol_collision_path):
+            shutil.rmtree(symbol_collision_path, ignore_errors=True)
+        with self.assertRaisesRegex(
+            ValueError,
+            r"exact path collision.*FooBarUnion.*FoobarUnion",
+        ):
+            convert_avro_schema_to_rust(
+                {
+                    "type": "record",
+                    "name": "Carrier",
+                    "namespace": "n",
+                    "fields": [
+                        {
+                            "name": "foo_bar",
+                            "type": ["long", "int"],
+                        },
+                        {
+                            "name": "foobar",
+                            "type": ["long", "int"],
+                        },
+                    ],
+                },
+                symbol_collision_path,
+                package_name="rust-plan-symbol-collision",
+                avro_annotation=False,
+            )
+        self.assertFalse(os.path.exists(symbol_collision_path))
+
     def test_generated_alias_is_replaced_on_regeneration(self):
         """Atomically replace stale generated aliases after a moved field."""
         rust_path = os.path.join(

--- a/test/test_avrotorust.py
+++ b/test/test_avrotorust.py
@@ -383,13 +383,17 @@ class TestAvroToRust(unittest.TestCase):
         )
         if os.path.exists(rust_path):
             shutil.rmtree(rust_path, ignore_errors=True)
-        convert_avro_schema_to_rust(
-            hash_schema,
-            rust_path,
-            package_name="rust-plan-non-avro-hash",
-            avro_annotation=False,
-        )
-        self.assertTrue(os.path.exists(rust_path))
+        with self.assertRaisesRegex(
+            ValueError,
+            r"exact path collision.*generated union.*named type",
+        ):
+            convert_avro_schema_to_rust(
+                hash_schema,
+                rust_path,
+                package_name="rust-plan-non-avro-hash",
+                avro_annotation=False,
+            )
+        self.assertFalse(os.path.exists(rust_path))
 
         collision_schema = [
             {
@@ -419,6 +423,71 @@ class TestAvroToRust(unittest.TestCase):
             avro_annotation=False,
         )
         self.assertTrue(os.path.exists(collision_path))
+
+        different_schema_path = os.path.join(
+            tempfile.gettempdir(),
+            "avrotize",
+            "rust-plan-owner-different-unions",
+        )
+        if os.path.exists(different_schema_path):
+            shutil.rmtree(different_schema_path, ignore_errors=True)
+        different_schema = [
+            {
+                "type": "record",
+                "name": "One",
+                "namespace": "n",
+                "fields": [
+                    {
+                        "name": "choice",
+                        "type": ["long", "int"],
+                    }
+                ],
+            },
+            {
+                "type": "record",
+                "name": "Two",
+                "namespace": "n",
+                "fields": [
+                    {
+                        "name": "choice",
+                        "type": ["string", "boolean"],
+                    }
+                ],
+            },
+        ]
+        convert_avro_schema_to_rust(
+            different_schema,
+            different_schema_path,
+            package_name="rust-plan-owner-different-unions",
+            avro_annotation=False,
+            serde_annotation=True,
+        )
+        self.assertFalse(
+            os.path.exists(
+                os.path.join(
+                    different_schema_path,
+                    "src",
+                    "n",
+                    "choiceunion.rs",
+                )
+            )
+        )
+        union_files = glob.glob(
+            os.path.join(
+                different_schema_path,
+                "src",
+                "n",
+                "unionpath*.rs",
+            )
+        )
+        self.assertEqual(2, len(union_files))
+        assert subprocess.check_call(
+            ['cargo', 'test'],
+            cwd=different_schema_path,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+            timeout=self.CARGO_TIMEOUT,
+        ) == 0
 
         symbol_collision_path = os.path.join(
             tempfile.gettempdir(),
@@ -515,6 +584,71 @@ class TestAvroToRust(unittest.TestCase):
                 package_name="rust-alias-regeneration",
                 avro_annotation=True,
             )
+
+    def test_legacy_union_file_migrates_and_ambiguous_alias_is_removed(self):
+        """Migrate old union modules and remove newly ambiguous aliases."""
+        rust_path = os.path.join(
+            tempfile.gettempdir(),
+            "avrotize",
+            "rust-legacy-union-migration",
+        )
+        if os.path.exists(rust_path):
+            shutil.rmtree(rust_path, ignore_errors=True)
+        alias_directory = os.path.join(rust_path, "src", "n")
+        os.makedirs(alias_directory, exist_ok=True)
+        alias_path = os.path.join(alias_directory, "choiceunion.rs")
+        with open(alias_path, "w", encoding="utf-8") as legacy_file:
+            legacy_file.write(
+                "pub enum ChoiceUnion { I64(i64), I32(i32) }\n"
+                "impl Default for ChoiceUnion { fn default() -> Self {"
+                " ChoiceUnion::I64(0) } }\n"
+                "impl ChoiceUnion { pub fn is_json_match(_: &()) -> bool"
+                " { true } }\n"
+                "#[cfg(test)] impl ChoiceUnion {"
+                " pub fn generate_random_instance() -> Self {"
+                " ChoiceUnion::I64(0) } }\n"
+                "#[test] fn test_union_variants_choiceunion() {}\n"
+            )
+        first_schema = {
+            "type": "record",
+            "name": "One",
+            "namespace": "n",
+            "fields": [
+                {"name": "choice", "type": ["long", "int"]}
+            ],
+        }
+        convert_avro_schema_to_rust(
+            first_schema,
+            rust_path,
+            package_name="rust-legacy-union-migration",
+            serde_annotation=True,
+        )
+        with open(alias_path, "r", encoding="utf-8") as alias_file:
+            self.assertTrue(alias_file.read().startswith(
+                "pub type ChoiceUnion = crate::"
+            ))
+
+        second_schema = [
+            first_schema,
+            {
+                "type": "record",
+                "name": "Two",
+                "namespace": "n",
+                "fields": [
+                    {
+                        "name": "choice",
+                        "type": ["string", "boolean"],
+                    }
+                ],
+            },
+        ]
+        convert_avro_schema_to_rust(
+            second_schema,
+            rust_path,
+            package_name="rust-legacy-union-migration",
+            serde_annotation=True,
+        )
+        self.assertFalse(os.path.exists(alias_path))
 
     def test_output_parent_path_case_is_preserved(self):
         """Never lowercase caller-provided output directory components."""
@@ -900,10 +1034,6 @@ class TestAvroToRust(unittest.TestCase):
             timeout=self.CARGO_TIMEOUT,
         ) == 0
 
-        legacy_field = (
-            "pub nullable: "
-            "crate::issue406::union_only::nullableunion::NullableUnion"
-        )
         for serde_annotation in (False, True):
             compatible_path = self.run_convert_to_rust(
                 "rust-union-annotation",
@@ -923,8 +1053,23 @@ class TestAvroToRust(unittest.TestCase):
                 encoding="utf-8",
             ) as generated_file:
                 compatible_source = generated_file.read()
-            self.assertIn(legacy_field, compatible_source)
+            self.assertRegex(
+                compatible_source,
+                r"pub nullable: crate::issue406::union_only::"
+                r"unionpath[a-z0-9]+::UnionPath[A-Za-z0-9]+,",
+            )
             self.assertNotIn("pub nullable: Option<", compatible_source)
+            self.assertTrue(
+                os.path.exists(
+                    os.path.join(
+                        compatible_path,
+                        "src",
+                        "issue406",
+                        "union_only",
+                        "nullableunion.rs",
+                    )
+                )
+            )
 
     def test_convert_multitype_avro_annotations_to_rust(self):
         """Compile records, enums, and unions that each define SCHEMA in one crate."""

--- a/test/test_avrotorust.py
+++ b/test/test_avrotorust.py
@@ -150,7 +150,7 @@ class TestAvroToRust(unittest.TestCase):
         ]
         with self.assertRaisesRegex(
             ValueError,
-            r"same Rust path.*Foo\.Item.*foo\.Item",
+            r"exact path collision.*Foo\.Item.*foo\.Item",
         ):
             convert_avro_schema_to_rust(
                 schema,
@@ -169,7 +169,7 @@ class TestAvroToRust(unittest.TestCase):
             shutil.rmtree(type_case_path, ignore_errors=True)
         with self.assertRaisesRegex(
             ValueError,
-            r"same Rust path.*foo\.ITEM.*foo\.Item",
+            r"exact path collision.*foo\.Item.*foo\.ITEM",
         ):
             convert_avro_schema_to_rust(
                 [
@@ -257,7 +257,10 @@ class TestAvroToRust(unittest.TestCase):
         ]
         cases = [[schema] for schema in schemas]
         cases.extend((schemas, list(reversed(schemas))))
-        for index, schema in enumerate(cases):
+        ordered_cases = []
+        for schema in cases:
+            ordered_cases.extend((schema, list(reversed(schema))))
+        for index, schema in enumerate(ordered_cases):
             rust_path = os.path.join(
                 tempfile.gettempdir(),
                 "avrotize",
@@ -267,7 +270,9 @@ class TestAvroToRust(unittest.TestCase):
                 shutil.rmtree(rust_path, ignore_errors=True)
             with self.assertRaisesRegex(
                 ValueError,
-                r"generated Rust (mod|lib)\.rs",
+                r"(generation plan has an exact path collision|"
+                r"generation plan requires the same path|"
+                r"generated Rust (mod|lib)\.rs)",
             ):
                 convert_avro_schema_to_rust(
                     schema,
@@ -276,6 +281,143 @@ class TestAvroToRust(unittest.TestCase):
                     avro_annotation=True,
                 )
             self.assertFalse(os.path.exists(rust_path))
+
+    def test_generated_union_and_alias_paths_fail_before_output(self):
+        """Preflight generated union and legacy alias path collisions."""
+        converter = AvroToRust()
+        union_name = converter.union_name_from_path([
+            ('record', 'n.Carrier'),
+            ('field', 'choice'),
+        ])
+        cases = [
+            [
+                {
+                    "type": "record",
+                    "name": union_name,
+                    "namespace": "n",
+                    "fields": [],
+                },
+                {
+                    "type": "record",
+                    "name": "Carrier",
+                    "namespace": "n",
+                    "fields": [
+                        {
+                            "name": "choice",
+                            "type": ["long", "int"],
+                        }
+                    ],
+                },
+            ],
+            [
+                {
+                    "type": "record",
+                    "name": "FooUnion",
+                    "namespace": "n",
+                    "fields": [],
+                },
+                {
+                    "type": "record",
+                    "name": "Carrier",
+                    "namespace": "n",
+                    "fields": [
+                        {
+                            "name": "foo",
+                            "type": ["long", "int"],
+                        }
+                    ],
+                },
+            ],
+        ]
+        for index, schema in enumerate(cases):
+            rust_path = os.path.join(
+                tempfile.gettempdir(),
+                "avrotize",
+                f"rust-planned-path-collision-{index}",
+            )
+            if os.path.exists(rust_path):
+                shutil.rmtree(rust_path, ignore_errors=True)
+            with self.assertRaisesRegex(
+                ValueError,
+                r"generation plan has an exact path collision",
+            ):
+                convert_avro_schema_to_rust(
+                    schema,
+                    rust_path,
+                    package_name="rust-planned-path-collision",
+                    avro_annotation=True,
+                )
+            self.assertFalse(os.path.exists(rust_path))
+
+    def test_generation_plan_matches_annotation_mode(self):
+        """Plan hash unions only for Avro and legacy names otherwise."""
+        converter = AvroToRust()
+        hash_name = converter.union_name_from_path([
+            ('record', 'n.Carrier'),
+            ('field', 'choice'),
+        ])
+        hash_schema = [
+            {
+                "type": "record",
+                "name": hash_name,
+                "namespace": "n",
+                "fields": [],
+            },
+            {
+                "type": "record",
+                "name": "Carrier",
+                "namespace": "n",
+                "fields": [
+                    {
+                        "name": "choice",
+                        "type": ["long", "int"],
+                    }
+                ],
+            },
+        ]
+        rust_path = os.path.join(
+            tempfile.gettempdir(),
+            "avrotize",
+            "rust-plan-non-avro-hash",
+        )
+        if os.path.exists(rust_path):
+            shutil.rmtree(rust_path, ignore_errors=True)
+        convert_avro_schema_to_rust(
+            hash_schema,
+            rust_path,
+            package_name="rust-plan-non-avro-hash",
+            avro_annotation=False,
+        )
+        self.assertTrue(os.path.exists(rust_path))
+
+        collision_schema = [
+            {
+                "type": "record",
+                "name": record_name,
+                "namespace": "n",
+                "fields": [
+                    {
+                        "name": "choice",
+                        "type": ["long", "int"],
+                    }
+                ],
+            }
+            for record_name in ("One", "Two")
+        ]
+        collision_path = os.path.join(
+            tempfile.gettempdir(),
+            "avrotize",
+            "rust-plan-non-avro-collision",
+        )
+        if os.path.exists(collision_path):
+            shutil.rmtree(collision_path, ignore_errors=True)
+        convert_avro_schema_to_rust(
+            collision_schema,
+            collision_path,
+            package_name="rust-plan-non-avro-collision",
+            avro_annotation=False,
+        )
+        self.assertTrue(os.path.exists(collision_path))
 
         root_schemas = [
             {
@@ -302,7 +444,7 @@ class TestAvroToRust(unittest.TestCase):
                 shutil.rmtree(rust_path, ignore_errors=True)
             with self.assertRaisesRegex(
                 ValueError,
-                r"both a file and directory.*'B'.*'b\.C'",
+                r"both a file and directory.*named type B.*named type b\.C",
             ):
                 convert_avro_schema_to_rust(
                     schema,
@@ -547,7 +689,7 @@ class TestAvroToRust(unittest.TestCase):
         rust_path = self.run_convert_to_rust("rust-union-annotation", True, True)
         self.assert_module_scoped_schemas(
             rust_path,
-            expected_count=10,
+            expected_count=16,
             required_modules={
                 "issue406/union_only/nestedholder.rs",
                 "issue406/union_only/unionholder.rs",
@@ -584,6 +726,9 @@ class TestAvroToRust(unittest.TestCase):
         ) as legacy_test:
             legacy_test.write(
                 "use rust_union_annotation::issue406::union_only::{\n"
+                "    nullfirstoption1union::NullFirstoption1Union,\n"
+                "    nulllastoption0union::NullLastoption0Union,\n"
+                "    nullmiddleoption0union::NullMiddleoption0Union,\n"
                 "    nullableunion::NullableUnion,\n"
                 "    unionholder::UnionHolder,\n"
                 "};\n\n"
@@ -594,6 +739,9 @@ class TestAvroToRust(unittest.TestCase):
                 "        ..Default::default()\n"
                 "    };\n"
                 "    assert!(matches!(holder.nullable, NullableUnion::String(_)));\n"
+                "    let _ = NullFirstoption1Union::default();\n"
+                "    let _ = NullMiddleoption0Union::default();\n"
+                "    let _ = NullLastoption0Union::default();\n"
                 "}\n"
             )
         assert subprocess.check_call(
@@ -635,20 +783,16 @@ class TestAvroToRust(unittest.TestCase):
         rust_path = self.run_convert_to_rust("rust-multitype-annotations", True, True)
         schema_modules = self.assert_module_scoped_schemas(
             rust_path,
-            expected_count=34,
+            expected_count=28,
             required_modules={
                 "issue406/multitype/alternate.rs",
-                "issue406/multitype/aliascarrier.rs",
-                "issue406/multitype/aliasnamespacecarrier.rs",
                 "issue406/multitype/collisionone.rs",
                 "issue406/multitype/collisiontwo.rs",
                 "issue406/multitype/composite.rs",
                 "issue406/multitype/foo.rs",
-                "issue406/multitype/foounion/nested.rs",
                 "issue406/multitype/foobar.rs",
                 "issue406/multitype/inlinekind.rs",
                 "issue406/multitype/simple.rs",
-                "issue406/multitype/solounion.rs",
                 "issue406/multitype/standalone.rs",
                 "issue406/multitype/syntheticpaths.rs",
                 "issue406/multitype/twina.rs",
@@ -661,27 +805,7 @@ class TestAvroToRust(unittest.TestCase):
             module for module in schema_modules
             if os.path.basename(module).startswith("union")
         }
-        self.assertEqual(16, len(union_modules))
-        solo_union_path = os.path.join(
-            rust_path,
-            "src",
-            "issue406",
-            "multitype",
-            "solounion.rs",
-        )
-        with open(solo_union_path, "r", encoding="utf-8") as generated_file:
-            self.assertIn("pub struct SoloUnion", generated_file.read())
-        self.assertFalse(
-            os.path.isfile(
-                os.path.join(
-                    rust_path,
-                    "src",
-                    "issue406",
-                    "multitype",
-                    "foounion.rs",
-                )
-            )
-        )
+        self.assertEqual(14, len(union_modules))
 
     def test_convert_named_reference_resolution_to_rust(self):
         """Resolve dotted names and duplicate short names by namespace."""


### PR DESCRIPTION
Fixes #406.

## Machine-review hardening

This head closes the PR-scoped findings from review comment 5354550212 while preserving the canonical-master Rust model APIs:

- validates exact JSON, XML, and Avro media types before decompression; only an exact `+gzip` suffix is accepted;
- caps generated struct, enum, and union decoding at 16 MiB, including gzip expansion;
- bounds recursive generated Avro value projection at 128 levels and covers attacker-constructed recursive record/array/union values;
- preserves nullable public fields, union variants, and `Default` behavior while adding compatible null-capable companions:
  - nullable standalone unions use `to_nullable_byte_array(Option<&Self>)` / `from_nullable_data() -> Option<Self>` against the original source schema;
  - records expose low-level `to_avro_data_value` / `from_avro_data_value` escape hatches for schema-valid nullable fields that cannot be represented by the frozen typed model;
  - legacy typed `Self::from_data` retains its explicit unsupported-null error rather than silently changing public representation;
- rejects JSON union values accepted by multiple generated matchers instead of selecting the first branch; generated test values account for numeric, map/record, identical-record, subset-record, and nested ambiguity;
- uses one containment-checked output-path constructor for named types, unions, aliases, module files, `lib.rs`, and XML support;
- compiles the richest fixture across default, Serde-only, Avro-only, and Avro+Serde modes and covers AnyValue in both Avro modes;
- removes newly introduced `let-else` syntax instead of raising the existing Rust version floor.

The nullable companion methods are intentionally additive and wire-paired: nullable union bytes use the original `SOURCE_SCHEMA` and must be decoded with `from_nullable_data`; legacy non-null methods retain their existing schema/index contract. The raw record companion is documented as an `apache_avro::Value` escape hatch, avoiding a prohibited field-type or enum-variant break.

## Evidence

```powershell
python -m pytest -q test\test_avrotorust.py
# 34 passed, 2 skipped in 630.46s

python -m pytest -q test\test_avrotorust.py -k "json_union_subset_records or recursive_named_type_shape_signature or convert_typemapunion or convert_multitype_avro_annotations or convert_union_avro_annotations"
# 5 passed, 31 deselected in 120.82s

python -m pytest -q test\test_avrotorust.py -k "convert_union_avro_annotations or convert_multitype_avro_annotations"
# 2 passed, 34 deselected in 95.73s
```

Generated Cargo tests cover gzip bombs, corrupt gzip, malformed media types, nullable union null/non-null round trips, parent-record raw nullable value round trips, recursive depth rejection, enum/union gzip round trips, ambiguous JSON rejection, mode matrices, and legacy API imports. The two suite skips are the pre-existing JFrog typed/Avro untagged-JSON cases; the default JFrog regression remains part of the passing suite.

No merge or release action is included.