### PR TITLE
fix(a2py): decode temporal JSON in from_data

### DIFF
--- a/avrotize/avrotopython/dataclass_core.jinja
+++ b/avrotize/avrotopython/dataclass_core.jinja
@@ -94,9 +94,20 @@ class {{ class_name }}:
         Returns:
             The dataclass representation of the dictionary.
         """
+        data = dict(data)
         {%- for field in fields %}
         {%- if field.name != field.original_name %}
-        data['{{ field.name }}'] = data.pop('{{ field.original_name }}')
+        if '{{ field.original_name }}' in data:
+            data['{{ field.name }}'] = data.pop('{{ field.original_name }}')
+        {%- endif %}
+        {%- set isdatetime = field.type == "datetime.datetime" or field.type == "datetime" or field.type == "typing.Optional[datetime.datetime]" %}
+        {%- set isdate = field.type == "datetime.date" or field.type == "typing.Optional[datetime.date]" %}
+        {%- if dataclasses_json_annotation and isdatetime %}
+        if '{{ field.name }}' in data:
+            data['{{ field.name }}'] = (lambda d: datetime.datetime.fromisoformat(d) if isinstance(d, str) else d if d else None)(data['{{ field.name }}'])
+        {%- elif dataclasses_json_annotation and isdate %}
+        if '{{ field.name }}' in data:
+            data['{{ field.name }}'] = (lambda d: datetime.date.fromisoformat(d) if isinstance(d, str) else d if d else None)(data['{{ field.name }}'])
         {%- endif %}
         {%- endfor %}
         return cls(**data)

--- a/test/test_avrotopython.py
+++ b/test/test_avrotopython.py
@@ -110,6 +110,147 @@ class TestAvroToPython(unittest.TestCase):
         finally:
             sys.path.remove(generated_src)
 
+    def test_issue_399_json_dictionary_entry_points_use_temporal_decoders(self):
+        """JSON dictionaries must use the generated date/datetime decoders."""
+        import datetime
+        import json
+
+        schema = {
+            "type": "record",
+            "name": "TemporalPayload",
+            "namespace": "example.issue399",
+            "fields": [
+                {
+                    "name": "required_at",
+                    "type": {"type": "long", "logicalType": "timestamp-millis"},
+                },
+                {
+                    "name": "optional_at",
+                    "type": [
+                        "null",
+                        {"type": "long", "logicalType": "timestamp-micros"},
+                    ],
+                },
+                {
+                    "name": "event_date",
+                    "type": {"type": "int", "logicalType": "date"},
+                },
+            ],
+        }
+        py_path = tempfile.mkdtemp(prefix="avrotize-issue399-")
+        self.addCleanup(shutil.rmtree, py_path, True)
+
+        from avrotize.avrotopython import convert_avro_schema_to_python
+        convert_avro_schema_to_python(
+            schema, py_path, package_name="issue_399_temporal",
+            dataclasses_json_annotation=True)
+
+        generated_src = os.path.join(py_path, "src")
+        sys.path.insert(0, generated_src)
+        self.addCleanup(sys.path.remove, generated_src)
+        module = importlib.import_module(
+            "issue_399_temporal.example.issue399.temporalpayload")
+        self.addCleanup(
+            lambda: [
+                sys.modules.pop(name, None)
+                for name in list(sys.modules)
+                if name == "issue_399_temporal"
+                or name.startswith("issue_399_temporal.")
+            ])
+        TemporalPayload = module.TemporalPayload
+
+        expected = TemporalPayload(
+            required_at=datetime.datetime(
+                2026, 7, 14, 17, 30, 34, tzinfo=datetime.timezone.utc),
+            optional_at=datetime.datetime(2026, 7, 14, 17, 31),
+            event_date=datetime.date(2026, 7, 14),
+        )
+        encoded = expected.to_byte_array("application/json")
+        decoded = json.loads(encoded)
+
+        entry_points = {
+            "from_data(bytes)": lambda data: TemporalPayload.from_data(
+                json.dumps(data).encode("utf-8"), "application/json"),
+            "from_data(dict)": lambda data: TemporalPayload.from_data(
+                data, "application/json"),
+            "from_serializer_dict": TemporalPayload.from_serializer_dict,
+        }
+        for label, load in entry_points.items():
+            with self.subTest(entry_point=label):
+                payload = dict(decoded)
+                restored = load(payload)
+                assert restored == expected
+                assert isinstance(restored.required_at, datetime.datetime)
+                assert isinstance(restored.optional_at, datetime.datetime)
+                assert isinstance(restored.event_date, datetime.date)
+                assert payload == decoded, \
+                    f"{label} must not mutate the caller's dictionary"
+
+        nullable = dict(decoded, optional_at=None)
+        for label, load in entry_points.items():
+            with self.subTest(entry_point=label, optional_at=None):
+                assert load(dict(nullable)).optional_at is None
+
+        malformed = dict(decoded, required_at="not-a-datetime")
+        for label, load in entry_points.items():
+            with self.subTest(entry_point=label, malformed=True):
+                with self.assertRaises(ValueError):
+                    load(dict(malformed))
+
+    def test_issue_399_json_dictionary_entry_points_preserve_field_names(self):
+        """Configured JSON names must survive decoder dispatch."""
+        import datetime
+        import json
+
+        schema = {
+            "type": "record",
+            "name": "RenamedTemporal",
+            "namespace": "example.issue399",
+            "fields": [
+                {
+                    "name": "class",
+                    "type": {"type": "long", "logicalType": "timestamp-millis"},
+                },
+                {"name": "label", "type": "string"},
+            ],
+        }
+        py_path = tempfile.mkdtemp(prefix="avrotize-issue399-name-")
+        self.addCleanup(shutil.rmtree, py_path, True)
+
+        from avrotize.avrotopython import convert_avro_schema_to_python
+        convert_avro_schema_to_python(
+            schema, py_path, package_name="issue_399_names",
+            dataclasses_json_annotation=True)
+
+        generated_src = os.path.join(py_path, "src")
+        sys.path.insert(0, generated_src)
+        self.addCleanup(sys.path.remove, generated_src)
+        module = importlib.import_module(
+            "issue_399_names.example.issue399.renamedtemporal")
+        self.addCleanup(
+            lambda: [
+                sys.modules.pop(name, None)
+                for name in list(sys.modules)
+                if name == "issue_399_names"
+                or name.startswith("issue_399_names.")
+            ])
+        RenamedTemporal = module.RenamedTemporal
+
+        value = datetime.datetime(
+            2026, 7, 14, 17, 30, 34,
+            tzinfo=datetime.timezone(datetime.timedelta(hours=8)))
+        payload = {"class": value.isoformat(), "label": "station"}
+        encoded = json.dumps(payload).encode("utf-8")
+
+        from_bytes = RenamedTemporal.from_data(encoded, "application/json")
+        from_dict = RenamedTemporal.from_data(dict(payload), "application/json")
+        from_serializer = RenamedTemporal.from_serializer_dict(dict(payload))
+
+        for restored in (from_bytes, from_dict, from_serializer):
+            assert restored.class_ == value
+            assert restored.label == "station"
+            assert json.loads(restored.to_byte_array("application/json")) == payload
+
     def test_issue_402_to_byte_array_application_json_returns_bytes(self):
         """ Issue #402: to_byte_array('application/json') must return bytes, not str.
 


