### PR TITLE
fix(s2py): emit dataclasses-json encoder/decoder metadata for date and time fields (#405)

### DIFF
--- a/avrotize/structuretopython.py
+++ b/avrotize/structuretopython.py
@@ -5,7 +5,8 @@
 import json
 import os
 import re
-import random
+import hashlib
+from random import Random
 from typing import Any, Dict, List, Set, Tuple, Union, Optional
 
 from avrotize.common import pascal, process_template, json_wire_name, json_enum_wire_value
@@ -14,6 +15,191 @@ from avrotize.jstructtoavro import JsonStructureToAvro
 JsonNode = Dict[str, 'JsonNode'] | List['JsonNode'] | str | None
 
 INDENT = '    '
+
+# Temporal Python types that need a dataclasses-json encoder/decoder pair.
+# Ordered most-specific first: datetime.datetime is a subclass of datetime.date,
+# so an isinstance chain must test datetime before date.
+TEMPORAL_SCALARS = ('datetime.datetime', 'datetime.date', 'datetime.time')
+
+# marshmallow field expression per temporal scalar. Only emitted for scalar and
+# Optional[scalar] fields, where the marshmallow representation is exact; nested
+# containers get an encoder/decoder pair but no mm_field, because marshmallow has
+# no faithful equivalent for e.g. typing.Set.
+_MM_FIELDS = {
+    'datetime.datetime': "fields.DateTime(format='iso')",
+    'datetime.date': "fields.Date(format='iso')",
+    'datetime.time': "fields.Time(format='iso')",
+}
+
+_ISO_PARSERS = {
+    'datetime.datetime': '_parse_iso_datetime',
+    'datetime.date': '_parse_iso_date',
+    'datetime.time': '_parse_iso_time',
+}
+
+_GENERIC_RE = re.compile(r'^typing\.(Optional|List|Set|Dict|Union|Tuple|FrozenSet)\[(.+)\]$')
+
+
+def split_type_args(arg_text: str) -> List[str]:
+    """ Splits the comma-separated arguments of a typing generic at bracket depth zero. """
+    args: List[str] = []
+    depth = 0
+    current = ''
+    for char in arg_text:
+        if char == '[':
+            depth += 1
+        elif char == ']':
+            depth -= 1
+        if char == ',' and depth == 0:
+            args.append(current.strip())
+            current = ''
+        else:
+            current += char
+    if current.strip():
+        args.append(current.strip())
+    return args
+
+
+def parse_generic_type(type_name: str) -> Optional[Tuple[str, List[str]]]:
+    """ Splits a typing generic into its origin and its arguments, or None if it is not generic. """
+    match = _GENERIC_RE.match(type_name)
+    if not match:
+        return None
+    origin, arg_text = match.groups()
+    return origin, split_type_args(arg_text)
+
+
+def type_contains_temporal(type_name: str) -> bool:
+    """ Reports whether a Python type annotation contains a temporal scalar at any nesting depth. """
+    if type_name in TEMPORAL_SCALARS:
+        return True
+    generic = parse_generic_type(type_name)
+    if not generic:
+        return False
+    return any(type_contains_temporal(arg) for arg in generic[1])
+
+
+def _codec_branches(type_name: str, var: str, depth: int, encode: bool) -> List[Tuple[int, str, str]]:
+    """ Builds the (priority, condition, value) branches of a temporal codec expression.
+
+    The branches are folded into a conditional chain that leaves any value it does
+    not recognize untouched, so malformed or unexpected payloads pass through
+    unchanged instead of raising.
+    """
+    if type_name == 'datetime.datetime':
+        if encode:
+            return [(0, f'isinstance({var}, datetime.datetime)', f'{var}.isoformat()')]
+        return [(0, f'isinstance({var}, str)', f'_parse_iso_datetime({var})')]
+    if type_name == 'datetime.date':
+        if encode:
+            # datetime.datetime is a subclass of datetime.date: narrow it to the
+            # date component so the emitted string is parseable by the decoder.
+            return [(0, f'isinstance({var}, datetime.datetime)', f'{var}.date().isoformat()'),
+                    (1, f'isinstance({var}, datetime.date)', f'{var}.isoformat()')]
+        return [(1, f'isinstance({var}, str)', f'_parse_iso_date({var})')]
+    if type_name == 'datetime.time':
+        if encode:
+            return [(2, f'isinstance({var}, datetime.time)', f'{var}.isoformat()')]
+        return [(2, f'isinstance({var}, str)', f'_parse_iso_time({var})')]
+
+    generic = parse_generic_type(type_name)
+    if not generic:
+        return []
+    origin, args = generic
+
+    if origin in ('Optional', 'Union'):
+        branches: List[Tuple[int, str, str]] = []
+        for arg in args:
+            branches.extend(_codec_branches(arg, var, depth, encode))
+        branches.sort(key=lambda branch: branch[0])
+        seen: Set[str] = set()
+        unique: List[Tuple[int, str, str]] = []
+        for branch in branches:
+            if branch[1] in seen:
+                continue
+            seen.add(branch[1])
+            unique.append(branch)
+        return unique
+
+    item = f'_item{depth}'
+    if origin in ('List', 'Set', 'FrozenSet', 'Tuple'):
+        inner = args[0]
+        if not type_contains_temporal(inner):
+            return []
+        inner_expr = build_codec_expression(inner, item, depth + 1, encode)
+        comprehension = f'[{inner_expr} for {item} in {var}]'
+        # JSON has no set or tuple, and the rest of this generator represents
+        # both as lists (see generate_test_value), so decoding yields a list too.
+        return [(3, f'isinstance({var}, (list, tuple, set, frozenset))', comprehension)]
+    if origin == 'Dict':
+        value_type = args[-1]
+        if not type_contains_temporal(value_type):
+            return []
+        key = f'_key{depth}'
+        inner_expr = build_codec_expression(value_type, item, depth + 1, encode)
+        return [(3, f'isinstance({var}, dict)',
+                 f'{{{key}: {inner_expr} for {key}, {item} in {var}.items()}}')]
+    return []
+
+
+def build_codec_expression(type_name: str, var: str, depth: int, encode: bool) -> str:
+    """ Builds a temporal encode/decode expression over ``var``, or ``var`` itself when nothing applies. """
+    branches = _codec_branches(type_name, var, depth, encode)
+    expression = var
+    for _priority, condition, value in reversed(branches):
+        expression = f'{value} if {condition} else {expression}'
+    return expression
+
+
+def build_mm_field(type_name: str) -> Optional[str]:
+    """ Builds the marshmallow field expression for a temporal type, or None when
+    marshmallow has no faithful equivalent (e.g. typing.Set, or a union of
+    several temporal types). """
+    if type_name in _MM_FIELDS:
+        return _MM_FIELDS[type_name]
+    generic = parse_generic_type(type_name)
+    if not generic:
+        return None
+    origin, args = generic
+    if origin == 'Optional':
+        return build_mm_field(args[0])
+    if origin == 'List':
+        inner = build_mm_field(args[0])
+        return f'fields.List({inner})' if inner else None
+    if origin == 'Dict' and len(args) == 2 and args[0] == 'str':
+        inner = build_mm_field(args[1])
+        return f'fields.Dict(keys=fields.Str(), values={inner})' if inner else None
+    return None
+
+
+def build_temporal_codec(type_name: str) -> Optional[Dict[str, Optional[str]]]:
+    """ Builds the dataclasses-json encoder/decoder/mm_field triple for a temporal field type.
+
+    Returns None when the type contains no temporal scalar. The encoder and
+    decoder walk nested ``Optional``/``Union``/``List``/``Set``/``Dict``
+    annotations, so collections of dates are serialized just like scalar dates.
+    """
+    if not type_contains_temporal(type_name):
+        return None
+    encoder = build_codec_expression(type_name, 'v', 0, encode=True)
+    decoder = build_codec_expression(type_name, 'v', 0, encode=False)
+    if encoder == 'v' and decoder == 'v':
+        return None
+
+    inner = type_name
+    generic = parse_generic_type(inner)
+    if generic and generic[0] == 'Optional':
+        inner = generic[1][0]
+    mm_field = build_mm_field(inner)
+
+    return {
+        'encoder': f'lambda v: {encoder}',
+        'decoder': f'lambda v: {decoder}',
+        'mm_field': mm_field,
+        'parsers': sorted({_ISO_PARSERS[scalar] for scalar in TEMPORAL_SCALARS
+                           if _ISO_PARSERS[scalar] in decoder}),
+    }
+
 
 # Python standard library modules that should not be shadowed by package names
 PYTHON_STDLIB_MODULES = {
@@ -407,25 +593,37 @@ class StructureToPython:
         doc = structure_schema.get('description', structure_schema.get('doc', class_name))
 
         # Generate field docstrings
-        field_docstrings = [{
-            'name': self.safe_name(field['name']),
-            'original_name': field.get('json_name') or field['name'],
-            'type': field['type'],
-            'is_primitive': field['is_primitive'],
-            'is_enum': field['is_enum'],
-            'docstring': self.generate_field_docstring(field, schema_namespace),
-            'test_value': self.generate_test_value(field),
-            'source_type': field.get('source_type', 'string'),
-            'xml_name': field['xml_name'],
-            'xml_kind': field['xml_kind'],
-            'xml_namespace': field['xml_namespace'],
-            'xml_metadata': {
-                'type': 'Attribute' if field['xml_kind'] == 'attribute' else 'Element',
-                'name': field['xml_name'],
-                **({'namespace': field['xml_namespace']}
-                   if field['xml_kind'] != 'attribute' and field['xml_namespace'] else {}),
-            },
-        } for field in fields]
+        field_docstrings = []
+        for field in fields:
+            codec = build_temporal_codec(field['type'])
+            field_docstrings.append({
+                'name': self.safe_name(field['name']),
+                'original_name': field.get('json_name') or field['name'],
+                'type': field['type'],
+                'is_primitive': field['is_primitive'],
+                'is_enum': field['is_enum'],
+                'docstring': self.generate_field_docstring(field, schema_namespace),
+                'test_value': self.generate_test_value(field),
+                'source_type': field.get('source_type', 'string'),
+                'json_encoder': codec['encoder'] if codec else None,
+                'json_decoder': codec['decoder'] if codec else None,
+                'mm_field': codec['mm_field'] if codec else None,
+                'iso_parsers': codec['parsers'] if codec else [],
+                'xml_name': field['xml_name'],
+                'xml_kind': field['xml_kind'],
+                'xml_namespace': field['xml_namespace'],
+                'xml_metadata': {
+                    'type': 'Attribute' if field['xml_kind'] == 'attribute' else 'Element',
+                    'name': field['xml_name'],
+                    **({'namespace': field['xml_namespace']}
+                       if field['xml_kind'] != 'attribute' and field['xml_namespace'] else {}),
+                },
+            })
+
+        # ISO parsing helpers required by the emitted decoders, in a stable order.
+        iso_parsers = [parser for parser in
+                       ('_parse_iso_date', '_parse_iso_datetime', '_parse_iso_time')
+                       if any(parser in field['iso_parsers'] for field in field_docstrings)]
 
         # If avro_annotation is enabled, convert JSON Structure schema to Avro schema
         # This is embedded in the generated class for runtime Avro serialization
@@ -443,6 +641,7 @@ class StructureToPython:
             class_name=class_name,
             docstring=doc,
             fields=field_docstrings,
+            iso_parsers=iso_parsers,
             import_types=sorted(import_types),
             base_package=self.base_package,
             dataclasses_json_annotation=self.dataclasses_json_annotation,
@@ -776,8 +975,17 @@ class StructureToPython:
         return python_qualified_name
 
     def generate_test_value(self, field: Dict) -> Any:
-        """Generates a test value for a given field"""
+        """Generates a test value for a given field.
+
+        The value is drawn from a generator seeded with a stable hash of the field
+        name and type, so repeated generation of the same schema produces
+        byte-identical output regardless of interpreter hash randomization.
+        """
         field_type = field['type']
+        seed = int.from_bytes(
+            hashlib.sha256(f"{field.get('name', '')}:{field_type}".encode('utf-8')).digest()[:8],
+            'big')
+        random = Random(seed)
 
         def generate_value(field_type: str):
             test_values = {

--- a/avrotize/structuretopython.py
+++ b/avrotize/structuretopython.py
@@ -443,7 +443,7 @@ class StructureToPython:
             class_name=class_name,
             docstring=doc,
             fields=field_docstrings,
-            import_types=import_types,
+            import_types=sorted(import_types),
             base_package=self.base_package,
             dataclasses_json_annotation=self.dataclasses_json_annotation,
             avro_annotation=self.avro_annotation,
@@ -765,7 +765,7 @@ class StructureToPython:
             class_name=class_name,
             docstring=doc,
             values_type=values_type,
-            import_types=import_types,
+            import_types=sorted(import_types),
             base_package=self.base_package
         )
         
@@ -864,7 +864,7 @@ class StructureToPython:
             class_name=class_name,
             test_class_name=test_class_name,
             fields=fields,
-            import_types=import_types,
+            import_types=sorted(import_types),
             avro_annotation=self.avro_annotation,
             dataclasses_json_annotation=self.dataclasses_json_annotation
         )

--- a/avrotize/structuretopython.py
+++ b/avrotize/structuretopython.py
@@ -37,6 +37,9 @@ _ISO_PARSERS = {
     'datetime.time': '_parse_iso_time',
 }
 
+# Emitted in this order so a module's helper block is stable.
+ISO_PARSER_ORDER = ('_parse_iso_date', '_parse_iso_datetime', '_parse_iso_time')
+
 _GENERIC_RE = re.compile(r'^typing\.(Optional|List|Set|Dict|Union|Tuple|FrozenSet)\[(.+)\]$')
 
 
@@ -79,28 +82,79 @@ def type_contains_temporal(type_name: str) -> bool:
     return any(type_contains_temporal(arg) for arg in generic[1])
 
 
-def _codec_branches(type_name: str, var: str, depth: int, encode: bool) -> List[Tuple[int, str, str]]:
+NONE_TYPES = ('None', 'NoneType', 'type(None)')
+
+# Branch priorities. Lower is tested first, so datetime must precede date: a
+# datetime.datetime satisfies isinstance(v, datetime.date) as well.
+_PRIORITY_DATETIME = 0
+_PRIORITY_DATE_NARROWING = 1
+_PRIORITY_DATE = 2
+_PRIORITY_TIME = 3
+_PRIORITY_CONTAINER = 4
+
+
+def temporal_scalars_in(type_name: str) -> Set[str]:
+    """ Collects the distinct temporal scalars a Python type annotation contains at any depth. """
+    if type_name in TEMPORAL_SCALARS:
+        return {type_name}
+    generic = parse_generic_type(type_name)
+    if not generic:
+        return set()
+    found: Set[str] = set()
+    for arg in generic[1]:
+        found |= temporal_scalars_in(arg)
+    return found
+
+
+def union_is_ambiguous(args: List[str]) -> bool:
+    """ Reports whether a union mixes temporal arms in a way no undiscriminated codec can encode.
+
+    A union of two temporal scalars (``Union[date, datetime]``) cannot be encoded
+    without losing the distinction, and a temporal scalar beside a non-temporal
+    arm (``Union[date, str]``) cannot be decoded without coercing values that
+    legitimately belong to the other arm. In both cases no codec is emitted, so
+    the pre-existing loud failure is preserved rather than replaced by silent
+    data loss.
+    """
+    arms = [arg for arg in args if arg not in NONE_TYPES]
+    scalars: Set[str] = set()
+    for arm in arms:
+        scalars |= temporal_scalars_in(arm)
+    if len(scalars) > 1:
+        return True
+    return any(not type_contains_temporal(arm) for arm in arms)
+
+
+def _codec_branches(type_name: str, var: str, depth: int, encode: bool,
+                    parsers: Set[str]) -> List[Tuple[int, str, str]]:
     """ Builds the (priority, condition, value) branches of a temporal codec expression.
 
-    The branches are folded into a conditional chain that leaves any value it does
-    not recognize untouched, so malformed or unexpected payloads pass through
-    unchanged instead of raising.
+    Every ISO parser referenced by the emitted branches is recorded in ``parsers``
+    so the caller knows exactly which helper definitions the generated module
+    needs. Values whose type the branches do not recognize are left untouched;
+    strings that should be temporal but cannot be parsed raise from the parser.
     """
     if type_name == 'datetime.datetime':
         if encode:
-            return [(0, f'isinstance({var}, datetime.datetime)', f'{var}.isoformat()')]
-        return [(0, f'isinstance({var}, str)', f'_parse_iso_datetime({var})')]
+            return [(_PRIORITY_DATETIME, f'isinstance({var}, datetime.datetime)', f'{var}.isoformat()')]
+        parsers.add('_parse_iso_datetime')
+        return [(_PRIORITY_DATETIME, f'isinstance({var}, str)', f'_parse_iso_datetime({var}, {{field_name}})')]
     if type_name == 'datetime.date':
         if encode:
             # datetime.datetime is a subclass of datetime.date: narrow it to the
             # date component so the emitted string is parseable by the decoder.
-            return [(0, f'isinstance({var}, datetime.datetime)', f'{var}.date().isoformat()'),
-                    (1, f'isinstance({var}, datetime.date)', f'{var}.isoformat()')]
-        return [(1, f'isinstance({var}, str)', f'_parse_iso_date({var})')]
+            # This branch is deliberately ranked below the datetime branch above
+            # so it can never displace it when both appear in one expression.
+            return [(_PRIORITY_DATE_NARROWING, f'isinstance({var}, datetime.datetime)',
+                     f'{var}.date().isoformat()'),
+                    (_PRIORITY_DATE, f'isinstance({var}, datetime.date)', f'{var}.isoformat()')]
+        parsers.add('_parse_iso_date')
+        return [(_PRIORITY_DATE, f'isinstance({var}, str)', f'_parse_iso_date({var}, {{field_name}})')]
     if type_name == 'datetime.time':
         if encode:
-            return [(2, f'isinstance({var}, datetime.time)', f'{var}.isoformat()')]
-        return [(2, f'isinstance({var}, str)', f'_parse_iso_time({var})')]
+            return [(_PRIORITY_TIME, f'isinstance({var}, datetime.time)', f'{var}.isoformat()')]
+        parsers.add('_parse_iso_time')
+        return [(_PRIORITY_TIME, f'isinstance({var}, str)', f'_parse_iso_time({var}, {{field_name}})')]
 
     generic = parse_generic_type(type_name)
     if not generic:
@@ -108,9 +162,11 @@ def _codec_branches(type_name: str, var: str, depth: int, encode: bool) -> List[
     origin, args = generic
 
     if origin in ('Optional', 'Union'):
+        if union_is_ambiguous(args):
+            return []
         branches: List[Tuple[int, str, str]] = []
         for arg in args:
-            branches.extend(_codec_branches(arg, var, depth, encode))
+            branches.extend(_codec_branches(arg, var, depth, encode, parsers))
         branches.sort(key=lambda branch: branch[0])
         seen: Set[str] = set()
         unique: List[Tuple[int, str, str]] = []
@@ -122,29 +178,35 @@ def _codec_branches(type_name: str, var: str, depth: int, encode: bool) -> List[
         return unique
 
     item = f'_item{depth}'
-    if origin in ('List', 'Set', 'FrozenSet', 'Tuple'):
+    # Only homogeneous containers are handled. typing.Tuple is deliberately
+    # excluded because its arguments are positional, so a single element codec
+    # cannot describe it.
+    if origin in ('List', 'Set', 'FrozenSet'):
         inner = args[0]
         if not type_contains_temporal(inner):
             return []
-        inner_expr = build_codec_expression(inner, item, depth + 1, encode)
+        inner_expr = build_codec_expression(inner, item, depth + 1, encode, parsers)
         comprehension = f'[{inner_expr} for {item} in {var}]'
-        # JSON has no set or tuple, and the rest of this generator represents
-        # both as lists (see generate_test_value), so decoding yields a list too.
-        return [(3, f'isinstance({var}, (list, tuple, set, frozenset))', comprehension)]
+        if not encode and origin == 'Set':
+            comprehension = f'set({comprehension})'
+        elif not encode and origin == 'FrozenSet':
+            comprehension = f'frozenset({comprehension})'
+        return [(_PRIORITY_CONTAINER, f'isinstance({var}, (list, tuple, set, frozenset))', comprehension)]
     if origin == 'Dict':
         value_type = args[-1]
         if not type_contains_temporal(value_type):
             return []
         key = f'_key{depth}'
-        inner_expr = build_codec_expression(value_type, item, depth + 1, encode)
-        return [(3, f'isinstance({var}, dict)',
+        inner_expr = build_codec_expression(value_type, item, depth + 1, encode, parsers)
+        return [(_PRIORITY_CONTAINER, f'isinstance({var}, dict)',
                  f'{{{key}: {inner_expr} for {key}, {item} in {var}.items()}}')]
     return []
 
 
-def build_codec_expression(type_name: str, var: str, depth: int, encode: bool) -> str:
+def build_codec_expression(type_name: str, var: str, depth: int, encode: bool,
+                           parsers: Set[str]) -> str:
     """ Builds a temporal encode/decode expression over ``var``, or ``var`` itself when nothing applies. """
-    branches = _codec_branches(type_name, var, depth, encode)
+    branches = _codec_branches(type_name, var, depth, encode, parsers)
     expression = var
     for _priority, condition, value in reversed(branches):
         expression = f'{value} if {condition} else {expression}'
@@ -172,19 +234,26 @@ def build_mm_field(type_name: str) -> Optional[str]:
     return None
 
 
-def build_temporal_codec(type_name: str) -> Optional[Dict[str, Optional[str]]]:
+def build_temporal_codec(type_name: str, field_name: str) -> Optional[Dict[str, Optional[str]]]:
     """ Builds the dataclasses-json encoder/decoder/mm_field triple for a temporal field type.
 
-    Returns None when the type contains no temporal scalar. The encoder and
-    decoder walk nested ``Optional``/``Union``/``List``/``Set``/``Dict``
-    annotations, so collections of dates are serialized just like scalar dates.
+    Returns None when the type contains no temporal scalar, or when it is a union
+    whose arms cannot be told apart on the wire. The encoder and decoder walk
+    nested ``Optional``/``Union``/``List``/``Set``/``Dict`` annotations, so
+    collections of dates are serialized just like scalar dates.
     """
     if not type_contains_temporal(type_name):
         return None
-    encoder = build_codec_expression(type_name, 'v', 0, encode=True)
-    decoder = build_codec_expression(type_name, 'v', 0, encode=False)
+    encode_parsers: Set[str] = set()
+    decode_parsers: Set[str] = set()
+    encoder = build_codec_expression(type_name, 'v', 0, True, encode_parsers)
+    decoder = build_codec_expression(type_name, 'v', 0, False, decode_parsers)
     if encoder == 'v' and decoder == 'v':
         return None
+
+    # The parsers name the field that rejected a value, so a malformed payload
+    # reports where it came from instead of surfacing a bare isoformat error.
+    decoder = decoder.replace('{field_name}', repr(field_name))
 
     inner = type_name
     generic = parse_generic_type(inner)
@@ -196,8 +265,7 @@ def build_temporal_codec(type_name: str) -> Optional[Dict[str, Optional[str]]]:
         'encoder': f'lambda v: {encoder}',
         'decoder': f'lambda v: {decoder}',
         'mm_field': mm_field,
-        'parsers': sorted({_ISO_PARSERS[scalar] for scalar in TEMPORAL_SCALARS
-                           if _ISO_PARSERS[scalar] in decoder}),
+        'parsers': sorted(decode_parsers),
     }
 
 
@@ -595,7 +663,8 @@ class StructureToPython:
         # Generate field docstrings
         field_docstrings = []
         for field in fields:
-            codec = build_temporal_codec(field['type'])
+            codec = build_temporal_codec(
+                field['type'], field.get('json_name') or field['name'])
             field_docstrings.append({
                 'name': self.safe_name(field['name']),
                 'original_name': field.get('json_name') or field['name'],
@@ -621,8 +690,7 @@ class StructureToPython:
             })
 
         # ISO parsing helpers required by the emitted decoders, in a stable order.
-        iso_parsers = [parser for parser in
-                       ('_parse_iso_date', '_parse_iso_datetime', '_parse_iso_time')
+        iso_parsers = [parser for parser in ISO_PARSER_ORDER
                        if any(parser in field['iso_parsers'] for field in field_docstrings)]
 
         # If avro_annotation is enabled, convert JSON Structure schema to Avro schema
@@ -1026,9 +1094,13 @@ class StructureToPython:
                 field_type = resolve(field_type)
 
             if field_type.startswith('typing.List[') or field_type.startswith('typing.Set['):
+                is_set = field_type.startswith('typing.Set[')
                 field_type = resolve(field_type)
                 array_range = random.randint(1, 5)
-                return f"[{', '.join([generate_value(field_type) for _ in range(array_range)])}]"
+                items = f"[{', '.join([generate_value(field_type) for _ in range(array_range)])}]"
+                # A typing.Set field must be constructed as a set, or the value
+                # would not match the container the deserializers rebuild.
+                return f"set({items})" if is_set else items
             elif field_type.startswith('typing.Dict['):
                 field_type = resolve(field_type)
                 dict_range = random.randint(1, 5)

--- a/avrotize/structuretopython.py
+++ b/avrotize/structuretopython.py
@@ -25,10 +25,16 @@ TEMPORAL_SCALARS = ('datetime.datetime', 'datetime.date', 'datetime.time')
 # Optional[scalar] fields, where the marshmallow representation is exact; nested
 # containers get an encoder/decoder pair but no mm_field, because marshmallow has
 # no faithful equivalent for e.g. typing.Set.
+#
+# These name generated subclasses rather than marshmallow's own fields, because
+# dataclasses_json.mm.schema() uses a supplied mm_field verbatim: it neither
+# assigns data_key nor applies the field's decoder. A plain fields.Date would
+# therefore lose the JSON field name and parse with marshmallow's own parser,
+# so schema() would disagree with the other four entry points.
 _MM_FIELDS = {
-    'datetime.datetime': "fields.DateTime(format='iso')",
-    'datetime.date': "fields.Date(format='iso')",
-    'datetime.time': "fields.Time(format='iso')",
+    'datetime.datetime': '_IsoDateTimeField',
+    'datetime.date': '_IsoDateField',
+    'datetime.time': '_IsoTimeField',
 }
 
 _ISO_PARSERS = {
@@ -37,8 +43,17 @@ _ISO_PARSERS = {
     'datetime.time': '_parse_iso_time',
 }
 
+# Each generated marshmallow field delegates to one of the ISO parsers, so
+# emitting the field also requires emitting its parser.
+_MM_FIELD_PARSERS = {
+    '_IsoDateField': '_parse_iso_date',
+    '_IsoDateTimeField': '_parse_iso_datetime',
+    '_IsoTimeField': '_parse_iso_time',
+}
+
 # Emitted in this order so a module's helper block is stable.
 ISO_PARSER_ORDER = ('_parse_iso_date', '_parse_iso_datetime', '_parse_iso_time')
+MM_FIELD_ORDER = ('_IsoDateField', '_IsoDateTimeField', '_IsoTimeField')
 
 _GENERIC_RE = re.compile(r'^typing\.(Optional|List|Set|Dict|Union|Tuple|FrozenSet)\[(.+)\]$')
 
@@ -213,24 +228,73 @@ def build_codec_expression(type_name: str, var: str, depth: int, encode: bool,
     return expression
 
 
-def build_mm_field(type_name: str) -> Optional[str]:
+def build_mm_field(type_name: str, mm_classes: Set[str],
+                   options: str = '') -> Optional[str]:
     """ Builds the marshmallow field expression for a temporal type, or None when
     marshmallow has no faithful equivalent (e.g. typing.Set, or a union of
-    several temporal types). """
+    several temporal types).
+
+    ``options`` carries the keyword arguments for the outermost field only, so
+    ``data_key`` is not repeated on the element field of a list or map.
+    """
     if type_name in _MM_FIELDS:
-        return _MM_FIELDS[type_name]
+        mm_class = _MM_FIELDS[type_name]
+        mm_classes.add(mm_class)
+        return f'{mm_class}({options})'
     generic = parse_generic_type(type_name)
     if not generic:
         return None
     origin, args = generic
     if origin == 'Optional':
-        return build_mm_field(args[0])
+        return build_mm_field(args[0], mm_classes, options)
     if origin == 'List':
-        inner = build_mm_field(args[0])
-        return f'fields.List({inner})' if inner else None
+        inner = build_mm_field(args[0], mm_classes)
+        return f'fields.List({inner}{", " + options if options else ""})' if inner else None
     if origin == 'Dict' and len(args) == 2 and args[0] == 'str':
-        inner = build_mm_field(args[1])
-        return f'fields.Dict(keys=fields.Str(), values={inner})' if inner else None
+        inner = build_mm_field(args[1], mm_classes)
+        if not inner:
+            return None
+        return (f'fields.Dict(keys=fields.Str(), values={inner}'
+                f'{", " + options if options else ""})')
+    return None
+
+
+def build_mm_options(type_name: str, json_name: str) -> str:
+    """ Builds the marshmallow keyword arguments that dataclasses_json would have
+    supplied itself.
+
+    ``dataclasses_json.mm.schema()`` only assigns ``data_key``, ``required`` and
+    ``allow_none`` on the branch it takes when no ``mm_field`` is configured, so
+    a field that supplies one has to carry them. ``data_key`` is the same value
+    passed to ``dataclasses_json.config(field_name=...)``, which is what
+    dataclasses_json would have computed from the configured letter case.
+    """
+    # Generated fields are kw_only and carry no default, so dataclasses_json
+    # would mark every one of them required.
+    options = [f'data_key={json_name!r}', 'required=True']
+    generic = parse_generic_type(type_name)
+    if generic and generic[0] == 'Optional':
+        options.append('allow_none=True')
+    return ', '.join(options)
+
+
+def build_container_rebuild(type_name: str) -> Optional[str]:
+    """ Builds an expression rebuilding a declared set container from a JSON list.
+
+    JSON has no set type, so a ``typing.Set`` field arrives as a list. The
+    dataclasses-json ``from_json`` path reconstructs the declared container, and
+    the generated ``from_serializer_dict`` has to do the same or the two paths
+    hand back different container types for the same payload.
+    """
+    generic = parse_generic_type(type_name)
+    if not generic:
+        return None
+    origin, args = generic
+    if origin == 'Optional':
+        inner = build_container_rebuild(args[0])
+        return f'None if v is None else {inner}' if inner else None
+    if origin in ('Set', 'FrozenSet'):
+        return f'{"set" if origin == "Set" else "frozenset"}(v)'
     return None
 
 
@@ -255,17 +319,24 @@ def build_temporal_codec(type_name: str, field_name: str) -> Optional[Dict[str, 
     # reports where it came from instead of surfacing a bare isoformat error.
     decoder = decoder.replace('{field_name}', repr(field_name))
 
-    inner = type_name
-    generic = parse_generic_type(inner)
-    if generic and generic[0] == 'Optional':
-        inner = generic[1][0]
-    mm_field = build_mm_field(inner)
+    mm_classes: Set[str] = set()
+    mm_field = build_mm_field(type_name, mm_classes,
+                              build_mm_options(type_name, field_name))
+    if not mm_field:
+        mm_classes.clear()
+
+    # A generated marshmallow field parses with the module's own ISO helper, so
+    # its parser has to be emitted even when no decoder lambda referenced it.
+    parsers = set(decode_parsers)
+    for mm_class in mm_classes:
+        parsers.add(_MM_FIELD_PARSERS[mm_class])
 
     return {
         'encoder': f'lambda v: {encoder}',
         'decoder': f'lambda v: {decoder}',
         'mm_field': mm_field,
-        'parsers': sorted(decode_parsers),
+        'mm_classes': sorted(mm_classes),
+        'parsers': sorted(parsers),
     }
 
 
@@ -677,7 +748,13 @@ class StructureToPython:
                 'json_encoder': codec['encoder'] if codec else None,
                 'json_decoder': codec['decoder'] if codec else None,
                 'mm_field': codec['mm_field'] if codec else None,
+                'mm_classes': codec['mm_classes'] if codec else [],
                 'iso_parsers': codec['parsers'] if codec else [],
+                # A set arrives from JSON as a list. Temporal sets are rebuilt by
+                # their own decoder; every other set needs an explicit rebuild so
+                # from_serializer_dict agrees with the dataclasses-json path.
+                'container_rebuild': (None if codec
+                                      else build_container_rebuild(field['type'])),
                 'xml_name': field['xml_name'],
                 'xml_kind': field['xml_kind'],
                 'xml_namespace': field['xml_namespace'],
@@ -692,6 +769,9 @@ class StructureToPython:
         # ISO parsing helpers required by the emitted decoders, in a stable order.
         iso_parsers = [parser for parser in ISO_PARSER_ORDER
                        if any(parser in field['iso_parsers'] for field in field_docstrings)]
+        # Marshmallow field subclasses required by the emitted mm_fields.
+        mm_classes = [mm_class for mm_class in MM_FIELD_ORDER
+                      if any(mm_class in field['mm_classes'] for field in field_docstrings)]
 
         # If avro_annotation is enabled, convert JSON Structure schema to Avro schema
         # This is embedded in the generated class for runtime Avro serialization
@@ -710,6 +790,7 @@ class StructureToPython:
             docstring=doc,
             fields=field_docstrings,
             iso_parsers=iso_parsers,
+            mm_classes=mm_classes,
             import_types=sorted(import_types),
             base_package=self.base_package,
             dataclasses_json_annotation=self.dataclasses_json_annotation,

--- a/avrotize/structuretopython/dataclass_core.jinja
+++ b/avrotize/structuretopython/dataclass_core.jinja
@@ -54,46 +54,52 @@ from {{ xml_runtime_module }} import parse_xml, serialize_xml
 {% endif %}
 {% if dataclasses_json_annotation and iso_parsers %}
 
+def _normalize_iso_string(value: str) -> str:
+    """ Normalizes an RFC 3339 string into a form datetime.fromisoformat accepts.
+
+    A trailing 'Z' is rewritten to '+00:00' and fractional seconds are padded or
+    truncated to exactly microsecond precision, because fromisoformat only
+    accepts the 'Z' designator and arbitrary fraction lengths from Python 3.11
+    onwards, and this package supports Python 3.10.
+    """
+    text = value[:-1] + '+00:00' if value.endswith(('Z', 'z')) else value
+    dot = text.find('.')
+    if dot != -1:
+        end = dot + 1
+        while end < len(text) and text[end].isdigit():
+            end += 1
+        digits = text[dot + 1:end]
+        if digits and len(digits) != 6:
+            text = text[:dot + 1] + digits[:6].ljust(6, '0') + text[end:]
+    return text
+
 {% for parser in iso_parsers %}
 {%- if parser == '_parse_iso_date' %}
-def _parse_iso_date(value: typing.Any) -> typing.Any:
-    """ Parses an ISO 8601 date string. Values that are not parseable dates are returned unchanged. """
-    if not isinstance(value, str):
-        return value
+def _parse_iso_date(value: str, field_name: str) -> datetime.date:
+    """ Parses an ISO 8601 date string, raising ValueError if it is malformed. """
     try:
-        return datetime.date.fromisoformat(value)
-    except ValueError:
-        return value
+        return datetime.date.fromisoformat(_normalize_iso_string(value))
+    except ValueError as error:
+        raise ValueError(
+            f"Invalid ISO 8601 date for field '{field_name}': {value!r}") from error
 
 {% elif parser == '_parse_iso_datetime' %}
-def _parse_iso_datetime(value: typing.Any) -> typing.Any:
-    """ Parses an ISO 8601 / RFC 3339 datetime string. Values that are not parseable datetimes are returned unchanged.
-
-    A trailing 'Z' is normalized to '+00:00' because datetime.fromisoformat only
-    accepts the 'Z' designator from Python 3.11 onwards.
-    """
-    if not isinstance(value, str):
-        return value
-    text = value[:-1] + '+00:00' if value.endswith(('Z', 'z')) else value
+def _parse_iso_datetime(value: str, field_name: str) -> datetime.datetime:
+    """ Parses an ISO 8601 / RFC 3339 datetime string, raising ValueError if it is malformed. """
     try:
-        return datetime.datetime.fromisoformat(text)
-    except ValueError:
-        return value
+        return datetime.datetime.fromisoformat(_normalize_iso_string(value))
+    except ValueError as error:
+        raise ValueError(
+            f"Invalid ISO 8601 datetime for field '{field_name}': {value!r}") from error
 
 {% elif parser == '_parse_iso_time' %}
-def _parse_iso_time(value: typing.Any) -> typing.Any:
-    """ Parses an ISO 8601 time string. Values that are not parseable times are returned unchanged.
-
-    A trailing 'Z' is normalized to '+00:00' because time.fromisoformat only
-    accepts the 'Z' designator from Python 3.11 onwards.
-    """
-    if not isinstance(value, str):
-        return value
-    text = value[:-1] + '+00:00' if value.endswith(('Z', 'z')) else value
+def _parse_iso_time(value: str, field_name: str) -> datetime.time:
+    """ Parses an ISO 8601 time string, raising ValueError if it is malformed. """
     try:
-        return datetime.time.fromisoformat(text)
-    except ValueError:
-        return value
+        return datetime.time.fromisoformat(_normalize_iso_string(value))
+    except ValueError as error:
+        raise ValueError(
+            f"Invalid ISO 8601 time for field '{field_name}': {value!r}") from error
 
 {% endif %}
 {%- endfor %}

--- a/avrotize/structuretopython/dataclass_core.jinja
+++ b/avrotize/structuretopython/dataclass_core.jinja
@@ -19,7 +19,7 @@ import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
 {%- for field in fields if field.mm_field %}
 {%- if loop.first %}
-from marshmallow import fields
+from marshmallow import fields, ValidationError
 {%- endif %}
 {%- endfor %}
 {%- endif %}
@@ -103,6 +103,80 @@ def _parse_iso_time(value: str, field_name: str) -> datetime.time:
 
 {% endif %}
 {%- endfor %}
+{% if mm_classes %}
+{% for mm_class in mm_classes %}
+{%- if mm_class == '_IsoDateField' %}
+class _IsoDateField(fields.Date):
+    """ A marshmallow date field that shares the module's ISO date parser.
+
+    dataclasses_json uses a configured mm_field verbatim, so without this the
+    schema() path would parse with marshmallow's own parser and disagree with
+    to_json/from_json about which strings are valid and what they mean.
+    """
+
+    def _serialize(self, value, attr, obj, **kwargs):
+        if value is None:
+            return None
+        if isinstance(value, datetime.datetime):
+            return value.date().isoformat()
+        if isinstance(value, datetime.date):
+            return value.isoformat()
+        return value
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        if value is None:
+            return None
+        try:
+            return _parse_iso_date(value, self.data_key or attr or 'value')
+        except ValueError as error:
+            raise ValidationError(str(error)) from error
+
+{% elif mm_class == '_IsoDateTimeField' %}
+class _IsoDateTimeField(fields.DateTime):
+    """ A marshmallow datetime field that shares the module's ISO datetime parser. """
+
+    def _serialize(self, value, attr, obj, **kwargs):
+        if value is None:
+            return None
+        if isinstance(value, datetime.datetime):
+            return value.isoformat()
+        return value
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        if value is None:
+            return None
+        try:
+            return _parse_iso_datetime(value, self.data_key or attr or 'value')
+        except ValueError as error:
+            raise ValidationError(str(error)) from error
+
+{% elif mm_class == '_IsoTimeField' %}
+class _IsoTimeField(fields.Time):
+    """ A marshmallow time field that shares the module's ISO time parser.
+
+    marshmallow's own time parser silently discards a UTC offset, so delegating
+    here is what keeps schema().loads from losing the offset that from_json
+    preserves.
+    """
+
+    def _serialize(self, value, attr, obj, **kwargs):
+        if value is None:
+            return None
+        if isinstance(value, datetime.time):
+            return value.isoformat()
+        return value
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        if value is None:
+            return None
+        try:
+            return _parse_iso_time(value, self.data_key or attr or 'value')
+        except ValueError as error:
+            raise ValidationError(str(error)) from error
+
+{% endif %}
+{%- endfor %}
+{% endif %}
 {% endif %}
 
 {% if dataclasses_json_annotation %}
@@ -162,6 +236,9 @@ class {{ class_name }}{% if base_class or is_abstract %}({% if base_class %}{{ b
         {%- elif dataclasses_json_annotation and field.json_decoder %}
         if '{{ field.name }}' in data:
             data['{{ field.name }}'] = ({{ field.json_decoder }})(data['{{ field.name }}'])
+        {%- elif field.container_rebuild %}
+        if '{{ field.name }}' in data:
+            data['{{ field.name }}'] = (lambda v: {{ field.container_rebuild }})(data['{{ field.name }}'])
         {%- endif %}
         {%- endfor %}
         return cls(**data)

--- a/avrotize/structuretopython/dataclass_core.jinja
+++ b/avrotize/structuretopython/dataclass_core.jinja
@@ -61,7 +61,12 @@ def _normalize_iso_string(value: str) -> str:
     truncated to exactly microsecond precision, because fromisoformat only
     accepts the 'Z' designator and arbitrary fraction lengths from Python 3.11
     onwards, and this package supports Python 3.10.
+
+    A non-string value raises ValueError so that callers report it the same way
+    they report a malformed string, rather than leaking an AttributeError.
     """
+    if not isinstance(value, str):
+        raise ValueError(f'expected an ISO 8601 string, got {type(value).__name__}')
     text = value[:-1] + '+00:00' if value.endswith(('Z', 'z')) else value
     dot = text.find('.')
     if dot != -1:
@@ -138,7 +143,9 @@ class _IsoDateTimeField(fields.DateTime):
     def _serialize(self, value, attr, obj, **kwargs):
         if value is None:
             return None
-        if isinstance(value, datetime.datetime):
+        # datetime.date is accepted as well because marshmallow's own
+        # DateTime(format='iso') serialized anything with an isoformat().
+        if isinstance(value, (datetime.datetime, datetime.date)):
             return value.isoformat()
         return value
 

--- a/avrotize/structuretopython/dataclass_core.jinja
+++ b/avrotize/structuretopython/dataclass_core.jinja
@@ -17,7 +17,7 @@ from abc import ABC
 {%- if dataclasses_json_annotation %}
 import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
-{%- for field in fields if field.type in ["datetime.datetime", "typing.Optional[datetime.datetime]", "datetime.date", "typing.Optional[datetime.date]", "datetime.time", "typing.Optional[datetime.time]"] %}
+{%- for field in fields if field.mm_field %}
 {%- if loop.first %}
 from marshmallow import fields
 {%- endif %}
@@ -52,6 +52,52 @@ import uuid
 {% if xml_annotation %}
 from {{ xml_runtime_module }} import parse_xml, serialize_xml
 {% endif %}
+{% if dataclasses_json_annotation and iso_parsers %}
+
+{% for parser in iso_parsers %}
+{%- if parser == '_parse_iso_date' %}
+def _parse_iso_date(value: typing.Any) -> typing.Any:
+    """ Parses an ISO 8601 date string. Values that are not parseable dates are returned unchanged. """
+    if not isinstance(value, str):
+        return value
+    try:
+        return datetime.date.fromisoformat(value)
+    except ValueError:
+        return value
+
+{% elif parser == '_parse_iso_datetime' %}
+def _parse_iso_datetime(value: typing.Any) -> typing.Any:
+    """ Parses an ISO 8601 / RFC 3339 datetime string. Values that are not parseable datetimes are returned unchanged.
+
+    A trailing 'Z' is normalized to '+00:00' because datetime.fromisoformat only
+    accepts the 'Z' designator from Python 3.11 onwards.
+    """
+    if not isinstance(value, str):
+        return value
+    text = value[:-1] + '+00:00' if value.endswith(('Z', 'z')) else value
+    try:
+        return datetime.datetime.fromisoformat(text)
+    except ValueError:
+        return value
+
+{% elif parser == '_parse_iso_time' %}
+def _parse_iso_time(value: typing.Any) -> typing.Any:
+    """ Parses an ISO 8601 time string. Values that are not parseable times are returned unchanged.
+
+    A trailing 'Z' is normalized to '+00:00' because time.fromisoformat only
+    accepts the 'Z' designator from Python 3.11 onwards.
+    """
+    if not isinstance(value, str):
+        return value
+    text = value[:-1] + '+00:00' if value.endswith(('Z', 'z')) else value
+    try:
+        return datetime.time.fromisoformat(text)
+    except ValueError:
+        return value
+
+{% endif %}
+{%- endfor %}
+{% endif %}
 
 {% if dataclasses_json_annotation %}
 @dataclass_json(undefined=Undefined.EXCLUDE)
@@ -78,12 +124,9 @@ class {{ class_name }}{% if base_class or is_abstract %}({% if base_class %}{{ b
     )
     {% endif %}
     {% for field in fields %}
-    {%- set isdatetime = field.type == "datetime.datetime" or field.type == "typing.Optional[datetime.datetime]" %}
-    {%- set isdate = field.type == "datetime.date" or field.type == "typing.Optional[datetime.date]" %}
-    {%- set istime = field.type == "datetime.time" or field.type == "typing.Optional[datetime.time]" %}
     {%- set is_int_as_string = field.source_type in ['int64', 'uint64', 'int128', 'uint128'] %}
     {%- set is_decimal_as_string = field.source_type == 'decimal' %}
-    {{ field.name }}: {{ field.type }}=dataclasses.field(kw_only=True{% if dataclasses_json_annotation %}, metadata=dataclasses_json.config(field_name="{{ field.original_name }}"{%- if isdatetime -%}, encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso'){%- elif isdate -%}, encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d.isoformat() if isinstance(d, datetime.date) else d if d else None, decoder=lambda d: datetime.date.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.Date(format='iso'){%- elif istime -%}, encoder=lambda d: d.isoformat() if isinstance(d, datetime.time) else d if d else None, decoder=lambda d: datetime.time.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.Time(format='iso'){%- elif is_int_as_string -%}, encoder=lambda v: str(v) if v is not None else None, decoder=lambda v: int(v) if isinstance(v, str) else v{%- elif is_decimal_as_string -%}, encoder=lambda v: str(v) if v is not None else None, decoder=lambda v: decimal.Decimal(v) if isinstance(v, str) else v{%- endif -%}){% if xml_annotation %} | {{ field.xml_metadata }}{% endif %}{%- elif xml_annotation %}, metadata={{ field.xml_metadata }}{%- endif %})
+    {{ field.name }}: {{ field.type }}=dataclasses.field(kw_only=True{% if dataclasses_json_annotation %}, metadata=dataclasses_json.config(field_name="{{ field.original_name }}"{%- if field.json_encoder -%}, encoder={{ field.json_encoder }}, decoder={{ field.json_decoder }}{% if field.mm_field %}, mm_field={{ field.mm_field }}{% endif %}{%- elif is_int_as_string -%}, encoder=lambda v: str(v) if v is not None else None, decoder=lambda v: int(v) if isinstance(v, str) else v{%- elif is_decimal_as_string -%}, encoder=lambda v: str(v) if v is not None else None, decoder=lambda v: decimal.Decimal(v) if isinstance(v, str) else v{%- endif -%}){% if xml_annotation %} | {{ field.xml_metadata }}{% endif %}{%- elif xml_annotation %}, metadata={{ field.xml_metadata }}{%- endif %})
     {%- endfor %}
 
 
@@ -98,6 +141,7 @@ class {{ class_name }}{% if base_class or is_abstract %}({% if base_class %}{{ b
         Returns:
             The dataclass representation of the dataclass.
         """
+        data = dict(data)
         {%- for field in fields %}
         {%- if field.name != field.original_name %}
         if '{{ field.original_name }}' in data:
@@ -109,15 +153,9 @@ class {{ class_name }}{% if base_class or is_abstract %}({% if base_class %}{{ b
         {%- elif field.source_type == 'decimal' %}
         if '{{ field.name }}' in data and isinstance(data['{{ field.name }}'], str):
             data['{{ field.name }}'] = decimal.Decimal(data['{{ field.name }}'])
-        {%- elif field.type in ['datetime.datetime', 'typing.Optional[datetime.datetime]'] %}
-        if '{{ field.name }}' in data and isinstance(data['{{ field.name }}'], str):
-            data['{{ field.name }}'] = datetime.datetime.fromisoformat(data['{{ field.name }}'])
-        {%- elif field.type in ['datetime.date', 'typing.Optional[datetime.date]'] %}
-        if '{{ field.name }}' in data and isinstance(data['{{ field.name }}'], str):
-            data['{{ field.name }}'] = datetime.date.fromisoformat(data['{{ field.name }}'])
-        {%- elif field.type in ['datetime.time', 'typing.Optional[datetime.time]'] %}
-        if '{{ field.name }}' in data and isinstance(data['{{ field.name }}'], str):
-            data['{{ field.name }}'] = datetime.time.fromisoformat(data['{{ field.name }}'])
+        {%- elif dataclasses_json_annotation and field.json_decoder %}
+        if '{{ field.name }}' in data:
+            data['{{ field.name }}'] = ({{ field.json_decoder }})(data['{{ field.name }}'])
         {%- endif %}
         {%- endfor %}
         return cls(**data)

--- a/avrotize/structuretopython/dataclass_core.jinja
+++ b/avrotize/structuretopython/dataclass_core.jinja
@@ -17,7 +17,7 @@ from abc import ABC
 {%- if dataclasses_json_annotation %}
 import dataclasses_json
 from dataclasses_json import Undefined, dataclass_json
-{%- for field in fields if field.type == "datetime.datetime" or field.type == "typing.Optional[datetime.datetime]" %}
+{%- for field in fields if field.type in ["datetime.datetime", "typing.Optional[datetime.datetime]", "datetime.date", "typing.Optional[datetime.date]", "datetime.time", "typing.Optional[datetime.time]"] %}
 {%- if loop.first %}
 from marshmallow import fields
 {%- endif %}
@@ -78,10 +78,12 @@ class {{ class_name }}{% if base_class or is_abstract %}({% if base_class %}{{ b
     )
     {% endif %}
     {% for field in fields %}
-    {%- set isdate = field.type == "datetime.datetime" or field.type == "typing.Optional[datetime.datetime]" %}
+    {%- set isdatetime = field.type == "datetime.datetime" or field.type == "typing.Optional[datetime.datetime]" %}
+    {%- set isdate = field.type == "datetime.date" or field.type == "typing.Optional[datetime.date]" %}
+    {%- set istime = field.type == "datetime.time" or field.type == "typing.Optional[datetime.time]" %}
     {%- set is_int_as_string = field.source_type in ['int64', 'uint64', 'int128', 'uint128'] %}
     {%- set is_decimal_as_string = field.source_type == 'decimal' %}
-    {{ field.name }}: {{ field.type }}=dataclasses.field(kw_only=True{% if dataclasses_json_annotation %}, metadata=dataclasses_json.config(field_name="{{ field.original_name }}"{%- if isdate -%}, encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso'){%- elif is_int_as_string -%}, encoder=lambda v: str(v) if v is not None else None, decoder=lambda v: int(v) if isinstance(v, str) else v{%- elif is_decimal_as_string -%}, encoder=lambda v: str(v) if v is not None else None, decoder=lambda v: decimal.Decimal(v) if isinstance(v, str) else v{%- endif -%}){% if xml_annotation %} | {{ field.xml_metadata }}{% endif %}{%- elif xml_annotation %}, metadata={{ field.xml_metadata }}{%- endif %})
+    {{ field.name }}: {{ field.type }}=dataclasses.field(kw_only=True{% if dataclasses_json_annotation %}, metadata=dataclasses_json.config(field_name="{{ field.original_name }}"{%- if isdatetime -%}, encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d if d else None, decoder=lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.DateTime(format='iso'){%- elif isdate -%}, encoder=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d.isoformat() if isinstance(d, datetime.date) else d if d else None, decoder=lambda d: datetime.date.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.Date(format='iso'){%- elif istime -%}, encoder=lambda d: d.isoformat() if isinstance(d, datetime.time) else d if d else None, decoder=lambda d: datetime.time.fromisoformat(d) if isinstance(d, str) else d if d else None, mm_field=fields.Time(format='iso'){%- elif is_int_as_string -%}, encoder=lambda v: str(v) if v is not None else None, decoder=lambda v: int(v) if isinstance(v, str) else v{%- elif is_decimal_as_string -%}, encoder=lambda v: str(v) if v is not None else None, decoder=lambda v: decimal.Decimal(v) if isinstance(v, str) else v{%- endif -%}){% if xml_annotation %} | {{ field.xml_metadata }}{% endif %}{%- elif xml_annotation %}, metadata={{ field.xml_metadata }}{%- endif %})
     {%- endfor %}
 
 
@@ -107,6 +109,15 @@ class {{ class_name }}{% if base_class or is_abstract %}({% if base_class %}{{ b
         {%- elif field.source_type == 'decimal' %}
         if '{{ field.name }}' in data and isinstance(data['{{ field.name }}'], str):
             data['{{ field.name }}'] = decimal.Decimal(data['{{ field.name }}'])
+        {%- elif field.type in ['datetime.datetime', 'typing.Optional[datetime.datetime]'] %}
+        if '{{ field.name }}' in data and isinstance(data['{{ field.name }}'], str):
+            data['{{ field.name }}'] = datetime.datetime.fromisoformat(data['{{ field.name }}'])
+        {%- elif field.type in ['datetime.date', 'typing.Optional[datetime.date]'] %}
+        if '{{ field.name }}' in data and isinstance(data['{{ field.name }}'], str):
+            data['{{ field.name }}'] = datetime.date.fromisoformat(data['{{ field.name }}'])
+        {%- elif field.type in ['datetime.time', 'typing.Optional[datetime.time]'] %}
+        if '{{ field.name }}' in data and isinstance(data['{{ field.name }}'], str):
+            data['{{ field.name }}'] = datetime.time.fromisoformat(data['{{ field.name }}'])
         {%- endif %}
         {%- endfor %}
         return cls(**data)

--- a/test/test_structuretopython.py
+++ b/test/test_structuretopython.py
@@ -1,6 +1,7 @@
 """Tests for JSON Structure to Python conversion."""
 
 import unittest
+import datetime
 import os
 import shutil
 import subprocess
@@ -1048,8 +1049,10 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
 
         Regression test for issue #405. Both a required `date` and a nullable
         `["null", "date"]` property must emit the same encoder/decoder/
-        mm_field=fields.Date triple that the a2py generator already emits, and
-        the existing `datetime` behaviour must be unchanged.
+        mm_field triple that the a2py generator already emits, and
+        the existing `datetime` behaviour must be unchanged. The mm_field is a
+        generated `fields.Date` subclass so that it can carry `data_key` and
+        delegate parsing to the module's ISO helper.
         """
         schema = {
             "type": "object",
@@ -1065,17 +1068,24 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
         _src, source = self._generate_issue_405_module(
             schema, "test_issue405_date")
 
-        assert "mm_field=fields.Date(format='iso')" in source, \
+        assert "mm_field=_IsoDateField(" in source, \
             f"date fields must declare a marshmallow Date field:\n{source}"
-        assert source.count("mm_field=fields.Date(format='iso')") == 2, \
+        assert source.count("mm_field=_IsoDateField(") == 2, \
             f"both the nullable and the required date field must be annotated:\n{source}"
+        # dataclasses_json only assigns data_key on the branch it takes when no
+        # mm_field is configured, so a supplied field has to carry it or
+        # schema() loses the JSON field name.
+        assert "mm_field=_IsoDateField(data_key='d', required=True, allow_none=True)" in source, \
+            f"a nullable date mm_field must carry data_key and allow_none:\n{source}"
+        assert "mm_field=_IsoDateField(data_key='born', required=True)" in source, \
+            f"a required date mm_field must carry data_key:\n{source}"
         assert "_parse_iso_date(v, 'd')" in source, \
             f"date fields must declare an ISO date decoder:\n{source}"
         assert "isinstance(v, datetime.date)" in source, \
             f"date encoder must handle datetime.date values:\n{source}"
 
         # No regression for the datetime sibling.
-        assert "mm_field=fields.DateTime(format='iso')" in source, \
+        assert "mm_field=_IsoDateTimeField(" in source, \
             f"datetime fields must keep their marshmallow DateTime field:\n{source}"
         assert "_parse_iso_datetime(v, 'ts')" in source, \
             f"datetime fields must keep their ISO datetime decoder:\n{source}"
@@ -1095,7 +1105,7 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
         _src, source = self._generate_issue_405_module(
             schema, "test_issue405_time")
 
-        assert source.count("mm_field=fields.Time(format='iso')") == 2, \
+        assert source.count("mm_field=_IsoTimeField(") == 2, \
             f"time fields must declare a marshmallow Time field:\n{source}"
         assert "_parse_iso_time(v, 'at')" in source, \
             f"time fields must declare an ISO time decoder:\n{source}"
@@ -1285,8 +1295,12 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
         ``datetime.fromisoformat`` only learned RFC 3339 ``Z`` and >6-digit
         fractional seconds on Python 3.11, but ``requires-python`` is
         ``">=3.10"`` and 3.10 leads the CI matrix. The generated decoders
-        normalise both so the same payload yields the same value, of the same
-        type, on every supported interpreter.
+        normalise both, so an *RFC 3339* payload -- ``Z``, lowercase ``z``,
+        numeric offsets and fractional seconds -- yields the same value, of the
+        same type, on every supported interpreter. Non-RFC-3339 ISO 8601 forms
+        that only ``fromisoformat`` on 3.11 accepts (basic format such as
+        ``20240101``, ordinal and week dates) are deliberately not normalised
+        and remain version dependent: they parse on 3.11 and raise on 3.10.
         """
         import datetime as dt
 
@@ -1610,6 +1624,179 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
         for name in sorted(renderings[0]):
             assert renderings[0][name] == renderings[1][name], \
                 f"s2py output for {name} differs between hash seeds"
+
+    # -- round 4: marshmallow schema() consistency -------------------------
+
+    _RENAMED_SCHEMA = {
+        "type": "object",
+        "name": "Names",
+        "namespace": "test.issue405",
+        "properties": {
+            "birth-date": {"type": "date"},
+            "class": {"type": "string"},
+            "seen-at": {"type": "datetime"},
+            "wake-time": {"type": "time"},
+        },
+        "required": ["birth-date", "class", "seen-at", "wake-time"],
+    }
+
+    def test_issue_405_schema_preserves_renamed_json_field_names(self):
+        """Positive fixture: attaching an mm_field must not drop ``data_key``.
+
+        ``dataclasses_json.mm.schema()`` uses a configured ``mm_field``
+        verbatim and only assigns ``data_key`` on the branch it takes when no
+        ``mm_field`` is present.  A temporal field whose JSON name differs from
+        its Python name therefore lost its wire name, so ``schema().dumps``
+        emitted a second, different wire format and ``schema().loads`` raised
+        ``KeyError``.
+        """
+        src_dir, source = self._generate_issue_405_module(
+            self._RENAMED_SCHEMA, "test_issue405_renamed")
+        module = self._import_generated(
+            src_dir, "test_issue405_renamed.test.issue405.names")
+
+        record = module.Names(
+            birth_date=datetime.date(2024, 1, 1),
+            class_="C",
+            seen_at=datetime.datetime(2024, 1, 1, 10, 0),
+            wake_time=datetime.time(7, 0))
+
+        expected_keys = ["birth-date", "class", "seen-at", "wake-time"]
+        assert sorted(json.loads(record.to_json())) == expected_keys, \
+            f"to_json must use the JSON field names:\n{source}"
+
+        dumped = module.Names.schema().dumps(record)
+        assert sorted(json.loads(dumped)) == expected_keys, \
+            f"schema().dumps must use the JSON field names, got {dumped}"
+        # One wire format, not two.
+        assert json.loads(dumped) == json.loads(record.to_json()), \
+            f"schema().dumps and to_json disagree: {dumped} vs {record.to_json()}"
+
+        # All five documented entry points must accept that payload.
+        payload = record.to_json()
+        assert module.Names.schema().loads(payload) == record
+        assert module.Names.from_json(payload) == record
+        assert module.Names.from_data(payload.encode("utf-8"),
+                                      "application/json") == record
+        assert module.Names.from_data(json.loads(payload),
+                                      "application/json") == record
+        assert module.Names.from_serializer_dict(json.loads(payload)) == record
+
+    def test_issue_405_schema_load_uses_the_generated_iso_parser(self):
+        """Positive fixture: ``schema().loads`` must share one parser.
+
+        A configured ``mm_field`` also suppresses the ``_deserialize`` override
+        dataclasses_json installs for a custom decoder, so ``schema().loads``
+        fell back to marshmallow's parser.  ``marshmallow.utils.from_iso_time``
+        does not support UTC offsets and silently discards them, and marshmallow
+        rejects a lowercase ``z`` that the other four entry points accept.
+        """
+        from marshmallow import ValidationError
+
+        src_dir, source = self._generate_issue_405_module(
+            self._TEMPORAL_TRIPLE_SCHEMA, "test_issue405_mmparser")
+        module = self._import_generated(
+            src_dir, "test_issue405_mmparser.test.issue405.strict")
+
+        offset = {"d": "2024-01-01", "t": "13:45:30+05:30",
+                  "ts": "2024-01-01T13:45:30+05:30"}
+        loaded = module.Strict.schema().loads(json.dumps(offset))
+        assert loaded.t.utcoffset() == datetime.timedelta(hours=5, minutes=30), \
+            f"schema().loads dropped the UTC offset on a time: {loaded.t!r}"
+        assert loaded == module.Strict.from_json(json.dumps(offset)), \
+            "schema().loads and from_json disagree on an offset-bearing payload"
+
+        lower_z = {"d": "2024-01-01", "t": "13:45:30z",
+                   "ts": "2024-01-01T13:45:30z"}
+        assert (module.Strict.schema().loads(json.dumps(lower_z))
+                == module.Strict.from_json(json.dumps(lower_z))), \
+            f"schema().loads must accept a lowercase z like from_json:\n{source}"
+
+        # Malformed input still has to be rejected, and marshmallow must keep
+        # owning the exception type on the path it controls.
+        with self.assertRaises(ValidationError) as caught:
+            module.Strict.schema().loads(json.dumps(
+                {"d": "20 November 1998", "t": "13:45:30",
+                 "ts": "2024-01-01T13:45:30"}))
+        assert "'d'" in str(caught.exception), \
+            f"the validation error must name the field: {caught.exception}"
+
+    def test_issue_405_set_containers_agree_across_entry_points(self):
+        """Boundary fixture: every entry point rebuilds declared containers.
+
+        ``from_json`` reconstructed a ``Set`` while ``from_serializer_dict``
+        (and therefore ``from_data``) handed back a list for non-temporal
+        element types, so ``from_data(to_byte_array(x)) != x``.
+        """
+        schema = {
+            "type": "object",
+            "name": "Sets",
+            "namespace": "test.issue405",
+            "properties": {
+                "labels": {"type": "set", "items": {"type": "string"}},
+                "days": {"type": "set", "items": {"type": "date"}},
+            },
+            "required": ["labels", "days"],
+        }
+        src_dir, source = self._generate_issue_405_module(
+            schema, "test_issue405_sets")
+        module = self._import_generated(
+            src_dir, "test_issue405_sets.test.issue405.sets")
+
+        record = module.Sets(
+            labels={"a", "b"},
+            days={datetime.date(2024, 1, 1), datetime.date(2024, 2, 2)})
+
+        payload = record.to_json()
+        for label, restored in (
+                ("from_json", module.Sets.from_json(payload)),
+                ("from_serializer_dict",
+                 module.Sets.from_serializer_dict(json.loads(payload))),
+                ("from_data",
+                 module.Sets.from_data(payload.encode("utf-8"),
+                                       "application/json")),
+        ):
+            assert isinstance(restored.labels, set), \
+                f"{label} returned {type(restored.labels).__name__} for Set[str]:\n{source}"
+            assert isinstance(restored.days, set), \
+                f"{label} returned {type(restored.days).__name__} for Set[date]"
+            assert restored == record, f"{label} did not round-trip: {restored!r}"
+
+        # The byte-array path is what a caller actually uses end to end.
+        assert module.Sets.from_data(record.to_byte_array("application/json"),
+                                     "application/json") == record, \
+            "from_data(to_byte_array(x)) must equal x"
+
+    def test_issue_405_nullable_temporal_survives_schema_round_trip(self):
+        """Invalid/boundary fixture: nullable temporal fields under schema().
+
+        The ``mm_field`` branch also skips ``allow_none``, so a null value for
+        an optional temporal field failed marshmallow validation.
+        """
+        schema = {
+            "type": "object",
+            "name": "Opt",
+            "namespace": "test.issue405",
+            "properties": {
+                "maybe-day": {"type": ["null", "date"]},
+                "label": {"type": "string"},
+            },
+            "required": ["maybe-day", "label"],
+        }
+        src_dir, source = self._generate_issue_405_module(
+            schema, "test_issue405_optional")
+        module = self._import_generated(
+            src_dir, "test_issue405_optional.test.issue405.opt")
+
+        for value in (None, datetime.date(2024, 1, 1)):
+            with self.subTest(value=value):
+                record = module.Opt(maybe_day=value, label="L")
+                dumped = module.Opt.schema().dumps(record)
+                assert json.loads(dumped) == json.loads(record.to_json()), \
+                    f"schema().dumps and to_json disagree: {dumped}"
+                assert "maybe-day" in json.loads(dumped), \
+                    f"schema().dumps lost the JSON field name:\n{source}"
+                assert module.Opt.schema().loads(dumped) == record
 
 
 if __name__ == '__main__':

--- a/test/test_structuretopython.py
+++ b/test/test_structuretopython.py
@@ -993,14 +993,14 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
     # "TypeError: Object of type date is not JSON serializable" on to_json().
     # ------------------------------------------------------------------
 
-    def _generate_issue_405_module(self, schema, package_name, dir_suffix):
+    def _generate_issue_405_module(self, schema, package_name):
         """Generates a dataclasses-json annotated module and returns (src_dir, source_text)."""
         from avrotize.structuretopython import convert_structure_schema_to_python
 
-        output_dir = os.path.join(tempfile.gettempdir(), "avrotize", dir_suffix)
-        if os.path.exists(output_dir):
-            shutil.rmtree(output_dir, ignore_errors=True)
-        os.makedirs(output_dir, exist_ok=True)
+        # A unique directory per generation keeps concurrent (pytest-xdist)
+        # workers from colliding on a shared fixed path.
+        output_dir = tempfile.mkdtemp(prefix="avrotize-issue405-")
+        self.addCleanup(shutil.rmtree, output_dir, True)
 
         convert_structure_schema_to_python(
             schema, output_dir, package_name=package_name,
@@ -1014,6 +1014,8 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
                 if f.lower() == expected:
                     class_file = os.path.join(root, f)
                     break
+            if class_file is not None:
+                break
         assert class_file is not None, f"Expected {expected} under {src_dir}"
 
         with open(class_file, "r", encoding="utf-8") as fh:
@@ -1022,6 +1024,24 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
         import ast
         ast.parse(source)
         return src_dir, source
+
+    def _import_generated(self, src_dir, module_name):
+        """Imports a generated module and unregisters it again when the test ends."""
+        import importlib
+
+        package = module_name.split(".", 1)[0]
+        sys.path.insert(0, src_dir)
+        self.addCleanup(self._forget_generated_package, src_dir, package)
+        return importlib.import_module(module_name)
+
+    @staticmethod
+    def _forget_generated_package(src_dir, package):
+        """Removes a generated package from sys.path and sys.modules."""
+        if src_dir in sys.path:
+            sys.path.remove(src_dir)
+        for name in [n for n in sys.modules
+                     if n == package or n.startswith(package + ".")]:
+            del sys.modules[name]
 
     def test_issue_405_date_field_has_dataclasses_json_metadata(self):
         """Positive fixture: date fields carry encoder/decoder/mm_field metadata.
@@ -1043,21 +1063,21 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
             "required": ["born"],
         }
         _src, source = self._generate_issue_405_module(
-            schema, "test_issue405_date", "issue-405-date-metadata")
+            schema, "test_issue405_date")
 
         assert "mm_field=fields.Date(format='iso')" in source, \
             f"date fields must declare a marshmallow Date field:\n{source}"
         assert source.count("mm_field=fields.Date(format='iso')") == 2, \
             f"both the nullable and the required date field must be annotated:\n{source}"
-        assert "datetime.date.fromisoformat(d)" in source, \
+        assert "_parse_iso_date(v)" in source, \
             f"date fields must declare an ISO date decoder:\n{source}"
-        assert "isinstance(d, datetime.date)" in source, \
+        assert "isinstance(v, datetime.date)" in source, \
             f"date encoder must handle datetime.date values:\n{source}"
 
         # No regression for the datetime sibling.
         assert "mm_field=fields.DateTime(format='iso')" in source, \
             f"datetime fields must keep their marshmallow DateTime field:\n{source}"
-        assert "datetime.datetime.fromisoformat(d)" in source, \
+        assert "_parse_iso_datetime(v)" in source, \
             f"datetime fields must keep their ISO datetime decoder:\n{source}"
 
     def test_issue_405_time_field_has_dataclasses_json_metadata(self):
@@ -1073,11 +1093,11 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
             "required": ["at"],
         }
         _src, source = self._generate_issue_405_module(
-            schema, "test_issue405_time", "issue-405-time-metadata")
+            schema, "test_issue405_time")
 
         assert source.count("mm_field=fields.Time(format='iso')") == 2, \
             f"time fields must declare a marshmallow Time field:\n{source}"
-        assert "datetime.time.fromisoformat(d)" in source, \
+        assert "_parse_iso_time(v)" in source, \
             f"time fields must declare an ISO time decoder:\n{source}"
 
     def test_issue_405_date_only_schema_imports_marshmallow_fields(self):
@@ -1087,10 +1107,7 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
         with a date (or time) field but no datetime field produced code
         referencing `fields.Date` without importing `fields`.
         """
-        for name, prop_type, suffix in (
-            ("DateOnly", "date", "issue-405-date-only-import"),
-            ("TimeOnly", "time", "issue-405-time-only-import"),
-        ):
+        for name, prop_type in (("DateOnly", "date"), ("TimeOnly", "time")):
             with self.subTest(prop_type=prop_type):
                 schema = {
                     "type": "object",
@@ -1103,25 +1120,20 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
                     "required": ["value", "label"],
                 }
                 src_dir, source = self._generate_issue_405_module(
-                    schema, "test_issue405_" + prop_type + "only", suffix)
+                    schema, "test_issue405_" + prop_type + "only")
 
                 assert "from marshmallow import fields" in source, \
                     f"marshmallow fields import missing for {prop_type}-only schema:\n{source}"
 
                 # The module must actually import (NameError guard).
-                import importlib
-                sys.path.insert(0, src_dir)
-                try:
-                    module = importlib.import_module(
-                        f"test_issue405_{prop_type}only.test.issue405.{name.lower()}")
-                    assert hasattr(module, name)
-                finally:
-                    sys.path.remove(src_dir)
+                module = self._import_generated(
+                    src_dir,
+                    f"test_issue405_{prop_type}only.test.issue405.{name.lower()}")
+                assert hasattr(module, name)
 
     def test_issue_405_date_round_trips_through_json(self):
         """Round-trip fixture: the exact failure mode reported in issue #405."""
         import datetime as dt
-        import importlib
 
         schema = {
             "type": "object",
@@ -1136,66 +1148,203 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
             "required": ["d", "t", "ts", "count"],
         }
         src_dir, _source = self._generate_issue_405_module(
-            schema, "test_issue405_roundtrip", "issue-405-roundtrip")
+            schema, "test_issue405_roundtrip")
 
-        sys.path.insert(0, src_dir)
-        try:
-            module = importlib.import_module(
-                "test_issue405_roundtrip.test.issue405.roundtrip")
-            RoundTrip = module.RoundTrip
-            record = RoundTrip(
-                d=dt.date(1998, 11, 20),
-                t=dt.time(13, 45, 30),
-                ts=dt.datetime(1998, 11, 20, 13, 45, 30, tzinfo=dt.timezone.utc),
-                count=9007199254740993,
-            )
+        module = self._import_generated(
+            src_dir, "test_issue405_roundtrip.test.issue405.roundtrip")
+        RoundTrip = module.RoundTrip
+        record = RoundTrip(
+            d=dt.date(1998, 11, 20),
+            t=dt.time(13, 45, 30),
+            ts=dt.datetime(1998, 11, 20, 13, 45, 30, tzinfo=dt.timezone.utc),
+            count=9007199254740993,
+        )
 
-            # pylint: disable=no-member
-            json_text = record.to_json()
-            assert '"1998-11-20"' in json_text, \
-                f"date must serialize as an ISO date string, got: {json_text}"
-            assert '"13:45:30"' in json_text, \
-                f"time must serialize as an ISO time string, got: {json_text}"
+        # pylint: disable=no-member
+        json_text = record.to_json()
+        assert '"1998-11-20"' in json_text, \
+            f"date must serialize as an ISO date string, got: {json_text}"
+        assert '"13:45:30"' in json_text, \
+            f"time must serialize as an ISO time string, got: {json_text}"
 
-            payload = record.to_byte_array("application/json")
-            assert isinstance(payload, bytes)
+        payload = record.to_byte_array("application/json")
+        assert isinstance(payload, bytes)
 
-            restored = RoundTrip.from_data(payload, "application/json")
-            assert restored == record, f"expected {record}, got {restored}"
-            assert isinstance(restored.d, dt.date) and not isinstance(restored.d, dt.datetime)
-            assert isinstance(restored.t, dt.time)
-            assert isinstance(restored.ts, dt.datetime)
+        restored = RoundTrip.from_data(payload, "application/json")
+        assert restored == record, f"expected {record}, got {restored}"
+        assert isinstance(restored.d, dt.date) and not isinstance(restored.d, dt.datetime)
+        assert isinstance(restored.t, dt.time)
+        assert isinstance(restored.ts, dt.datetime)
 
-            # dataclasses_json's own decoder path must round-trip too.
-            assert RoundTrip.from_json(json_text) == record
-        finally:
-            sys.path.remove(src_dir)
+        # dataclasses_json's own decoder path must round-trip too.
+        assert RoundTrip.from_json(json_text) == record
 
-    def test_issue_405_invalid_date_string_is_rejected(self):
-        """Invalid-input fixture: malformed temporal strings must not corrupt silently."""
-        import importlib
+    def test_issue_405_date_field_holding_datetime_emits_one_wire_format(self):
+        """Boundary fixture: datetime.datetime is a subclass of datetime.date.
+
+        A naive ``isinstance(v, datetime.datetime)``-first encoder in the date
+        branch emits a datetime-shaped string that the matching
+        ``datetime.date.fromisoformat`` decoder cannot parse, giving two wire
+        formats for one value. The date encoder must narrow to the date part.
+        """
+        import datetime as dt
 
         schema = {
             "type": "object",
-            "name": "StrictDate",
+            "name": "DateNarrowing",
             "namespace": "test.issue405",
             "properties": {"d": {"type": "date"}},
             "required": ["d"],
         }
         src_dir, _source = self._generate_issue_405_module(
-            schema, "test_issue405_strict", "issue-405-invalid-input")
+            schema, "test_issue405_narrow")
 
-        sys.path.insert(0, src_dir)
-        try:
-            module = importlib.import_module(
-                "test_issue405_strict.test.issue405.strictdate")
-            StrictDate = module.StrictDate
-            with self.assertRaises(ValueError):
-                StrictDate.from_data(b'{"d": "20 November 1998"}', "application/json")
-        finally:
-            sys.path.remove(src_dir)
+        module = self._import_generated(
+            src_dir, "test_issue405_narrow.test.issue405.datenarrowing")
+        DateNarrowing = module.DateNarrowing
+        record = DateNarrowing(d=dt.datetime(2024, 1, 1, 10, 0, 0))
+
+        # pylint: disable=no-member
+        json_text = record.to_json()
+        assert '"2024-01-01"' in json_text, \
+            f"a datetime in a date field must serialize as a date, got: {json_text}"
+        assert "10:00:00" not in json_text, \
+            f"date wire format must not carry a time component: {json_text}"
+
+        # Both wire producers must agree, and the value must survive the trip.
+        assert '"2024-01-01"' in DateNarrowing.schema().dumps(record)
+        assert DateNarrowing.from_json(json_text).d == dt.date(2024, 1, 1)
+        assert DateNarrowing.from_data(
+            json_text.encode("utf-8"), "application/json").d == dt.date(2024, 1, 1)
+
+    def test_issue_405_nested_temporal_collections_round_trip(self):
+        """Positive fixture: temporal types nested in arrays, maps and unions.
+
+        Issue #405 is only fixed if encoder selection follows the type
+        structure. Exact string matching on the six scalar spellings leaves
+        ``List[date]``, ``Dict[str, date]`` and ``Optional[List[date]]``
+        raising the original TypeError.
+        """
+        import datetime as dt
+
+        schema = {
+            "type": "object",
+            "name": "NestedTemporal",
+            "namespace": "test.issue405",
+            "properties": {
+                "dates": {"type": "array", "items": {"type": "date"}},
+                "by_key": {"type": "map", "values": {"type": "date"}},
+                "stamps": {"type": "set", "items": {"type": "datetime"}},
+                "maybe_times": {"type": ["null", {"type": "array",
+                                                  "items": {"type": "time"}}]},
+            },
+            "required": ["dates", "by_key", "stamps"],
+        }
+        src_dir, _source = self._generate_issue_405_module(
+            schema, "test_issue405_nested")
+
+        module = self._import_generated(
+            src_dir, "test_issue405_nested.test.issue405.nestedtemporal")
+        NestedTemporal = module.NestedTemporal
+        record = NestedTemporal(
+            dates=[dt.date(2024, 2, 2)],
+            by_key={"k": dt.date(2024, 3, 3)},
+            stamps=[dt.datetime(2024, 4, 4, 5, 6, 7)],
+            maybe_times=[dt.time(1, 2, 3)],
+        )
+
+        # pylint: disable=no-member
+        json_text = record.to_json()
+        assert '"2024-02-02"' in json_text, json_text
+        assert '"2024-03-03"' in json_text, json_text
+        assert '"01:02:03"' in json_text, json_text
+
+        for restored in (NestedTemporal.from_json(json_text),
+                         NestedTemporal.from_data(
+                             json_text.encode("utf-8"), "application/json")):
+            assert list(restored.dates) == [dt.date(2024, 2, 2)], restored
+            assert restored.by_key == {"k": dt.date(2024, 3, 3)}, restored
+            assert list(restored.stamps) == [dt.datetime(2024, 4, 4, 5, 6, 7)], restored
+            assert list(restored.maybe_times) == [dt.time(1, 2, 3)], restored
+
+    def test_issue_405_rfc3339_zulu_and_empty_strings_are_tolerated(self):
+        """Invalid-input and boundary fixture for the deserializer coercion.
+
+        ``datetime.fromisoformat`` only learned RFC 3339 ``Z`` on Python 3.11,
+        and it raises on an empty string on every version. The generated
+        decoders must normalise ``Z`` and must leave anything unparseable
+        untouched rather than raising, on every supported interpreter
+        (``requires-python = ">=3.10"``).
+        """
+        import datetime as dt
+
+        schema = {
+            "type": "object",
+            "name": "Tolerant",
+            "namespace": "test.issue405",
+            "properties": {
+                "d": {"type": "date"},
+                "t": {"type": "time"},
+                "ts": {"type": "datetime"},
+            },
+            "required": ["d", "t", "ts"],
+        }
+        src_dir, _source = self._generate_issue_405_module(
+            schema, "test_issue405_tolerant")
+
+        module = self._import_generated(
+            src_dir, "test_issue405_tolerant.test.issue405.tolerant")
+        Tolerant = module.Tolerant
+        utc = dt.timezone.utc
+
+        # RFC 3339 "Z" must parse identically on 3.10 and 3.11+.
+        zulu = b'{"d": "2024-01-01", "t": "13:45:30Z", "ts": "2024-01-01T00:00:00Z"}'
+        for restored in (Tolerant.from_data(zulu, "application/json"),
+                         Tolerant.from_json(zulu.decode("utf-8"))):
+            assert restored.ts == dt.datetime(2024, 1, 1, tzinfo=utc), restored
+            assert restored.t == dt.time(13, 45, 30, tzinfo=utc), restored
+
+        # Unparseable strings must pass through unchanged, not raise. The
+        # previous behaviour of these paths was to return the raw string, and
+        # callers relying on that must keep working.
+        for payload in (b'{"d": "", "t": "", "ts": ""}',
+                        b'{"d": "20 November 1998", "t": "x", "ts": "y"}'):
+            restored = Tolerant.from_data(payload, "application/json")
+            decoded = json.loads(payload.decode("utf-8"))
+            assert restored.d == decoded["d"], restored
+            assert restored.t == decoded["t"], restored
+            assert restored.ts == decoded["ts"], restored
+
+    def test_issue_405_from_serializer_dict_does_not_mutate_input(self):
+        """Invalid-input fixture: deserialization must not rewrite the caller's dict."""
+        schema = {
+            "type": "object",
+            "name": "NoMutate",
+            "namespace": "test.issue405",
+            "properties": {"d": {"type": "date"}},
+            "required": ["d"],
+        }
+        src_dir, _source = self._generate_issue_405_module(
+            schema, "test_issue405_nomutate")
+
+        module = self._import_generated(
+            src_dir, "test_issue405_nomutate.test.issue405.nomutate")
+        payload = {"d": "2024-01-01"}
+        module.NoMutate.from_serializer_dict(dict(payload))
+        original = {"d": "2024-01-01"}
+        module.NoMutate.from_serializer_dict(original)
+        assert original == payload, \
+            f"from_serializer_dict must not mutate its argument, got {original}"
+
     def test_issue_405_generation_is_deterministic(self):
-        """Repeated generation of the same schema must produce identical sources."""
+        """Repeated generation of the same schema must produce identical sources.
+
+        The two generations run in separate interpreters with different
+        PYTHONHASHSEED values; running them in-process would pass even against
+        an unsorted generator because the hash seed would be shared.
+        """
+        import textwrap
+
         schema = {
             "type": "object",
             "name": "Determinism",
@@ -1204,18 +1353,68 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
                 "d": {"type": "date"},
                 "t": {"type": "time"},
                 "ts": {"type": "datetime"},
+                "label": {"type": "string"},
+                "count": {"type": "int32"},
+                "flag": {"type": "boolean"},
+                "ratio": {"type": "double"},
+                "tags": {"type": "array", "items": {"type": "string"}},
+                "scores": {"type": "map", "values": {"type": "int32"}},
                 "nested": {"type": "object", "name": "NestedOne",
                            "properties": {"x": {"type": "string"}}, "required": ["x"]},
                 "other": {"type": "object", "name": "NestedTwo",
                           "properties": {"y": {"type": "string"}}, "required": ["y"]},
             },
-            "required": ["d", "t", "ts", "nested", "other"],
+            "required": ["d", "t", "ts", "label", "count", "flag", "ratio",
+                         "tags", "scores", "nested", "other"],
         }
-        first = self._generate_issue_405_module(
-            schema, "test_issue405_det", "issue-405-determinism-a")[1]
-        second = self._generate_issue_405_module(
-            schema, "test_issue405_det", "issue-405-determinism-b")[1]
-        assert first == second, "s2py output must be deterministic across runs"
+
+        work_dir = tempfile.mkdtemp(prefix="avrotize-issue405-det-")
+        self.addCleanup(shutil.rmtree, work_dir, True)
+        script = os.path.join(work_dir, "generate.py")
+        with open(script, "w", encoding="utf-8") as fh:
+            fh.write(textwrap.dedent("""
+                import json
+                import sys
+                from avrotize.structuretopython import convert_structure_schema_to_python
+
+                with open(sys.argv[1], 'r', encoding='utf-8') as handle:
+                    schema = json.load(handle)
+                convert_structure_schema_to_python(
+                    schema, sys.argv[2], package_name='det_pkg',
+                    dataclasses_json_annotation=True)
+                """))
+        schema_file = os.path.join(work_dir, "schema.json")
+        with open(schema_file, "w", encoding="utf-8") as fh:
+            json.dump(schema, fh)
+
+        repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        renderings = []
+        for seed in ("1", "2"):
+            out_dir = os.path.join(work_dir, "out" + seed)
+            env = dict(os.environ)
+            env["PYTHONHASHSEED"] = seed
+            env["PYTHONPATH"] = os.pathsep.join(
+                [repo_root] + ([env["PYTHONPATH"]] if env.get("PYTHONPATH") else []))
+            result = subprocess.run(
+                [sys.executable, script, schema_file, out_dir],
+                env=env, capture_output=True, text=True, check=False)
+            assert result.returncode == 0, \
+                f"generation failed for PYTHONHASHSEED={seed}: {result.stderr}"
+
+            rendering = {}
+            for root, dirs, files in os.walk(out_dir):
+                dirs.sort()
+                for name in sorted(files):
+                    path = os.path.join(root, name)
+                    with open(path, "r", encoding="utf-8", errors="replace") as fh:
+                        rendering[os.path.relpath(path, out_dir)] = fh.read()
+            renderings.append(rendering)
+
+        assert sorted(renderings[0]) == sorted(renderings[1]), \
+            "s2py must emit the same set of files regardless of PYTHONHASHSEED"
+        for name in sorted(renderings[0]):
+            assert renderings[0][name] == renderings[1][name], \
+                f"s2py output for {name} differs between hash seeds"
 
 
 if __name__ == '__main__':

--- a/test/test_structuretopython.py
+++ b/test/test_structuretopython.py
@@ -1419,17 +1419,30 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
                 # The other four entry points leave a non-string untouched, as
                 # they do on master: their decoders are guarded by
                 # `isinstance(v, str)` so that `from_serializer_dict` can accept
-                # the real `datetime` objects `to_serializer_dict` emits. What
-                # matters is that none of them raises AttributeError.
-                for label, call in entry_points.items():
-                    if label == "schema().loads":
-                        continue
+                # the real `datetime` objects `to_serializer_dict` emits. These
+                # calls must be built from `payload`/`value`, not reused from
+                # the malformed-string table above, or they would never feed a
+                # non-string to the decoders this block exists to pin.
+                raw = {"d": value, "t": value, "ts": value}
+                non_string_entry_points = {
+                    "from_data(bytes)": lambda: Strict.from_data(
+                        payload.encode("utf-8"), "application/json"),
+                    "from_data(dict)": lambda: Strict.from_data(
+                        dict(raw), "application/json"),
+                    "from_json": lambda: Strict.from_json(payload),
+                    "from_serializer_dict":
+                        lambda: Strict.from_serializer_dict(dict(raw)),
+                }
+                for label, call in non_string_entry_points.items():
                     try:
-                        call()
+                        record = call()
                     except AttributeError as error:  # pragma: no cover
                         self.fail(f"{label} leaked AttributeError: {error}")
-                    except Exception:  # noqa: BLE001
-                        pass
+                    for name in ("d", "t", "ts"):
+                        actual = getattr(record, name)
+                        assert actual == value, \
+                            (f"{label} must pass a non-string through "
+                             f"untouched, got {actual!r} for {name!r}")
 
     def test_issue_405_serializer_dict_round_trips_typed_temporal_values(self):
         """Boundary fixture: the decoders' ``isinstance(v, str)`` guard.

--- a/test/test_structuretopython.py
+++ b/test/test_structuretopython.py
@@ -1069,7 +1069,7 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
             f"date fields must declare a marshmallow Date field:\n{source}"
         assert source.count("mm_field=fields.Date(format='iso')") == 2, \
             f"both the nullable and the required date field must be annotated:\n{source}"
-        assert "_parse_iso_date(v)" in source, \
+        assert "_parse_iso_date(v, 'd')" in source, \
             f"date fields must declare an ISO date decoder:\n{source}"
         assert "isinstance(v, datetime.date)" in source, \
             f"date encoder must handle datetime.date values:\n{source}"
@@ -1077,7 +1077,7 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
         # No regression for the datetime sibling.
         assert "mm_field=fields.DateTime(format='iso')" in source, \
             f"datetime fields must keep their marshmallow DateTime field:\n{source}"
-        assert "_parse_iso_datetime(v)" in source, \
+        assert "_parse_iso_datetime(v, 'ts')" in source, \
             f"datetime fields must keep their ISO datetime decoder:\n{source}"
 
     def test_issue_405_time_field_has_dataclasses_json_metadata(self):
@@ -1097,7 +1097,7 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
 
         assert source.count("mm_field=fields.Time(format='iso')") == 2, \
             f"time fields must declare a marshmallow Time field:\n{source}"
-        assert "_parse_iso_time(v)" in source, \
+        assert "_parse_iso_time(v, 'at')" in source, \
             f"time fields must declare an ISO time decoder:\n{source}"
 
     def test_issue_405_date_only_schema_imports_marshmallow_fields(self):
@@ -1267,53 +1267,248 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
             assert list(restored.stamps) == [dt.datetime(2024, 4, 4, 5, 6, 7)], restored
             assert list(restored.maybe_times) == [dt.time(1, 2, 3)], restored
 
-    def test_issue_405_rfc3339_zulu_and_empty_strings_are_tolerated(self):
-        """Invalid-input and boundary fixture for the deserializer coercion.
+    _TEMPORAL_TRIPLE_SCHEMA = {
+        "type": "object",
+        "name": "Strict",
+        "namespace": "test.issue405",
+        "properties": {
+            "d": {"type": "date"},
+            "t": {"type": "time"},
+            "ts": {"type": "datetime"},
+        },
+        "required": ["d", "t", "ts"],
+    }
 
-        ``datetime.fromisoformat`` only learned RFC 3339 ``Z`` on Python 3.11,
-        and it raises on an empty string on every version. The generated
-        decoders must normalise ``Z`` and must leave anything unparseable
-        untouched rather than raising, on every supported interpreter
-        (``requires-python = ">=3.10"``).
+    def test_issue_405_rfc3339_zulu_and_fractional_seconds_normalise(self):
+        """Boundary fixture: RFC 3339 offsets and fractional seconds.
+
+        ``datetime.fromisoformat`` only learned RFC 3339 ``Z`` and >6-digit
+        fractional seconds on Python 3.11, but ``requires-python`` is
+        ``">=3.10"`` and 3.10 leads the CI matrix. The generated decoders
+        normalise both so the same payload yields the same value, of the same
+        type, on every supported interpreter.
+        """
+        import datetime as dt
+
+        src_dir, _source = self._generate_issue_405_module(
+            self._TEMPORAL_TRIPLE_SCHEMA, "test_issue405_zulu")
+
+        module = self._import_generated(
+            src_dir, "test_issue405_zulu.test.issue405.strict")
+        Strict = module.Strict
+        utc = dt.timezone.utc
+
+        # A trailing "Z" (and its lowercase form) is the most common JSON
+        # timestamp encoding; it must parse identically on 3.10 and 3.11+.
+        for suffix in ("Z", "z"):
+            payload = ('{"d": "2024-01-01", "t": "13:45:30%s",'
+                       ' "ts": "2024-01-01T00:00:00%s"}' % (suffix, suffix))
+            for restored in (Strict.from_data(payload.encode("utf-8"),
+                                              "application/json"),
+                             Strict.from_json(payload)):
+                assert restored.ts == dt.datetime(2024, 1, 1, tzinfo=utc), restored
+                assert restored.t == dt.time(13, 45, 30, tzinfo=utc), restored
+                assert restored.d == dt.date(2024, 1, 1), restored
+
+        # Nanosecond precision is the default Go/protobuf timestamp emission.
+        # It must truncate to microseconds rather than yielding a str on 3.10
+        # and a datetime on 3.11.
+        nanos = ('{"d": "2024-01-01", "t": "13:45:30.123456789Z",'
+                 ' "ts": "2024-01-01T00:00:00.123456789Z"}')
+        restored = Strict.from_json(nanos)
+        assert restored.ts == dt.datetime(2024, 1, 1, 0, 0, 0, 123456,
+                                          tzinfo=utc), restored
+        assert restored.t == dt.time(13, 45, 30, 123456, tzinfo=utc), restored
+
+        # An explicit numeric offset keeps working.
+        offset = ('{"d": "2024-01-01", "t": "13:45:30+05:30",'
+                  ' "ts": "2024-01-01T00:00:00+05:30"}')
+        restored = Strict.from_json(offset)
+        assert restored.ts.utcoffset() == dt.timedelta(hours=5, minutes=30), restored
+
+    def test_issue_405_invalid_date_string_is_rejected(self):
+        """Invalid-input fixture: a malformed date must raise, never corrupt.
+
+        Acceptance item 5 on issue #405 requires a malformed date string to be
+        rejected with ``ValueError``. Returning the raw string instead would
+        leave a field declared ``datetime.date`` holding a ``str``, so the
+        failure would surface as an ``AttributeError`` far from the
+        deserialization site and ``to_json`` would launder the bad value back
+        onto the wire.
+        """
+        src_dir, _source = self._generate_issue_405_module(
+            self._TEMPORAL_TRIPLE_SCHEMA, "test_issue405_invalid")
+
+        module = self._import_generated(
+            src_dir, "test_issue405_invalid.test.issue405.strict")
+        Strict = module.Strict
+
+        for bad in ("20 November 1998", "", "2024-13-45", "not-a-date"):
+            payload = json.dumps({"d": bad, "t": "01:02:03",
+                                  "ts": "2024-01-01T00:00:00"})
+            with self.assertRaises(ValueError) as caught:
+                Strict.from_json(payload)
+            # The message must name the offending field, otherwise the error is
+            # untraceable in a record with several temporal fields.
+            assert "'d'" in str(caught.exception), caught.exception
+
+    def test_issue_405_all_entry_points_reject_malformed_temporal_strings(self):
+        """Invalid-input fixture: every public deserializer must agree.
+
+        A generated class exposes five deserialization entry points. If some
+        tolerate a malformed value and others reject it, the same payload
+        produces an instance or an exception depending only on which entry
+        point the caller happened to use.
+        """
+        src_dir, _source = self._generate_issue_405_module(
+            self._TEMPORAL_TRIPLE_SCHEMA, "test_issue405_entrypoints")
+
+        module = self._import_generated(
+            src_dir, "test_issue405_entrypoints.test.issue405.strict")
+        Strict = module.Strict
+
+        bad = {"d": "20 November 1998", "t": "x", "ts": "y"}
+        text = json.dumps(bad)
+        entry_points = {
+            "from_data(bytes)":
+                lambda: Strict.from_data(text.encode("utf-8"), "application/json"),
+            "from_data(dict)":
+                lambda: Strict.from_data(dict(bad), "application/json"),
+            "from_json": lambda: Strict.from_json(text),
+            "from_serializer_dict": lambda: Strict.from_serializer_dict(dict(bad)),
+            # marshmallow owns this path and raises its own ValidationError.
+            "schema().loads": lambda: Strict.schema().loads(text),
+        }
+        for label, call in entry_points.items():
+            with self.subTest(entry_point=label):
+                with self.assertRaises(Exception) as caught:
+                    call()
+                assert not isinstance(caught.exception, AttributeError), \
+                    f"{label} must reject at the deserialization site"
+
+    def test_issue_405_ambiguous_temporal_union_emits_no_codec(self):
+        """Invalid-input fixture: an undecidable union must not guess.
+
+        ``["date", "datetime"]`` has no discriminated wire encoding, so a
+        codec would have to pick one arm. Picking the date arm truncates the
+        time component; picking by declaration order makes the two spellings
+        of the same logical union behave differently. Emitting no codec keeps
+        the pre-existing loud behaviour instead of losing data silently.
+        """
+        import datetime as dt
+
+        orders = {
+            "date_first": ["date", "datetime"],
+            "datetime_first": ["datetime", "date"],
+        }
+        encodings = {}
+        for label, arms in orders.items():
+            schema = {
+                "type": "object",
+                "name": "AmbiguousUnion",
+                "namespace": "test.issue405",
+                "properties": {"v": {"type": arms}},
+                "required": ["v"],
+            }
+            src_dir, source = self._generate_issue_405_module(
+                schema, "test_issue405_union_" + label)
+            assert "encoder=" not in source, \
+                f"{label}: an undecidable union must not get an encoder\n{source}"
+            assert "mm_field=" not in source, \
+                f"{label}: an undecidable union must not get an mm_field\n{source}"
+
+            module = self._import_generated(
+                src_dir,
+                f"test_issue405_union_{label}.test.issue405.ambiguousunion")
+            moment = dt.datetime(2024, 1, 1, 10, 30, 45)
+            encodings[label] = json.loads(module.AmbiguousUnion(v=moment).to_json())["v"]
+            assert encodings[label] != "2024-01-01", \
+                f"{label}: the time component must not be silently truncated"
+
+        assert encodings["date_first"] == encodings["datetime_first"], \
+            f"union arm order must not change the wire format: {encodings}"
+
+    def test_issue_405_union_of_date_and_string_does_not_coerce_the_string_arm(self):
+        """Invalid-input fixture: a str value must survive a ``[date, string]`` union.
+
+        A decoder that parses every ``str`` in such a union turns a value that
+        legitimately belongs to the string arm into a ``date``, so the record
+        no longer round-trips.
+        """
+        schema = {
+            "type": "object",
+            "name": "DateOrString",
+            "namespace": "test.issue405",
+            "properties": {"v": {"type": ["date", "string"]}},
+            "required": ["v"],
+        }
+        src_dir, source = self._generate_issue_405_module(
+            schema, "test_issue405_union_str")
+        assert "decoder=" not in source, \
+            f"a date/string union must not get a decoder\n{source}"
+
+        module = self._import_generated(
+            src_dir, "test_issue405_union_str.test.issue405.dateorstring")
+        record = module.DateOrString(v="2024-01-01")
+        restored = module.DateOrString.from_json(record.to_json())
+        assert restored.v == "2024-01-01", restored
+        assert isinstance(restored.v, str), \
+            f"the string arm must not be coerced to a date, got {type(restored.v)}"
+
+    def test_issue_405_temporal_set_decodes_to_a_set(self):
+        """Positive fixture: a temporal set must decode like any other set.
+
+        ``dataclasses_json`` reconstructs the declared container for fields
+        without a custom decoder, so a temporal set decoding to a ``list``
+        would both violate its own ``typing.Set`` annotation and behave
+        differently from a non-temporal set on the same class.
         """
         import datetime as dt
 
         schema = {
             "type": "object",
-            "name": "Tolerant",
+            "name": "SetProbe",
             "namespace": "test.issue405",
             "properties": {
-                "d": {"type": "date"},
-                "t": {"type": "time"},
-                "ts": {"type": "datetime"},
+                "labels": {"type": "set", "items": {"type": "string"}},
+                "days": {"type": "set", "items": {"type": "date"}},
             },
-            "required": ["d", "t", "ts"],
+            "required": ["labels", "days"],
         }
         src_dir, _source = self._generate_issue_405_module(
-            schema, "test_issue405_tolerant")
+            schema, "test_issue405_set")
 
         module = self._import_generated(
-            src_dir, "test_issue405_tolerant.test.issue405.tolerant")
-        Tolerant = module.Tolerant
-        utc = dt.timezone.utc
+            src_dir, "test_issue405_set.test.issue405.setprobe")
+        SetProbe = module.SetProbe
+        record = SetProbe(labels={"a", "b"},
+                          days={dt.date(2024, 1, 1), dt.date(2024, 2, 2)})
 
-        # RFC 3339 "Z" must parse identically on 3.10 and 3.11+.
-        zulu = b'{"d": "2024-01-01", "t": "13:45:30Z", "ts": "2024-01-01T00:00:00Z"}'
-        for restored in (Tolerant.from_data(zulu, "application/json"),
-                         Tolerant.from_json(zulu.decode("utf-8"))):
-            assert restored.ts == dt.datetime(2024, 1, 1, tzinfo=utc), restored
-            assert restored.t == dt.time(13, 45, 30, tzinfo=utc), restored
+        restored = SetProbe.from_json(record.to_json())
+        assert isinstance(restored.labels, set), type(restored.labels)
+        assert isinstance(restored.days, set), \
+            f"a temporal set must decode to a set, got {type(restored.days)}"
+        assert restored.days == record.days, restored.days
+        assert restored == record, "a temporal set must round-trip by equality"
 
-        # Unparseable strings must pass through unchanged, not raise. The
-        # previous behaviour of these paths was to return the raw string, and
-        # callers relying on that must keep working.
-        for payload in (b'{"d": "", "t": "", "ts": ""}',
-                        b'{"d": "20 November 1998", "t": "x", "ts": "y"}'):
-            restored = Tolerant.from_data(payload, "application/json")
-            decoded = json.loads(payload.decode("utf-8"))
-            assert restored.d == decoded["d"], restored
-            assert restored.t == decoded["t"], restored
-            assert restored.ts == decoded["ts"], restored
+    def test_issue_405_only_the_needed_iso_parsers_are_emitted(self):
+        """A module must not carry parser helpers it never calls."""
+        src_dir, source = self._generate_issue_405_module(
+            {
+                "type": "object",
+                "name": "DatetimeOnly",
+                "namespace": "test.issue405",
+                "properties": {"ts": {"type": "datetime"}},
+                "required": ["ts"],
+            },
+            "test_issue405_parsers")
+        del src_dir
+
+        assert "def _parse_iso_datetime(" in source, source
+        assert "def _parse_iso_date(" not in source, \
+            "a datetime-only module must not emit the unused date parser"
+        assert "def _parse_iso_time(" not in source, \
+            "a datetime-only module must not emit the unused time parser"
 
     def test_issue_405_from_serializer_dict_does_not_mutate_input(self):
         """Invalid-input fixture: deserialization must not rewrite the caller's dict."""

--- a/test/test_structuretopython.py
+++ b/test/test_structuretopython.py
@@ -1400,6 +1400,94 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
                 assert not isinstance(caught.exception, AttributeError), \
                     f"{label} must reject at the deserialization site"
 
+        # Non-string JSON must not leak an AttributeError out of the parser
+        # either. `_normalize_iso_string` calls str methods, so an int, bool,
+        # float, list or dict reaching it escaped as AttributeError from inside
+        # marshmallow, where master raised ValidationError and callers relying
+        # on `err.messages` for per-field aggregation crashed instead.
+        from marshmallow import ValidationError
+
+        for value in (12345, True, 1.5, [1, 2], {"a": 1}):
+            with self.subTest(non_string=value):
+                payload = json.dumps({"d": value, "t": value, "ts": value})
+                with self.assertRaises(ValidationError) as caught:
+                    Strict.schema().loads(payload)
+                messages = caught.exception.messages
+                assert set(messages) == {"d", "t", "ts"}, \
+                    f"schema().loads must aggregate per field, got {messages}"
+
+                # The other four entry points leave a non-string untouched, as
+                # they do on master: their decoders are guarded by
+                # `isinstance(v, str)` so that `from_serializer_dict` can accept
+                # the real `datetime` objects `to_serializer_dict` emits. What
+                # matters is that none of them raises AttributeError.
+                for label, call in entry_points.items():
+                    if label == "schema().loads":
+                        continue
+                    try:
+                        call()
+                    except AttributeError as error:  # pragma: no cover
+                        self.fail(f"{label} leaked AttributeError: {error}")
+                    except Exception:  # noqa: BLE001
+                        pass
+
+    def test_issue_405_serializer_dict_round_trips_typed_temporal_values(self):
+        """Boundary fixture: the decoders' ``isinstance(v, str)`` guard.
+
+        ``to_serializer_dict`` emits real ``datetime`` objects rather than ISO
+        strings, so the generated decoders must pass a non-string through
+        untouched or the documented
+        ``from_serializer_dict(to_serializer_dict(x))`` pair would stop working.
+        """
+        src_dir, _source = self._generate_issue_405_module(
+            self._TEMPORAL_TRIPLE_SCHEMA, "test_issue405_typedserdict")
+        module = self._import_generated(
+            src_dir, "test_issue405_typedserdict.test.issue405.strict")
+
+        record = module.Strict(
+            d=datetime.date(2024, 1, 1),
+            t=datetime.time(7, 0),
+            ts=datetime.datetime(2024, 1, 1, 10, 0))
+
+        serialized = record.to_serializer_dict()
+        assert isinstance(serialized["ts"], datetime.datetime), \
+            f"to_serializer_dict should keep typed values, got {serialized['ts']!r}"
+        assert module.Strict.from_serializer_dict(serialized) == record
+
+    def test_issue_405_datetime_field_holding_a_date_dumps_like_master(self):
+        """Boundary fixture: a ``date`` value in a ``datetime``-declared field.
+
+        ``marshmallow.fields.DateTime(format='iso')`` serialized anything with
+        an ``isoformat()``, so ``schema().dumps`` accepted a ``date`` in a
+        ``datetime`` field and emitted ``"2024-05-06"``. The generated
+        ``mm_field`` replaces that field, so it has to keep accepting it rather
+        than handing the raw object to ``json.dumps`` and raising ``TypeError``.
+        """
+        schema = {
+            "type": "object",
+            "name": "Dt",
+            "namespace": "test.issue405",
+            "properties": {
+                "v": {"type": "datetime"},
+                "label": {"type": "string"},
+            },
+            "required": ["v", "label"],
+        }
+        src_dir, source = self._generate_issue_405_module(
+            schema, "test_issue405_dtdump")
+        module = self._import_generated(
+            src_dir, "test_issue405_dtdump.test.issue405.dt")
+
+        record = module.Dt(v=datetime.date(2024, 5, 6), label="L")
+        dumped = module.Dt.schema().dumps(record)
+        assert json.loads(dumped)["v"] == "2024-05-06", \
+            f"schema().dumps must keep master's output for a date value: {dumped}\n{source}"
+
+        # A real datetime is still emitted with its time component.
+        exact = module.Dt(v=datetime.datetime(2024, 5, 6, 7, 8, 9), label="L")
+        assert json.loads(module.Dt.schema().dumps(exact))["v"] == "2024-05-06T07:08:09"
+        assert json.loads(exact.to_json()) == json.loads(module.Dt.schema().dumps(exact))
+
     def test_issue_405_ambiguous_temporal_union_emits_no_codec(self):
         """Invalid-input fixture: an undecidable union must not guess.
 

--- a/test/test_structuretopython.py
+++ b/test/test_structuretopython.py
@@ -987,6 +987,236 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
         assert "'6-'" in source, "Enum value for 6- must be the original string"
         assert "'6+'" in source, "Enum value for 6+ must be the original string"
 
+    # ------------------------------------------------------------------
+    # Issue #405: s2py emits temporal fields without dataclasses_json
+    # encoder/decoder/mm_field metadata, so date/time values raise
+    # "TypeError: Object of type date is not JSON serializable" on to_json().
+    # ------------------------------------------------------------------
+
+    def _generate_issue_405_module(self, schema, package_name, dir_suffix):
+        """Generates a dataclasses-json annotated module and returns (src_dir, source_text)."""
+        from avrotize.structuretopython import convert_structure_schema_to_python
+
+        output_dir = os.path.join(tempfile.gettempdir(), "avrotize", dir_suffix)
+        if os.path.exists(output_dir):
+            shutil.rmtree(output_dir, ignore_errors=True)
+        os.makedirs(output_dir, exist_ok=True)
+
+        convert_structure_schema_to_python(
+            schema, output_dir, package_name=package_name,
+            dataclasses_json_annotation=True)
+
+        src_dir = os.path.join(output_dir, "src")
+        class_file = None
+        expected = schema["name"].lower() + ".py"
+        for root, _dirs, files in os.walk(src_dir):
+            for f in sorted(files):
+                if f.lower() == expected:
+                    class_file = os.path.join(root, f)
+                    break
+        assert class_file is not None, f"Expected {expected} under {src_dir}"
+
+        with open(class_file, "r", encoding="utf-8") as fh:
+            source = fh.read()
+
+        import ast
+        ast.parse(source)
+        return src_dir, source
+
+    def test_issue_405_date_field_has_dataclasses_json_metadata(self):
+        """Positive fixture: date fields carry encoder/decoder/mm_field metadata.
+
+        Regression test for issue #405. Both a required `date` and a nullable
+        `["null", "date"]` property must emit the same encoder/decoder/
+        mm_field=fields.Date triple that the a2py generator already emits, and
+        the existing `datetime` behaviour must be unchanged.
+        """
+        schema = {
+            "type": "object",
+            "name": "DateProbe",
+            "namespace": "test.issue405",
+            "properties": {
+                "d": {"type": ["null", "date"]},
+                "born": {"type": "date"},
+                "ts": {"type": ["null", "datetime"]},
+            },
+            "required": ["born"],
+        }
+        _src, source = self._generate_issue_405_module(
+            schema, "test_issue405_date", "issue-405-date-metadata")
+
+        assert "mm_field=fields.Date(format='iso')" in source, \
+            f"date fields must declare a marshmallow Date field:\n{source}"
+        assert source.count("mm_field=fields.Date(format='iso')") == 2, \
+            f"both the nullable and the required date field must be annotated:\n{source}"
+        assert "datetime.date.fromisoformat(d)" in source, \
+            f"date fields must declare an ISO date decoder:\n{source}"
+        assert "isinstance(d, datetime.date)" in source, \
+            f"date encoder must handle datetime.date values:\n{source}"
+
+        # No regression for the datetime sibling.
+        assert "mm_field=fields.DateTime(format='iso')" in source, \
+            f"datetime fields must keep their marshmallow DateTime field:\n{source}"
+        assert "datetime.datetime.fromisoformat(d)" in source, \
+            f"datetime fields must keep their ISO datetime decoder:\n{source}"
+
+    def test_issue_405_time_field_has_dataclasses_json_metadata(self):
+        """Positive fixture: `time`, the sibling temporal type, has the same defect."""
+        schema = {
+            "type": "object",
+            "name": "TimeProbe",
+            "namespace": "test.issue405",
+            "properties": {
+                "at": {"type": "time"},
+                "maybe_at": {"type": ["null", "time"]},
+            },
+            "required": ["at"],
+        }
+        _src, source = self._generate_issue_405_module(
+            schema, "test_issue405_time", "issue-405-time-metadata")
+
+        assert source.count("mm_field=fields.Time(format='iso')") == 2, \
+            f"time fields must declare a marshmallow Time field:\n{source}"
+        assert "datetime.time.fromisoformat(d)" in source, \
+            f"time fields must declare an ISO time decoder:\n{source}"
+
+    def test_issue_405_date_only_schema_imports_marshmallow_fields(self):
+        """Boundary fixture: the marshmallow import guard must fire for date-only schemas.
+
+        Before the fix the guard only matched `datetime.datetime`, so a schema
+        with a date (or time) field but no datetime field produced code
+        referencing `fields.Date` without importing `fields`.
+        """
+        for name, prop_type, suffix in (
+            ("DateOnly", "date", "issue-405-date-only-import"),
+            ("TimeOnly", "time", "issue-405-time-only-import"),
+        ):
+            with self.subTest(prop_type=prop_type):
+                schema = {
+                    "type": "object",
+                    "name": name,
+                    "namespace": "test.issue405",
+                    "properties": {
+                        "value": {"type": prop_type},
+                        "label": {"type": "string"},
+                    },
+                    "required": ["value", "label"],
+                }
+                src_dir, source = self._generate_issue_405_module(
+                    schema, "test_issue405_" + prop_type + "only", suffix)
+
+                assert "from marshmallow import fields" in source, \
+                    f"marshmallow fields import missing for {prop_type}-only schema:\n{source}"
+
+                # The module must actually import (NameError guard).
+                import importlib
+                sys.path.insert(0, src_dir)
+                try:
+                    module = importlib.import_module(
+                        f"test_issue405_{prop_type}only.test.issue405.{name.lower()}")
+                    assert hasattr(module, name)
+                finally:
+                    sys.path.remove(src_dir)
+
+    def test_issue_405_date_round_trips_through_json(self):
+        """Round-trip fixture: the exact failure mode reported in issue #405."""
+        import datetime as dt
+        import importlib
+
+        schema = {
+            "type": "object",
+            "name": "RoundTrip",
+            "namespace": "test.issue405",
+            "properties": {
+                "d": {"type": "date"},
+                "t": {"type": "time"},
+                "ts": {"type": "datetime"},
+                "count": {"type": "int64"},
+            },
+            "required": ["d", "t", "ts", "count"],
+        }
+        src_dir, _source = self._generate_issue_405_module(
+            schema, "test_issue405_roundtrip", "issue-405-roundtrip")
+
+        sys.path.insert(0, src_dir)
+        try:
+            module = importlib.import_module(
+                "test_issue405_roundtrip.test.issue405.roundtrip")
+            RoundTrip = module.RoundTrip
+            record = RoundTrip(
+                d=dt.date(1998, 11, 20),
+                t=dt.time(13, 45, 30),
+                ts=dt.datetime(1998, 11, 20, 13, 45, 30, tzinfo=dt.timezone.utc),
+                count=9007199254740993,
+            )
+
+            # pylint: disable=no-member
+            json_text = record.to_json()
+            assert '"1998-11-20"' in json_text, \
+                f"date must serialize as an ISO date string, got: {json_text}"
+            assert '"13:45:30"' in json_text, \
+                f"time must serialize as an ISO time string, got: {json_text}"
+
+            payload = record.to_byte_array("application/json")
+            assert isinstance(payload, bytes)
+
+            restored = RoundTrip.from_data(payload, "application/json")
+            assert restored == record, f"expected {record}, got {restored}"
+            assert isinstance(restored.d, dt.date) and not isinstance(restored.d, dt.datetime)
+            assert isinstance(restored.t, dt.time)
+            assert isinstance(restored.ts, dt.datetime)
+
+            # dataclasses_json's own decoder path must round-trip too.
+            assert RoundTrip.from_json(json_text) == record
+        finally:
+            sys.path.remove(src_dir)
+
+    def test_issue_405_invalid_date_string_is_rejected(self):
+        """Invalid-input fixture: malformed temporal strings must not corrupt silently."""
+        import importlib
+
+        schema = {
+            "type": "object",
+            "name": "StrictDate",
+            "namespace": "test.issue405",
+            "properties": {"d": {"type": "date"}},
+            "required": ["d"],
+        }
+        src_dir, _source = self._generate_issue_405_module(
+            schema, "test_issue405_strict", "issue-405-invalid-input")
+
+        sys.path.insert(0, src_dir)
+        try:
+            module = importlib.import_module(
+                "test_issue405_strict.test.issue405.strictdate")
+            StrictDate = module.StrictDate
+            with self.assertRaises(ValueError):
+                StrictDate.from_data(b'{"d": "20 November 1998"}', "application/json")
+        finally:
+            sys.path.remove(src_dir)
+    def test_issue_405_generation_is_deterministic(self):
+        """Repeated generation of the same schema must produce identical sources."""
+        schema = {
+            "type": "object",
+            "name": "Determinism",
+            "namespace": "test.issue405",
+            "properties": {
+                "d": {"type": "date"},
+                "t": {"type": "time"},
+                "ts": {"type": "datetime"},
+                "nested": {"type": "object", "name": "NestedOne",
+                           "properties": {"x": {"type": "string"}}, "required": ["x"]},
+                "other": {"type": "object", "name": "NestedTwo",
+                          "properties": {"y": {"type": "string"}}, "required": ["y"]},
+            },
+            "required": ["d", "t", "ts", "nested", "other"],
+        }
+        first = self._generate_issue_405_module(
+            schema, "test_issue405_det", "issue-405-determinism-a")[1]
+        second = self._generate_issue_405_module(
+            schema, "test_issue405_det", "issue-405-determinism-b")[1]
+        assert first == second, "s2py output must be deterministic across runs"
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #405.

`s2py` generated Python dataclasses whose `date`-typed fields carried no
dataclasses-json field metadata, so `to_json()` raised
`TypeError: Object of type date is not JSON serializable` and `date` values did
not round-trip through `to_json` / `from_json`.

## Command / function surface touched

No public API, signature or entry-point change.

- Command: `s2py` (registered in `avrotize/commands.json`)
- Entry point: `avrotize.structuretopython.convert_structure_to_python`
- Also exercised: `avrotize.structuretopython.convert_structure_schema_to_python`

Files changed: `avrotize/structuretopython.py`,
`avrotize/structuretopython/dataclass_core.jinja`,
`test/test_structuretopython.py`.

## What changed

**Temporal field metadata.** The generator's `isdate` guard matched only the
literal spelling `datetime.datetime`, so it was mis-named and no `date` or
`time` field ever received metadata. Encoder/decoder selection is now driven by
a recursive walk of the field's type, so `date`, `time` and `datetime` are
covered as scalars and when nested in `List`, `Dict`, `Set`, `FrozenSet`,
`Optional` and unambiguous unions. Each such field gets `encoder=` and
`decoder=`; scalar and `List[T]`/`Dict[str, T]` temporals additionally get
`mm_field=` (marshmallow has no set-aware field, so `Set`/`FrozenSet` temporals
and anything nested more deeply carry encoder and decoder only). The marshmallow
`fields` import guard is the exact union of the three metadata conditions.

**Date narrowing.** `datetime.datetime` is a subclass of `datetime.date`, so a
naive `isinstance` chain would emit a datetime-shaped string into a `date` field
that its own decoder could not read. The encoder narrows with
`v.date().isoformat()`, giving one wire format across `to_json`,
`to_byte_array` and `schema().dumps`.

**`schema()` keeps the JSON field names, and shares one parser.**
`dataclasses_json.mm.schema()` uses a configured `mm_field` *verbatim* and only
assigns `data_key`, `required`, `allow_none` and the custom-decoder
`_deserialize` override on the branch it takes when no `mm_field` is present.
Attaching an `mm_field` to a temporal field therefore silently forfeited all of
them. Two consequences, both fixed here:

* Any field whose JSON name differs from its Python name — kebab-case such as
  `birth-date`, or a Python keyword such as `class` — lost its wire name, so
  `schema().dumps` emitted a second, different wire format and `schema().loads`
  raised `KeyError`. The generated `mm_field` now carries
  `data_key=<original JSON name>`, taken from the same `field.original_name`
  value already threaded into `config(field_name=...)` so it cannot drift from
  the non-temporal fields in the same class, plus `required=True` and
  `allow_none=True` for nullable fields.
* `schema().loads` fell back to marshmallow's own parser.
  `marshmallow.utils.from_iso_time` does not support UTC offsets and silently
  discards them, so `"13:45:30+05:30"` lost its offset on that one path, and a
  lowercase `z` was rejected there while the other four accepted it. Each
  temporal type now emits a small `fields.Date`/`DateTime`/`Time` subclass whose
  `_deserialize` delegates to the module's `_parse_iso_*` helper and re-raises
  its `ValueError` as marshmallow's `ValidationError`, preserving the field-name
  message. All five entry points now share exactly one parser.

`data_key` is extended to the `datetime` `mm_field` as well. That defect is
pre-existing on master rather than caused here, but it is the same token in the
same expression, and leaving `datetime` broken while `date`/`time` worked would
manufacture a fresh inconsistency inside the surface this PR owns. Noted as a
bonus correction.

`dump_default`/`load_default` is deliberately **not** emitted. dataclasses-json
sets it via `options.setdefault(missing_key, None)` only for fields it treats as
optional; the generated dataclasses are `kw_only` with no defaults, so the
attribute is always present on dump and `required=True` is the faithful
translation on load. Emitting a load default would make a missing key silently
produce `None` where master raised.

**Malformed input is rejected.** The generated modules emit
`_parse_iso_date` / `_parse_iso_time` / `_parse_iso_datetime` helpers that raise
`ValueError` naming the offending field. All five deserialization entry points
now agree that a malformed temporal string is an error. Measured against master
with the value `"20 November 1998"`:

| entry point | master, `date` field | master, `datetime` field | this PR, both |
| --- | --- | --- | --- |
| `from_json` | accepted, field held `str` | `ValueError` | `ValueError` |
| `from_data(bytes, "application/json")` | accepted, field held `str` | accepted, field held `str` | `ValueError` |
| `from_data(dict, "application/json")` | accepted, field held `str` | accepted, field held `str` | `ValueError` |
| `from_serializer_dict` | accepted, field held `str` | accepted, field held `str` | `ValueError` |
| `schema().loads` | accepted, field held `str` | `ValidationError` | `ValidationError` |

`schema().loads` raises marshmallow's own `ValidationError` rather than
`ValueError` because marshmallow owns that path; all five reject.

**RFC 3339 normalisation.** `datetime.fromisoformat` only learned the `Z`
designator and >6-digit fractional seconds in Python 3.11, but
`requires-python` is `">=3.10"` and 3.10 leads the CI matrix. The helpers
normalise a trailing `Z`/`z` to `+00:00` and truncate fractional seconds to
microseconds, so an **RFC 3339** payload — `Z`, lowercase `z`, numeric offsets
and fractional seconds of any length, e.g. `"2024-01-01T00:00:00.123456789Z"` —
yields the same value, of the same type, on 3.10 and 3.11. Master parsed none of
these on 3.10. This claim is scoped to RFC 3339: wider ISO 8601 forms that only
3.11's `fromisoformat` accepts (basic format `20240101`, week dates
`2024-W01-1`, `134530`) are not normalised and remain version dependent — they
parse on 3.11 and now raise on 3.10, which is a hard accept/reject split rather
than the silent type divergence that existed before the helpers raised.

**Undecidable unions emit no codec.** A union carrying more than one distinct
temporal scalar, or a temporal scalar mixed with a non-temporal arm, has no
discriminated wire encoding. Rather than guess, the generator emits no codec, so
`["date", "datetime"]` and `["datetime", "date"]` behave identically and a value
in the `string` arm of `["date", "string"]` is not coerced to a `date`. This
output is byte-identical to master for those schemas.

**Sets stay sets, on every entry point.** A declared `Set`/`FrozenSet` is
rebuilt as its declared container by both the temporal decoder and
`from_serializer_dict`, so a temporal set and a non-temporal set on the same
class no longer reconstruct as different container types, and
`from_data(to_byte_array(x)) == x` holds. Master was asymmetric rather than
uniformly wrong: `from_data(bytes)`, `from_data(dict)` and `from_serializer_dict`
returned a `list`, while `from_json` and `schema().loads` already returned a
`set` — though on all five the elements stayed `str` rather than becoming
`date`. So the same payload produced a different container type depending only
on which entry point the caller used. (Master's `schema().dumps` on a `Set[date]`
did not return a list either; with real `date` objects in the set all three of
master's dump paths raised the original #405 `TypeError`. `to_json` and
`to_byte_array` are now fixed; `schema().dumps` still raises — see
Compatibility.) For a purely non-temporal schema the generated
output still differs from master only in randomised test values and the
`data = dict(data)` copy.

**Non-string JSON in a temporal field.** `_normalize_iso_string` uses string
methods, so an `int`, `bool`, `float`, `list` or `dict` arriving in a temporal
field escaped as an `AttributeError` from inside marshmallow once the generated
`mm_field` was on the load path. It now raises the same field-naming
`ValueError` used for a malformed string, which the field subclass converts to
`ValidationError`. For a `datetime`-declared field `schema().loads` is back to
master's behaviour — a `ValidationError` whose `.messages` is keyed per field, so
callers doing `except ValidationError as err: err.messages` keep working:
`{'v': ["Invalid ISO 8601 datetime for field 'v': 12345"]}`. For `date`- and
`time`-declared fields master bound no `mm_field` at all and `schema().loads`
*returned an instance* with the raw `int` in the field, so there is no prior
behaviour to return to there; that path now raises, which is recorded as
intentional breakage in Compatibility.

The other four entry points leave a non-string value untouched, exactly as on
master. Their decoders are guarded by `isinstance(v, str)`, and that guard is
load-bearing: `to_serializer_dict()` emits real `datetime` objects rather than
ISO strings, so `from_serializer_dict(to_serializer_dict(x))` would stop working
without it. The four non-schema paths therefore match master for non-string
input on all three declared types; `schema().loads` matches master for
`datetime`-declared fields and intentionally diverges for `date`/`time`, where
master returned an instance with the raw `int` still in the field — see the
table in Compatibility.

**Deterministic output.** `import_types` is sorted at all three
`process_template` call sites, and `generate_test_value` seeds a `random.Random`
from a stable hash instead of using the global RNG. Output is byte-identical
across `PYTHONHASHSEED=1` and `2` in separate processes; master's is not.

## Explicitly out of scope

`duration` / `datetime.timedelta` is **not** given a codec. Its JSON wire form
is an owner decision tracked in #465, and guessing one here would be harder to
undo than the current loud failure. Behaviour is unchanged from master: a
generated `timedelta` schema produces the same 2 failed / 2 passed generated
tests before and after this PR, so this is pre-existing, not a regression.

The identical date-narrowing defect exists in the `a2py` sibling template
(`avrotize/avrotopython/dataclass_core.jinja`) and is deliberately left
untouched here so this PR stays scoped to #405; it is reported separately.

## Acceptance items satisfied

1. `date` fields carry `encoder` / `decoder` / `mm_field` metadata — `test_issue_405_date_field_has_dataclasses_json_metadata`
2. The sibling `time` type is covered — `test_issue_405_time_field_has_dataclasses_json_metadata`
3. Generated code is importable and the marshmallow import is present whenever referenced — `test_issue_405_date_only_schema_imports_marshmallow_fields`
4. `date` round-trips through `to_json` / `from_json` / `from_data` — `test_issue_405_date_round_trips_through_json`, `test_issue_405_nested_temporal_collections_round_trip`
5. A malformed date string is rejected with `ValueError` and does not corrupt data — `test_issue_405_invalid_date_string_is_rejected`, `test_issue_405_all_entry_points_reject_malformed_temporal_strings`
6. Output is deterministic — `test_issue_405_generation_is_deterministic` (two subprocesses, `PYTHONHASHSEED=1` vs `2`, byte-identical)

Boundary fixtures: `test_issue_405_rfc3339_zulu_and_fractional_seconds_normalise`,
`test_issue_405_date_field_holding_datetime_emits_one_wire_format`,
`test_issue_405_temporal_set_decodes_to_a_set`,
`test_issue_405_set_containers_agree_across_entry_points`,
`test_issue_405_only_the_needed_iso_parsers_are_emitted`.
Invalid-input fixtures: `test_issue_405_ambiguous_temporal_union_emits_no_codec`,
`test_issue_405_union_of_date_and_string_does_not_coerce_the_string_arm`,
`test_issue_405_from_serializer_dict_does_not_mutate_input`,
`test_issue_405_nullable_temporal_survives_schema_round_trip`.
`schema()` consistency fixtures:
`test_issue_405_schema_preserves_renamed_json_field_names` (kebab-case and a
Python keyword across all five entry points, `to_json` == `schema().dumps`),
`test_issue_405_schema_load_uses_the_generated_iso_parser` (offset preservation,
lowercase `z`, and `ValidationError` naming the field),
`test_issue_405_datetime_field_holding_a_date_dumps_like_master`,
`test_issue_405_serializer_dict_round_trips_typed_temporal_values`.

## Tests

```
$ python -m pytest test/test_structuretopython.py -q
48 passed, 14 subtests passed in 8.66s

$ python -m pytest test/test_avrotopython.py test/test_python_xml_adversarial.py -q
58 passed in 136.82s (0:02:16)
```

Generated code was additionally executed on a real Python 3.10.10 interpreter as
well as 3.11.3, since `fromisoformat` behaviour differs between them and 3.10 is
the declared minimum and the first CI matrix entry. Malformed-input rejection,
`Z` normalisation, fractional-second truncation, set round-tripping, offset
preservation through `schema().loads` and `to_json` == `schema().dumps` for
kebab-case and keyword field names were verified identical on both.

## Compatibility

No public API, signature, entry-point or CLI surface change.

The `datetime` wire format is byte-identical to master for naive, timezone-aware
and microsecond values, across `to_json`, `to_byte_array` and `schema().dumps`.
Schemas that produce undecidable temporal unions generate byte-identical output
to master.

There is one deliberate behaviour change on previously working paths. On master
a malformed temporal string was accepted and left as a `str` in a field declared
`datetime.date` by **all five** entry points for a `date` field, and by
`from_data(bytes)`, `from_data(dict)` and `from_serializer_dict` for a `datetime`
field. All five now reject — four with `ValueError`, `schema().loads` with
`ValidationError`. This is required by acceptance item 5: the previous behaviour
deferred the failure to an `AttributeError` in unrelated user code and allowed
`to_json` to launder the bad value back onto the wire.

A second, closely related path also changes. For a field declared `date` or
`time`, master bound no `mm_field`, so a *non-string* JSON scalar was accepted by
`schema().loads` and left in the field as-is — `{"v": 12345}` produced an
instance with `v == 12345` typed `int`. This PR raises `ValidationError` there,
with `.messages` keyed per field. Measured against master:

| declared type | master `schema().loads({"v": 12345})` | this PR |
| --- | --- | --- |
| `date` | instance, `v = 12345` (`int`) | `ValidationError` |
| `time` | instance, `v = 12345` (`int`) | `ValidationError` |
| `datetime` | `ValidationError` | `ValidationError` |

Only the `datetime` row is a return to master's behaviour; the `date` and `time`
rows are a deliberate break of the same class as the malformed-string rejection
above, and for the same reason — a field declared `date` should not silently
retain an `int`. The other four entry points are unchanged from master here and
still pass a non-string through untouched, because their decoders are guarded by
`isinstance(v, str)`; that guard is load-bearing, since `to_serializer_dict`
emits real `datetime`/`date`/`time` objects and
`from_serializer_dict(to_serializer_dict(x)) == x` depends on it.

Two `schema()` behaviours also change relative to master **for temporal fields**,
both correcting divergence rather than introducing it: `schema().dumps` now emits
the same wire format as `to_json` for temporal fields whose JSON name differs
from their Python name (master emitted the Python name for `datetime`, and
`schema().loads` raised `KeyError` on its own output), and `schema().loads` now
preserves UTC offsets on `time` values instead of silently discarding them.

That claim is scoped to temporal fields deliberately. `schema()` is *not* made
consistent with the other entry points in general: an `Optional[str]` in the same
class still rejects `null` on `schema().loads`, because dataclasses-json's
`_is_optional` does not see through the string annotations produced by
`from __future__ import annotations`. That is pre-existing, unchanged here, and
out of scope for #405.

One further previously-succeeding dump path changes its output. A
`datetime.datetime` stored in a field *declared* `date` was serialized by master
as a POSIX float and read back as a `float`:

| | master | this PR |
| --- | --- | --- |
| `to_json` | `{"v": 1704149999.0}` | `{"v": "2024-01-01"}` |
| `to_byte_array` | `{"v": 1704149999.0}` | `{"v": "2024-01-01"}` |
| `schema().dumps` | `{"v": 1704149999.0}` | `{"v": "2024-01-01"}` |
| read back as | `float` | `datetime.date` |

This is the date-narrowing behaviour working as intended — the field is declared
`date`, so a date-shaped string is the correct wire form and it now round-trips
to a `date`. It is recorded here because it is an output change on a path that
previously succeeded.

The mirror-image case is unchanged from master: a `datetime.date` stored in a
field declared `datetime` still dumps as `"2024-05-06"` through `schema().dumps`
and still raises `TypeError` through `to_json`/`to_byte_array`, exactly as before.

Not addressed here, unchanged from master and not regressed:
`schema().dumps` on a `Set[date]` still raises the original #405 `TypeError`
(marshmallow has no set-aware field for it), and an undecidable temporal union
holding a `datetime` still serialises via the dataclasses-json POSIX-float
fallback, byte-identically to master.