### PR DESCRIPTION
Fixes #399.

## Scope

- Command: `a2py` with `--dataclasses-json`
- Python entry points: `avrotize.avrotopython.convert_avro_to_python` and `convert_avro_schema_to_python`
- Generated methods: `from_data(..., "application/json")` and `from_serializer_dict(...)`
- Exact head: `5cca9bd81d3ce4bc447721d8ca3046a49b449c4e`
- Exact base: `87383ab04087faf87715de3b945a9de3ba501bba`

`from_serializer_dict` previously renamed fields and called `cls(**data)`, bypassing the existing dataclasses-json date/datetime decoder expressions. JSON strings therefore remained raw `str` values, malformed temporal strings were accepted, and `from_data(bytes, ...)` raised `KeyError` for Python-keyword field names because it renamed the same key twice.

The generated method now copies its input, conditionally normalizes configured JSON field names, and applies the same existing date/datetime decoder expressions before construction. This keeps the change local instead of routing every field through a broader deserializer with different unknown-field or nested-type behavior.

## Why the diff is a2py-only

Issue #399's qualification named both `a2py` and `s2py` because both templates originally bypassed temporal decoders. Merged PR #464 changed `s2py` before this implementation: its `from_serializer_dict` now applies the generated `field.json_decoder`, and its JSON `from_data` paths delegate there. The merged #464 suite covers required and nullable date/datetime values, byte and dictionary `from_data`, `from_serializer_dict`, malformed temporal strings, typed values, and renamed JSON fields. Repeating that implementation here would duplicate merged behavior and conflict with the instruction to preserve #464 semantics, so this PR closes only the remaining `a2py` gap. The full adjacent `s2py` suite passes on this exact head.

## Measured behavior

| Path | `master` | This head |
| --- | --- | --- |
| `from_data(bytes, "application/json")` | required/optional datetime and date remain `str` | native `datetime.datetime` / `datetime.date` |
| `from_data(dict, "application/json")` | temporal values remain `str`; caller dict is renamed in place for aliased fields | native temporal values; caller dict unchanged |
| `from_serializer_dict(dict)` | temporal values remain `str`; caller dict is renamed in place | native temporal values; caller dict unchanged |
| malformed datetime | accepted as `str` on all three paths | `ValueError`, matching the existing generated decoder |
| JSON field `class` mapped to Python `class_` | bytes path raises `KeyError` | all three paths decode and re-emit `class` |
| nullable datetime with `null` | `None` | `None` (unchanged) |

The two new regression tests fail on `master` with six temporal type/assertion failures plus the renamed-field `KeyError`; they pass at this head with 9 subtests.

## Tests

```text
python -m pytest test\test_avrotopython.py::TestAvroToPython::test_issue_399_json_dictionary_entry_points_use_temporal_decoders test\test_avrotopython.py::TestAvroToPython::test_issue_399_json_dictionary_entry_points_preserve_field_names -q
2 passed, 9 subtests passed

python -m pytest test\test_avrotopython.py test\test_structuretopython.py -q
68 passed, 23 subtests passed
```

## Compatibility

Defect/patch intent: no CLI, Python API, generated signature, JSON wire-format, dependency, or runtime-floor change. Already-typed values and `None` continue to pass through unchanged. Valid ISO strings now rehydrate to the declared native types, and malformed strings now fail at deserialization as the generated decoder already specifies.

PR #464's `s2py` date/time parsing, renamed-field, and invalid-input behavior is unchanged and covered by the adjacent `test_structuretopython.py` suite. This PR deliberately does not add codecs or change wire formats owned by #465, and does not address the separate `a2py` date-narrowing/time/nested-metadata scope in #466.