### PR TITLE
fix(s2py): add JSON codecs for duration UUID and binary

### DIFF
--- a/avrotize/structuretopython.py
+++ b/avrotize/structuretopython.py
@@ -27,6 +27,8 @@ JSON_CODEC_SCALARS = (
     'uuid.UUID',
     'bytes',
 )
+STRICT_JSON_CODEC_SCALARS = frozenset(
+    ('datetime.timedelta', 'uuid.UUID', 'bytes'))
 
 # Marshmallow field expression per custom JSON scalar. List, set and string-keyed
 # map fields compose these scalar fields so schema() uses the same wire codec.
@@ -276,9 +278,32 @@ def build_codec_expression(type_name: str, var: str, depth: int, encode: bool,
     """ Builds a custom JSON encode/decode expression over ``var``, or ``var`` itself when nothing applies. """
     branches = _codec_branches(type_name, var, depth, encode, parsers)
     expression = var
+    if not encode and (
+            json_codec_scalars_in(type_name) & STRICT_JSON_CODEC_SCALARS):
+        expected_container = decoded_container_kind(type_name)
+        if expected_container:
+            expression = (
+                f"{var} if {var} is None else "
+                f"_invalid_container({var}, {{field_name}}, '{expected_container}')"
+            )
     for _priority, condition, value in reversed(branches):
         expression = f'{value} if {condition} else {expression}'
     return expression
+
+
+def decoded_container_kind(type_name: str) -> Optional[str]:
+    """ Returns the JSON container kind required by a decoded custom-scalar field. """
+    generic = parse_generic_type(type_name)
+    if not generic:
+        return None
+    origin, args = generic
+    if origin == 'Optional':
+        return decoded_container_kind(args[0])
+    if origin in ('List', 'Set', 'FrozenSet'):
+        return 'array'
+    if origin == 'Dict':
+        return 'object'
+    return None
 
 
 def build_mm_field(type_name: str, mm_classes: Set[str],
@@ -814,7 +839,7 @@ class StructureToPython:
                 # A set arrives from JSON as a list. Temporal sets are rebuilt by
                 # their own decoder; every other set needs an explicit rebuild so
                 # from_serializer_dict agrees with the dataclasses-json path.
-                'container_rebuild': (None if codec
+                'container_rebuild': (None if self.dataclasses_json_annotation and codec
                                       else build_container_rebuild(field['type'])),
                 'xml_name': field['xml_name'],
                 'xml_kind': field['xml_kind'],
@@ -852,6 +877,10 @@ class StructureToPython:
             fields=field_docstrings,
             json_parsers=json_parsers,
             uses_iso_parser=any(parser.startswith('_parse_iso_') for parser in json_parsers),
+            uses_container_validator=any(
+                field['json_decoder']
+                and '_invalid_container' in field['json_decoder']
+                for field in field_docstrings),
             needs_base64='_parse_base64' in json_parsers,
             needs_decimal=('decimal.Decimal' in import_types
                            or (self.dataclasses_json_annotation

--- a/avrotize/structuretopython.py
+++ b/avrotize/structuretopython.py
@@ -206,22 +206,22 @@ def _codec_branches(type_name: str, var: str, depth: int, encode: bool,
     if type_name == 'datetime.timedelta':
         if encode:
             return [(_PRIORITY_DURATION, f'isinstance({var}, datetime.timedelta)',
-                     f'str({var}.total_seconds())')]
+                     f'_format_duration({var})')]
         parsers.add('_parse_duration')
-        return [(_PRIORITY_DURATION, f'isinstance({var}, str)',
+        return [(_PRIORITY_DURATION, f'{var} is not None',
                  f'_parse_duration({var}, {{field_name}})')]
     if type_name == 'uuid.UUID':
         if encode:
             return [(_PRIORITY_UUID, f'isinstance({var}, uuid.UUID)', f'str({var})')]
         parsers.add('_parse_uuid')
-        return [(_PRIORITY_UUID, f'isinstance({var}, str)',
+        return [(_PRIORITY_UUID, f'{var} is not None',
                  f'_parse_uuid({var}, {{field_name}})')]
     if type_name == 'bytes':
         if encode:
             return [(_PRIORITY_BINARY, f'isinstance({var}, bytes)',
                      f"base64.b64encode({var}).decode('ascii')")]
         parsers.add('_parse_base64')
-        return [(_PRIORITY_BINARY, f'isinstance({var}, str)',
+        return [(_PRIORITY_BINARY, f'{var} is not None',
                  f'_parse_base64({var}, {{field_name}})')]
 
     generic = parse_generic_type(type_name)
@@ -853,6 +853,9 @@ class StructureToPython:
             json_parsers=json_parsers,
             uses_iso_parser=any(parser.startswith('_parse_iso_') for parser in json_parsers),
             needs_base64='_parse_base64' in json_parsers,
+            needs_decimal=('decimal.Decimal' in import_types
+                           or (self.dataclasses_json_annotation
+                               and '_parse_duration' in json_parsers)),
             mm_classes=mm_classes,
             import_types=sorted(import_types),
             base_package=self.base_package,

--- a/avrotize/structuretopython.py
+++ b/avrotize/structuretopython.py
@@ -210,20 +210,20 @@ def _codec_branches(type_name: str, var: str, depth: int, encode: bool,
             return [(_PRIORITY_DURATION, f'isinstance({var}, datetime.timedelta)',
                      f'_format_duration({var})')]
         parsers.add('_parse_duration')
-        return [(_PRIORITY_DURATION, f'{var} is not None',
+        return [(_PRIORITY_DURATION, 'True',
                  f'_parse_duration({var}, {{field_name}})')]
     if type_name == 'uuid.UUID':
         if encode:
             return [(_PRIORITY_UUID, f'isinstance({var}, uuid.UUID)', f'str({var})')]
         parsers.add('_parse_uuid')
-        return [(_PRIORITY_UUID, f'{var} is not None',
+        return [(_PRIORITY_UUID, 'True',
                  f'_parse_uuid({var}, {{field_name}})')]
     if type_name == 'bytes':
         if encode:
             return [(_PRIORITY_BINARY, f'isinstance({var}, bytes)',
                      f"base64.b64encode({var}).decode('ascii')")]
         parsers.add('_parse_base64')
-        return [(_PRIORITY_BINARY, f'{var} is not None',
+        return [(_PRIORITY_BINARY, 'True',
                  f'_parse_base64({var}, {{field_name}})')]
 
     generic = parse_generic_type(type_name)
@@ -283,12 +283,24 @@ def build_codec_expression(type_name: str, var: str, depth: int, encode: bool,
         expected_container = decoded_container_kind(type_name)
         if expected_container:
             expression = (
-                f"{var} if {var} is None else "
-                f"_invalid_container({var}, {{field_name}}, '{expected_container}')"
+                f"_invalid_container({var}, {{field_name}}, "
+                f"'{expected_container}')"
             )
     for _priority, condition, value in reversed(branches):
         expression = f'{value} if {condition} else {expression}'
+    if not encode and type_allows_none(type_name):
+        expression = f'None if {var} is None else {expression}'
     return expression
+
+
+def type_allows_none(type_name: str) -> bool:
+    """ Reports whether this exact annotation node declares nullability. """
+    generic = parse_generic_type(type_name)
+    if not generic:
+        return type_name in NONE_TYPES
+    origin, args = generic
+    return origin == 'Optional' or (
+        origin == 'Union' and any(arg in NONE_TYPES for arg in args))
 
 
 def decoded_container_kind(type_name: str) -> Optional[str]:
@@ -324,7 +336,11 @@ def build_mm_field(type_name: str, mm_classes: Set[str],
         return None
     origin, args = generic
     if origin == 'Optional':
-        return build_mm_field(args[0], mm_classes, options)
+        optional_options = options
+        if 'allow_none=' not in optional_options:
+            optional_options += (
+                ', ' if optional_options else '') + 'allow_none=True'
+        return build_mm_field(args[0], mm_classes, optional_options)
     if origin == 'List':
         inner = build_mm_field(args[0], mm_classes)
         return f'fields.List({inner}{", " + options if options else ""})' if inner else None
@@ -836,6 +852,12 @@ class StructureToPython:
                 'mm_field': codec['mm_field'] if codec else None,
                 'mm_classes': codec['mm_classes'] if codec else [],
                 'json_parsers': codec['parsers'] if codec else [],
+                'reject_json_null': (
+                    bool(codec)
+                    and bool(json_codec_scalars_in(field['type'])
+                             & STRICT_JSON_CODEC_SCALARS)
+                    and not type_allows_none(field['type'])
+                ),
                 # A set arrives from JSON as a list. Temporal sets are rebuilt by
                 # their own decoder; every other set needs an explicit rebuild so
                 # from_serializer_dict agrees with the dataclasses-json path.

--- a/avrotize/structuretopython.py
+++ b/avrotize/structuretopython.py
@@ -16,15 +16,20 @@ JsonNode = Dict[str, 'JsonNode'] | List['JsonNode'] | str | None
 
 INDENT = '    '
 
-# Temporal Python types that need a dataclasses-json encoder/decoder pair.
+# Python types that need a dataclasses-json encoder/decoder pair.
 # Ordered most-specific first: datetime.datetime is a subclass of datetime.date,
 # so an isinstance chain must test datetime before date.
-TEMPORAL_SCALARS = ('datetime.datetime', 'datetime.date', 'datetime.time')
+JSON_CODEC_SCALARS = (
+    'datetime.datetime',
+    'datetime.date',
+    'datetime.time',
+    'datetime.timedelta',
+    'uuid.UUID',
+    'bytes',
+)
 
-# marshmallow field expression per temporal scalar. Only emitted for scalar and
-# Optional[scalar] fields, where the marshmallow representation is exact; nested
-# containers get an encoder/decoder pair but no mm_field, because marshmallow has
-# no faithful equivalent for e.g. typing.Set.
+# Marshmallow field expression per custom JSON scalar. List, set and string-keyed
+# map fields compose these scalar fields so schema() uses the same wire codec.
 #
 # These name generated subclasses rather than marshmallow's own fields, because
 # dataclasses_json.mm.schema() uses a supplied mm_field verbatim: it neither
@@ -35,25 +40,49 @@ _MM_FIELDS = {
     'datetime.datetime': '_IsoDateTimeField',
     'datetime.date': '_IsoDateField',
     'datetime.time': '_IsoTimeField',
+    'datetime.timedelta': '_DurationField',
+    'uuid.UUID': '_UuidField',
+    'bytes': '_Base64Field',
 }
 
-_ISO_PARSERS = {
+_JSON_PARSERS = {
     'datetime.datetime': '_parse_iso_datetime',
     'datetime.date': '_parse_iso_date',
     'datetime.time': '_parse_iso_time',
+    'datetime.timedelta': '_parse_duration',
+    'uuid.UUID': '_parse_uuid',
+    'bytes': '_parse_base64',
 }
 
-# Each generated marshmallow field delegates to one of the ISO parsers, so
+# Each generated marshmallow field delegates to one of the JSON parsers, so
 # emitting the field also requires emitting its parser.
 _MM_FIELD_PARSERS = {
     '_IsoDateField': '_parse_iso_date',
     '_IsoDateTimeField': '_parse_iso_datetime',
     '_IsoTimeField': '_parse_iso_time',
+    '_DurationField': '_parse_duration',
+    '_UuidField': '_parse_uuid',
+    '_Base64Field': '_parse_base64',
 }
 
 # Emitted in this order so a module's helper block is stable.
-ISO_PARSER_ORDER = ('_parse_iso_date', '_parse_iso_datetime', '_parse_iso_time')
-MM_FIELD_ORDER = ('_IsoDateField', '_IsoDateTimeField', '_IsoTimeField')
+JSON_PARSER_ORDER = (
+    '_parse_iso_date',
+    '_parse_iso_datetime',
+    '_parse_iso_time',
+    '_parse_duration',
+    '_parse_uuid',
+    '_parse_base64',
+)
+MM_FIELD_ORDER = (
+    '_IsoDateField',
+    '_IsoDateTimeField',
+    '_IsoTimeField',
+    '_DurationField',
+    '_UuidField',
+    '_Base64Field',
+    '_SetField',
+)
 
 _GENERIC_RE = re.compile(r'^typing\.(Optional|List|Set|Dict|Union|Tuple|FrozenSet)\[(.+)\]$')
 
@@ -87,14 +116,14 @@ def parse_generic_type(type_name: str) -> Optional[Tuple[str, List[str]]]:
     return origin, split_type_args(arg_text)
 
 
-def type_contains_temporal(type_name: str) -> bool:
-    """ Reports whether a Python type annotation contains a temporal scalar at any nesting depth. """
-    if type_name in TEMPORAL_SCALARS:
+def type_contains_json_codec(type_name: str) -> bool:
+    """ Reports whether a Python type annotation contains a custom JSON scalar at any nesting depth. """
+    if type_name in JSON_CODEC_SCALARS:
         return True
     generic = parse_generic_type(type_name)
     if not generic:
         return False
-    return any(type_contains_temporal(arg) for arg in generic[1])
+    return any(type_contains_json_codec(arg) for arg in generic[1])
 
 
 NONE_TYPES = ('None', 'NoneType', 'type(None)')
@@ -105,27 +134,30 @@ _PRIORITY_DATETIME = 0
 _PRIORITY_DATE_NARROWING = 1
 _PRIORITY_DATE = 2
 _PRIORITY_TIME = 3
-_PRIORITY_CONTAINER = 4
+_PRIORITY_DURATION = 4
+_PRIORITY_UUID = 5
+_PRIORITY_BINARY = 6
+_PRIORITY_CONTAINER = 7
 
 
-def temporal_scalars_in(type_name: str) -> Set[str]:
-    """ Collects the distinct temporal scalars a Python type annotation contains at any depth. """
-    if type_name in TEMPORAL_SCALARS:
+def json_codec_scalars_in(type_name: str) -> Set[str]:
+    """ Collects the distinct custom JSON scalars a Python type annotation contains at any depth. """
+    if type_name in JSON_CODEC_SCALARS:
         return {type_name}
     generic = parse_generic_type(type_name)
     if not generic:
         return set()
     found: Set[str] = set()
     for arg in generic[1]:
-        found |= temporal_scalars_in(arg)
+        found |= json_codec_scalars_in(arg)
     return found
 
 
 def union_is_ambiguous(args: List[str]) -> bool:
-    """ Reports whether a union mixes temporal arms in a way no undiscriminated codec can encode.
+    """ Reports whether a union mixes custom scalar arms in a way no undiscriminated codec can encode.
 
-    A union of two temporal scalars (``Union[date, datetime]``) cannot be encoded
-    without losing the distinction, and a temporal scalar beside a non-temporal
+    A union of two custom scalars (``Union[date, datetime]``) cannot be encoded
+    without losing the distinction, and a custom scalar beside an unencoded
     arm (``Union[date, str]``) cannot be decoded without coercing values that
     legitimately belong to the other arm. In both cases no codec is emitted, so
     the pre-existing loud failure is preserved rather than replaced by silent
@@ -134,20 +166,21 @@ def union_is_ambiguous(args: List[str]) -> bool:
     arms = [arg for arg in args if arg not in NONE_TYPES]
     scalars: Set[str] = set()
     for arm in arms:
-        scalars |= temporal_scalars_in(arm)
+        scalars |= json_codec_scalars_in(arm)
     if len(scalars) > 1:
         return True
-    return any(not type_contains_temporal(arm) for arm in arms)
+    return any(not type_contains_json_codec(arm) for arm in arms)
 
 
 def _codec_branches(type_name: str, var: str, depth: int, encode: bool,
                     parsers: Set[str]) -> List[Tuple[int, str, str]]:
-    """ Builds the (priority, condition, value) branches of a temporal codec expression.
+    """ Builds the (priority, condition, value) branches of a custom JSON codec expression.
 
-    Every ISO parser referenced by the emitted branches is recorded in ``parsers``
+    Every parser referenced by the emitted branches is recorded in ``parsers``
     so the caller knows exactly which helper definitions the generated module
     needs. Values whose type the branches do not recognize are left untouched;
-    strings that should be temporal but cannot be parsed raise from the parser.
+    strings that should use a custom wire format but cannot be parsed raise from
+    the parser.
     """
     if type_name == 'datetime.datetime':
         if encode:
@@ -170,6 +203,26 @@ def _codec_branches(type_name: str, var: str, depth: int, encode: bool,
             return [(_PRIORITY_TIME, f'isinstance({var}, datetime.time)', f'{var}.isoformat()')]
         parsers.add('_parse_iso_time')
         return [(_PRIORITY_TIME, f'isinstance({var}, str)', f'_parse_iso_time({var}, {{field_name}})')]
+    if type_name == 'datetime.timedelta':
+        if encode:
+            return [(_PRIORITY_DURATION, f'isinstance({var}, datetime.timedelta)',
+                     f'str({var}.total_seconds())')]
+        parsers.add('_parse_duration')
+        return [(_PRIORITY_DURATION, f'isinstance({var}, str)',
+                 f'_parse_duration({var}, {{field_name}})')]
+    if type_name == 'uuid.UUID':
+        if encode:
+            return [(_PRIORITY_UUID, f'isinstance({var}, uuid.UUID)', f'str({var})')]
+        parsers.add('_parse_uuid')
+        return [(_PRIORITY_UUID, f'isinstance({var}, str)',
+                 f'_parse_uuid({var}, {{field_name}})')]
+    if type_name == 'bytes':
+        if encode:
+            return [(_PRIORITY_BINARY, f'isinstance({var}, bytes)',
+                     f"base64.b64encode({var}).decode('ascii')")]
+        parsers.add('_parse_base64')
+        return [(_PRIORITY_BINARY, f'isinstance({var}, str)',
+                 f'_parse_base64({var}, {{field_name}})')]
 
     generic = parse_generic_type(type_name)
     if not generic:
@@ -198,7 +251,7 @@ def _codec_branches(type_name: str, var: str, depth: int, encode: bool,
     # cannot describe it.
     if origin in ('List', 'Set', 'FrozenSet'):
         inner = args[0]
-        if not type_contains_temporal(inner):
+        if not type_contains_json_codec(inner):
             return []
         inner_expr = build_codec_expression(inner, item, depth + 1, encode, parsers)
         comprehension = f'[{inner_expr} for {item} in {var}]'
@@ -209,7 +262,7 @@ def _codec_branches(type_name: str, var: str, depth: int, encode: bool,
         return [(_PRIORITY_CONTAINER, f'isinstance({var}, (list, tuple, set, frozenset))', comprehension)]
     if origin == 'Dict':
         value_type = args[-1]
-        if not type_contains_temporal(value_type):
+        if not type_contains_json_codec(value_type):
             return []
         key = f'_key{depth}'
         inner_expr = build_codec_expression(value_type, item, depth + 1, encode, parsers)
@@ -220,7 +273,7 @@ def _codec_branches(type_name: str, var: str, depth: int, encode: bool,
 
 def build_codec_expression(type_name: str, var: str, depth: int, encode: bool,
                            parsers: Set[str]) -> str:
-    """ Builds a temporal encode/decode expression over ``var``, or ``var`` itself when nothing applies. """
+    """ Builds a custom JSON encode/decode expression over ``var``, or ``var`` itself when nothing applies. """
     branches = _codec_branches(type_name, var, depth, encode, parsers)
     expression = var
     for _priority, condition, value in reversed(branches):
@@ -230,9 +283,9 @@ def build_codec_expression(type_name: str, var: str, depth: int, encode: bool,
 
 def build_mm_field(type_name: str, mm_classes: Set[str],
                    options: str = '') -> Optional[str]:
-    """ Builds the marshmallow field expression for a temporal type, or None when
-    marshmallow has no faithful equivalent (e.g. typing.Set, or a union of
-    several temporal types).
+    """ Builds the marshmallow field expression for a custom JSON type, or None when
+    marshmallow has no faithful equivalent (e.g. a union of several custom
+    scalar types).
 
     ``options`` carries the keyword arguments for the outermost field only, so
     ``data_key`` is not repeated on the element field of a list or map.
@@ -250,6 +303,12 @@ def build_mm_field(type_name: str, mm_classes: Set[str],
     if origin == 'List':
         inner = build_mm_field(args[0], mm_classes)
         return f'fields.List({inner}{", " + options if options else ""})' if inner else None
+    if origin == 'Set':
+        inner = build_mm_field(args[0], mm_classes)
+        if not inner:
+            return None
+        mm_classes.add('_SetField')
+        return f'_SetField({inner}{", " + options if options else ""})'
     if origin == 'Dict' and len(args) == 2 and args[0] == 'str':
         inner = build_mm_field(args[1], mm_classes)
         if not inner:
@@ -298,15 +357,15 @@ def build_container_rebuild(type_name: str) -> Optional[str]:
     return None
 
 
-def build_temporal_codec(type_name: str, field_name: str) -> Optional[Dict[str, Optional[str]]]:
-    """ Builds the dataclasses-json encoder/decoder/mm_field triple for a temporal field type.
+def build_json_codec(type_name: str, field_name: str) -> Optional[Dict[str, Optional[str]]]:
+    """ Builds the dataclasses-json encoder/decoder/mm_field triple for a custom JSON field type.
 
-    Returns None when the type contains no temporal scalar, or when it is a union
+    Returns None when the type contains no custom JSON scalar, or when it is a union
     whose arms cannot be told apart on the wire. The encoder and decoder walk
     nested ``Optional``/``Union``/``List``/``Set``/``Dict`` annotations, so
-    collections of dates are serialized just like scalar dates.
+    collections of custom scalars are serialized just like scalar values.
     """
-    if not type_contains_temporal(type_name):
+    if not type_contains_json_codec(type_name):
         return None
     encode_parsers: Set[str] = set()
     decode_parsers: Set[str] = set()
@@ -329,7 +388,9 @@ def build_temporal_codec(type_name: str, field_name: str) -> Optional[Dict[str, 
     # its parser has to be emitted even when no decoder lambda referenced it.
     parsers = set(decode_parsers)
     for mm_class in mm_classes:
-        parsers.add(_MM_FIELD_PARSERS[mm_class])
+        parser = _MM_FIELD_PARSERS.get(mm_class)
+        if parser:
+            parsers.add(parser)
 
     return {
         'encoder': f'lambda v: {encoder}',
@@ -734,7 +795,7 @@ class StructureToPython:
         # Generate field docstrings
         field_docstrings = []
         for field in fields:
-            codec = build_temporal_codec(
+            codec = build_json_codec(
                 field['type'], field.get('json_name') or field['name'])
             field_docstrings.append({
                 'name': self.safe_name(field['name']),
@@ -749,7 +810,7 @@ class StructureToPython:
                 'json_decoder': codec['decoder'] if codec else None,
                 'mm_field': codec['mm_field'] if codec else None,
                 'mm_classes': codec['mm_classes'] if codec else [],
-                'iso_parsers': codec['parsers'] if codec else [],
+                'json_parsers': codec['parsers'] if codec else [],
                 # A set arrives from JSON as a list. Temporal sets are rebuilt by
                 # their own decoder; every other set needs an explicit rebuild so
                 # from_serializer_dict agrees with the dataclasses-json path.
@@ -766,9 +827,9 @@ class StructureToPython:
                 },
             })
 
-        # ISO parsing helpers required by the emitted decoders, in a stable order.
-        iso_parsers = [parser for parser in ISO_PARSER_ORDER
-                       if any(parser in field['iso_parsers'] for field in field_docstrings)]
+        # JSON parsing helpers required by the emitted decoders, in a stable order.
+        json_parsers = [parser for parser in JSON_PARSER_ORDER
+                        if any(parser in field['json_parsers'] for field in field_docstrings)]
         # Marshmallow field subclasses required by the emitted mm_fields.
         mm_classes = [mm_class for mm_class in MM_FIELD_ORDER
                       if any(mm_class in field['mm_classes'] for field in field_docstrings)]
@@ -789,7 +850,9 @@ class StructureToPython:
             class_name=class_name,
             docstring=doc,
             fields=field_docstrings,
-            iso_parsers=iso_parsers,
+            json_parsers=json_parsers,
+            uses_iso_parser=any(parser.startswith('_parse_iso_') for parser in json_parsers),
+            needs_base64='_parse_base64' in json_parsers,
             mm_classes=mm_classes,
             import_types=sorted(import_types),
             base_package=self.base_package,

--- a/avrotize/structuretopython/dataclass_core.jinja
+++ b/avrotize/structuretopython/dataclass_core.jinja
@@ -10,6 +10,9 @@ import gzip
 import enum
 import typing
 import dataclasses
+{%- if dataclasses_json_annotation and needs_base64 %}
+import base64
+{%- endif %}
 from dataclasses import dataclass
 {%- if is_abstract %}
 from abc import ABC
@@ -52,8 +55,9 @@ import uuid
 {% if xml_annotation %}
 from {{ xml_runtime_module }} import parse_xml, serialize_xml
 {% endif %}
-{% if dataclasses_json_annotation and iso_parsers %}
+{% if dataclasses_json_annotation and json_parsers %}
 
+{% if uses_iso_parser %}
 def _normalize_iso_string(value: str) -> str:
     """ Normalizes an RFC 3339 string into a form datetime.fromisoformat accepts.
 
@@ -78,7 +82,8 @@ def _normalize_iso_string(value: str) -> str:
             text = text[:dot + 1] + digits[:6].ljust(6, '0') + text[end:]
     return text
 
-{% for parser in iso_parsers %}
+{% endif %}
+{% for parser in json_parsers %}
 {%- if parser == '_parse_iso_date' %}
 def _parse_iso_date(value: str, field_name: str) -> datetime.date:
     """ Parses an ISO 8601 date string, raising ValueError if it is malformed. """
@@ -105,6 +110,33 @@ def _parse_iso_time(value: str, field_name: str) -> datetime.time:
     except ValueError as error:
         raise ValueError(
             f"Invalid ISO 8601 time for field '{field_name}': {value!r}") from error
+
+{% elif parser == '_parse_duration' %}
+def _parse_duration(value: str, field_name: str) -> datetime.timedelta:
+    """ Parses a decimal total-seconds string, raising ValueError if it is malformed. """
+    try:
+        return datetime.timedelta(seconds=float(value))
+    except (TypeError, ValueError, OverflowError) as error:
+        raise ValueError(
+            f"Invalid decimal duration for field '{field_name}': {value!r}") from error
+
+{% elif parser == '_parse_uuid' %}
+def _parse_uuid(value: str, field_name: str) -> uuid.UUID:
+    """ Parses a UUID string, raising ValueError if it is malformed. """
+    try:
+        return uuid.UUID(value)
+    except (AttributeError, TypeError, ValueError) as error:
+        raise ValueError(
+            f"Invalid UUID for field '{field_name}': {value!r}") from error
+
+{% elif parser == '_parse_base64' %}
+def _parse_base64(value: str, field_name: str) -> bytes:
+    """ Parses strict RFC 4648 base64, raising ValueError if it is malformed. """
+    try:
+        return base64.b64decode(value, validate=True)
+    except (TypeError, ValueError) as error:
+        raise ValueError(
+            f"Invalid RFC 4648 base64 for field '{field_name}': {value!r}") from error
 
 {% endif %}
 {%- endfor %}
@@ -180,6 +212,72 @@ class _IsoTimeField(fields.Time):
             return _parse_iso_time(value, self.data_key or attr or 'value')
         except ValueError as error:
             raise ValidationError(str(error)) from error
+
+{% elif mm_class == '_DurationField' %}
+class _DurationField(fields.String):
+    """ A marshmallow field for decimal total-seconds duration strings. """
+
+    def _serialize(self, value, attr, obj, **kwargs):
+        if value is None:
+            return None
+        if isinstance(value, datetime.timedelta):
+            return str(value.total_seconds())
+        return value
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        if value is None:
+            return None
+        try:
+            return _parse_duration(value, self.data_key or attr or 'value')
+        except ValueError as error:
+            raise ValidationError(str(error)) from error
+
+{% elif mm_class == '_UuidField' %}
+class _UuidField(fields.String):
+    """ A marshmallow field for canonical hyphenated UUID strings. """
+
+    def _serialize(self, value, attr, obj, **kwargs):
+        if value is None:
+            return None
+        if isinstance(value, uuid.UUID):
+            return str(value)
+        return value
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        if value is None:
+            return None
+        try:
+            return _parse_uuid(value, self.data_key or attr or 'value')
+        except ValueError as error:
+            raise ValidationError(str(error)) from error
+
+{% elif mm_class == '_Base64Field' %}
+class _Base64Field(fields.String):
+    """ A marshmallow field for strict RFC 4648 base64 strings. """
+
+    def _serialize(self, value, attr, obj, **kwargs):
+        if value is None:
+            return None
+        if isinstance(value, bytes):
+            return base64.b64encode(value).decode('ascii')
+        return value
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        if value is None:
+            return None
+        try:
+            return _parse_base64(value, self.data_key or attr or 'value')
+        except ValueError as error:
+            raise ValidationError(str(error)) from error
+
+{% elif mm_class == '_SetField' %}
+class _SetField(fields.List):
+    """ A marshmallow list field that restores the declared Python set type. """
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        if value is None:
+            return None
+        return set(super()._deserialize(value, attr, data, **kwargs))
 
 {% endif %}
 {%- endfor %}

--- a/avrotize/structuretopython/dataclass_core.jinja
+++ b/avrotize/structuretopython/dataclass_core.jinja
@@ -141,11 +141,25 @@ def _parse_duration(value: typing.Any, field_name: str) -> datetime.timedelta:
         )
         if not seconds.is_finite() or not minimum <= seconds <= maximum:
             raise decimal.InvalidOperation
-        with decimal.localcontext() as context:
-            context.prec = max(len(seconds.as_tuple().digits) + 6, 28)
-            total_microseconds = seconds * decimal.Decimal(1000000)
-        if total_microseconds != total_microseconds.to_integral_value():
-            raise decimal.InvalidOperation
+        sign, digits, exponent = seconds.as_tuple()
+        if not any(digits):
+            return datetime.timedelta(0)
+        scaled_exponent = exponent + 6
+        if scaled_exponent < 0:
+            fractional_digits = -scaled_exponent
+            if fractional_digits >= len(digits):
+                raise decimal.InvalidOperation
+            split = len(digits) - fractional_digits
+            if any(digits[split:]):
+                raise decimal.InvalidOperation
+            integer_digits = digits[:split]
+        else:
+            integer_digits = digits + (0,) * scaled_exponent
+        total_microseconds = 0
+        for digit in integer_digits:
+            total_microseconds = total_microseconds * 10 + digit
+        if sign:
+            total_microseconds = -total_microseconds
         return datetime.timedelta(microseconds=int(total_microseconds))
     except (decimal.InvalidOperation, ValueError, OverflowError) as error:
         raise ValueError(
@@ -189,6 +203,15 @@ def _parse_base64(value: typing.Any, field_name: str) -> bytes:
 
 {% endif %}
 {%- endfor %}
+{% if uses_container_validator %}
+def _invalid_container(value: typing.Any, field_name: str, expected: str):
+    """ Raises a field-specific error for an invalid decoded container shape. """
+    raise ValueError(
+        f"Invalid container for field '{field_name}': "
+        f"expected a JSON {expected}, got {type(value).__name__}")
+
+
+{% endif %}
 {% if mm_classes %}
 {% for mm_class in mm_classes %}
 {%- if mm_class == '_IsoDateField' %}

--- a/avrotize/structuretopython/dataclass_core.jinja
+++ b/avrotize/structuretopython/dataclass_core.jinja
@@ -134,12 +134,7 @@ def _parse_duration(value: typing.Any, field_name: str) -> datetime.timedelta:
             f"expected a string or datetime.timedelta, got {type(value).__name__}")
     try:
         seconds = decimal.Decimal(value)
-        minimum = decimal.Decimal(-999999999 * 86400)
-        maximum = (
-            decimal.Decimal(999999999 * 86400 + 86399)
-            + decimal.Decimal('0.999999')
-        )
-        if not seconds.is_finite() or not minimum <= seconds <= maximum:
+        if not seconds.is_finite():
             raise decimal.InvalidOperation
         sign, digits, exponent = seconds.as_tuple()
         if not any(digits):
@@ -154,12 +149,22 @@ def _parse_duration(value: typing.Any, field_name: str) -> datetime.timedelta:
                 raise decimal.InvalidOperation
             integer_digits = digits[:split]
         else:
+            # The timedelta bounds have 20 decimal digits in microseconds.
+            # Reject larger exponents before constructing a zero-filled tuple.
+            if len(digits) + scaled_exponent > 20:
+                raise decimal.InvalidOperation
             integer_digits = digits + (0,) * scaled_exponent
         total_microseconds = 0
         for digit in integer_digits:
             total_microseconds = total_microseconds * 10 + digit
         if sign:
             total_microseconds = -total_microseconds
+        minimum_microseconds = -999999999 * 86400 * 1000000
+        maximum_microseconds = (
+            (999999999 * 86400 + 86399) * 1000000 + 999999
+        )
+        if not minimum_microseconds <= total_microseconds <= maximum_microseconds:
+            raise decimal.InvalidOperation
         return datetime.timedelta(microseconds=int(total_microseconds))
     except (decimal.InvalidOperation, ValueError, OverflowError) as error:
         raise ValueError(
@@ -357,6 +362,36 @@ class _SetField(fields.List):
 {% endif %}
 
 {% if dataclasses_json_annotation %}
+{%- for field in fields if field.reject_json_null %}
+{%- if loop.first %}
+def _reject_nonnullable_json_nulls(cls):
+    """ Makes dataclasses-json reject null before it skips custom decoders. """
+    original_from_dict = cls.from_dict.__func__
+
+    @classmethod
+    def from_dict(inner_cls, data, *, infer_missing=False):
+        if isinstance(data, dict):
+        {%- for required_field in fields if required_field.reject_json_null %}
+            if data.get('{{ required_field.original_name }}', ...) is None:
+                raise ValueError(
+                    "Invalid null for field '{{ required_field.original_name }}'")
+        {%- endfor %}
+        return original_from_dict(
+            inner_cls, data, infer_missing=infer_missing)
+
+    cls.from_dict = from_dict
+    return cls
+
+
+{%- endif %}
+{%- endfor %}
+{% endif %}
+{% if dataclasses_json_annotation %}
+{%- for field in fields if field.reject_json_null %}
+{%- if loop.first %}
+@_reject_nonnullable_json_nulls
+{%- endif %}
+{%- endfor %}
 @dataclass_json(undefined=Undefined.EXCLUDE)
 {%- endif %}
 @dataclass

--- a/avrotize/structuretopython/dataclass_core.jinja
+++ b/avrotize/structuretopython/dataclass_core.jinja
@@ -124,6 +124,25 @@ def _format_duration(value: datetime.timedelta) -> str:
     return f'{sign}{whole_seconds}.0'
 
 
+_DURATION_MIN_MICROSECONDS = -999999999 * 86400 * 1000000
+_DURATION_MAX_MICROSECONDS = (
+    (999999999 * 86400 + 86399) * 1000000 + 999999
+)
+_DURATION_MAX_MICROSECOND_DIGITS = max(
+    len(str(abs(_DURATION_MIN_MICROSECONDS))),
+    len(str(_DURATION_MAX_MICROSECONDS)),
+)
+_DURATION_MAX_ABS_EXPONENT = _DURATION_MAX_MICROSECOND_DIGITS + 6 - 1
+# Allow a sign, leading zero before a decimal point, decimal point, exponent
+# marker/sign, and the largest useful exponent around a bounded coefficient.
+_DURATION_MAX_LITERAL_LENGTH = (
+    _DURATION_MAX_MICROSECOND_DIGITS
+    + len(str(_DURATION_MAX_ABS_EXPONENT))
+    + 5
+)
+_DURATION_SIZE_ERROR = 'duration literal exceeds supported timedelta size'
+
+
 def _parse_duration(value: typing.Any, field_name: str) -> datetime.timedelta:
     """ Parses exact decimal total seconds, raising ValueError if invalid. """
     if isinstance(value, datetime.timedelta):
@@ -133,6 +152,8 @@ def _parse_duration(value: typing.Any, field_name: str) -> datetime.timedelta:
             f"Invalid decimal duration for field '{field_name}': "
             f"expected a string or datetime.timedelta, got {type(value).__name__}")
     try:
+        if len(value) > _DURATION_MAX_LITERAL_LENGTH:
+            raise ValueError(_DURATION_SIZE_ERROR)
         seconds = decimal.Decimal(value)
         if not seconds.is_finite():
             raise decimal.InvalidOperation
@@ -140,6 +161,9 @@ def _parse_duration(value: typing.Any, field_name: str) -> datetime.timedelta:
         if not any(digits):
             return datetime.timedelta(0)
         scaled_exponent = exponent + 6
+        microsecond_digit_count = len(digits) + scaled_exponent
+        if microsecond_digit_count > _DURATION_MAX_MICROSECOND_DIGITS:
+            raise ValueError(_DURATION_SIZE_ERROR)
         if scaled_exponent < 0:
             fractional_digits = -scaled_exponent
             if fractional_digits >= len(digits):
@@ -149,21 +173,16 @@ def _parse_duration(value: typing.Any, field_name: str) -> datetime.timedelta:
                 raise decimal.InvalidOperation
             integer_digits = digits[:split]
         else:
-            # The timedelta bounds have 20 decimal digits in microseconds.
-            # Reject larger exponents before constructing a zero-filled tuple.
-            if len(digits) + scaled_exponent > 20:
-                raise decimal.InvalidOperation
             integer_digits = digits + (0,) * scaled_exponent
         total_microseconds = 0
         for digit in integer_digits:
             total_microseconds = total_microseconds * 10 + digit
         if sign:
             total_microseconds = -total_microseconds
-        minimum_microseconds = -999999999 * 86400 * 1000000
-        maximum_microseconds = (
-            (999999999 * 86400 + 86399) * 1000000 + 999999
-        )
-        if not minimum_microseconds <= total_microseconds <= maximum_microseconds:
+        if not (
+                _DURATION_MIN_MICROSECONDS
+                <= total_microseconds
+                <= _DURATION_MAX_MICROSECONDS):
             raise decimal.InvalidOperation
         return datetime.timedelta(microseconds=int(total_microseconds))
     except (decimal.InvalidOperation, ValueError, OverflowError) as error:

--- a/avrotize/structuretopython/dataclass_core.jinja
+++ b/avrotize/structuretopython/dataclass_core.jinja
@@ -41,11 +41,9 @@ from {{ '.'.join(import_type.split('.')[:-1]) | lower }} import {{ import_type.s
 import datetime
 {%- endif %}
 {%- endfor %}
-{%- for import_type in import_types if import_type == 'decimal.Decimal' %}
-{%- if loop.first %}
+{%- if needs_decimal %}
 import decimal
 {%- endif %}
-{%- endfor %}
 {%- for import_type in import_types if import_type == 'uuid.UUID' %}
 {%- if loop.first %}
 import uuid
@@ -112,28 +110,79 @@ def _parse_iso_time(value: str, field_name: str) -> datetime.time:
             f"Invalid ISO 8601 time for field '{field_name}': {value!r}") from error
 
 {% elif parser == '_parse_duration' %}
-def _parse_duration(value: str, field_name: str) -> datetime.timedelta:
-    """ Parses a decimal total-seconds string, raising ValueError if it is malformed. """
+def _format_duration(value: datetime.timedelta) -> str:
+    """ Formats a timedelta as exact decimal total seconds. """
+    total_microseconds = (
+        (value.days * 86400 + value.seconds) * 1000000
+        + value.microseconds
+    )
+    sign = '-' if total_microseconds < 0 else ''
+    whole_seconds, microseconds = divmod(abs(total_microseconds), 1000000)
+    if microseconds:
+        fraction = f'{microseconds:06d}'.rstrip('0')
+        return f'{sign}{whole_seconds}.{fraction}'
+    return f'{sign}{whole_seconds}.0'
+
+
+def _parse_duration(value: typing.Any, field_name: str) -> datetime.timedelta:
+    """ Parses exact decimal total seconds, raising ValueError if invalid. """
+    if isinstance(value, datetime.timedelta):
+        return value
+    if not isinstance(value, str):
+        raise ValueError(
+            f"Invalid decimal duration for field '{field_name}': "
+            f"expected a string or datetime.timedelta, got {type(value).__name__}")
     try:
-        return datetime.timedelta(seconds=float(value))
-    except (TypeError, ValueError, OverflowError) as error:
+        seconds = decimal.Decimal(value)
+        minimum = decimal.Decimal(-999999999 * 86400)
+        maximum = (
+            decimal.Decimal(999999999 * 86400 + 86399)
+            + decimal.Decimal('0.999999')
+        )
+        if not seconds.is_finite() or not minimum <= seconds <= maximum:
+            raise decimal.InvalidOperation
+        with decimal.localcontext() as context:
+            context.prec = max(len(seconds.as_tuple().digits) + 6, 28)
+            total_microseconds = seconds * decimal.Decimal(1000000)
+        if total_microseconds != total_microseconds.to_integral_value():
+            raise decimal.InvalidOperation
+        return datetime.timedelta(microseconds=int(total_microseconds))
+    except (decimal.InvalidOperation, ValueError, OverflowError) as error:
         raise ValueError(
             f"Invalid decimal duration for field '{field_name}': {value!r}") from error
 
 {% elif parser == '_parse_uuid' %}
-def _parse_uuid(value: str, field_name: str) -> uuid.UUID:
-    """ Parses a UUID string, raising ValueError if it is malformed. """
+def _parse_uuid(value: typing.Any, field_name: str) -> uuid.UUID:
+    """ Parses a canonical UUID string, raising ValueError if invalid. """
+    if isinstance(value, uuid.UUID):
+        return value
+    if not isinstance(value, str):
+        raise ValueError(
+            f"Invalid UUID for field '{field_name}': "
+            f"expected a canonical string or uuid.UUID, got {type(value).__name__}")
     try:
-        return uuid.UUID(value)
-    except (AttributeError, TypeError, ValueError) as error:
+        parsed = uuid.UUID(value)
+        if value != str(parsed):
+            raise ValueError('UUID is not in canonical hyphenated form')
+        return parsed
+    except ValueError as error:
         raise ValueError(
             f"Invalid UUID for field '{field_name}': {value!r}") from error
 
 {% elif parser == '_parse_base64' %}
-def _parse_base64(value: str, field_name: str) -> bytes:
-    """ Parses strict RFC 4648 base64, raising ValueError if it is malformed. """
+def _parse_base64(value: typing.Any, field_name: str) -> bytes:
+    """ Parses canonical RFC 4648 base64, raising ValueError if invalid. """
+    if isinstance(value, bytes):
+        return value
+    if not isinstance(value, str):
+        raise ValueError(
+            f"Invalid RFC 4648 base64 for field '{field_name}': "
+            f"expected a canonical string or bytes, got {type(value).__name__}")
     try:
-        return base64.b64decode(value, validate=True)
+        decoded = base64.b64decode(value, validate=True)
+        if value != base64.b64encode(decoded).decode('ascii'):
+            raise ValueError('base64 is not in canonical RFC 4648 form')
+        return decoded
     except (TypeError, ValueError) as error:
         raise ValueError(
             f"Invalid RFC 4648 base64 for field '{field_name}': {value!r}") from error
@@ -221,7 +270,7 @@ class _DurationField(fields.String):
         if value is None:
             return None
         if isinstance(value, datetime.timedelta):
-            return str(value.total_seconds())
+            return _format_duration(value)
         return value
 
     def _deserialize(self, value, attr, data, **kwargs):

--- a/test/test_structuretopython.py
+++ b/test/test_structuretopython.py
@@ -1,6 +1,7 @@
 """Tests for JSON Structure to Python conversion."""
 
 import unittest
+from unittest import mock
 import datetime
 import os
 import shutil
@@ -2175,6 +2176,8 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
              "8640000000.000001"),
             (datetime.timedelta(days=-100000, microseconds=1),
              "-8639999999.999999"),
+            (datetime.timedelta.max, "86399999999999.999999"),
+            (datetime.timedelta.min, "-86399999913600.0"),
         )
 
         for value, expected_wire in fixtures:
@@ -2198,6 +2201,83 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
                         module.ExactDuration.from_serializer_dict(dict(raw))):
                     assert restored == record, \
                         f"{expected_wire} restored as {restored.value!r}"
+
+    def test_issue_465_duration_rejects_oversized_literals_before_decimal(self):
+        """Size guard rejects oversized coefficients/exponents before Decimal parsing."""
+        schema = {
+            "type": "object",
+            "name": "BoundedDurationLiteral",
+            "namespace": "test.issue465",
+            "properties": {"value": {"type": "duration"}},
+            "required": ["value"],
+        }
+        src_dir, _source = self._generate_issue_465_module(
+            schema, "test_issue465_duration_literal_bound")
+        module = self._import_generated(
+            src_dir,
+            "test_issue465_duration_literal_bound.test.issue465."
+            "boundeddurationliteral")
+        oversized = (
+            ("1" * 80000) + "0e-7",
+            ("0" * 80000) + "1.0",
+            "1e-" + ("9" * 80000),
+        )
+
+        for value in oversized:
+            with self.subTest(length=len(value), suffix=value[-8:]):
+                with mock.patch.object(
+                        module.decimal, "Decimal",
+                        side_effect=AssertionError("Decimal must not be called")):
+                    with self.assertRaises(ValueError) as caught:
+                        module._parse_duration(value, "value")
+                assert "value" in str(caught.exception)
+                assert caught.exception.__cause__ is not None
+                assert "supported timedelta size" in str(
+                    caught.exception.__cause__)
+
+    def test_issue_465_duration_bounds_digits_before_integer_accumulation(self):
+        """Negative exponents cannot bypass the representable digit guard."""
+        schema = {
+            "type": "object",
+            "name": "BoundedDurationDigits",
+            "namespace": "test.issue465",
+            "properties": {"value": {"type": "duration"}},
+            "required": ["value"],
+        }
+        src_dir, _source = self._generate_issue_465_module(
+            schema, "test_issue465_duration_digit_bound")
+        module = self._import_generated(
+            src_dir,
+            "test_issue465_duration_digit_bound.test.issue465."
+            "boundeddurationdigits")
+        value = ("1" * 21) + "0e-7"
+
+        with self.assertRaises(ValueError) as direct:
+            module._parse_duration(value, "value")
+        assert "value" in str(direct.exception)
+        assert direct.exception.__cause__ is not None
+        assert "supported timedelta size" in str(direct.exception.__cause__)
+
+        text = json.dumps({"value": value})
+        raw = {"value": value}
+        entry_points = {
+            "from_json": lambda: module.BoundedDurationDigits.from_json(text),
+            "schema().loads":
+                lambda: module.BoundedDurationDigits.schema().loads(text),
+            "from_data(bytes)": lambda: module.BoundedDurationDigits.from_data(
+                text.encode("utf-8"), "application/json"),
+            "from_data(dict)": lambda: module.BoundedDurationDigits.from_data(
+                dict(raw), "application/json"),
+            "from_serializer_dict":
+                lambda: module.BoundedDurationDigits.from_serializer_dict(
+                    dict(raw)),
+        }
+        for label, call in entry_points.items():
+            with self.subTest(entry_point=label):
+                with self.assertRaises(Exception) as caught:
+                    call()
+                assert "value" in str(caught.exception), \
+                    f"{label} error did not identify value: {caught.exception}"
 
     def test_issue_465_duration_ignores_ambient_decimal_context(self):
         """Boundary fixture: caller precision and traps cannot affect wire parsing."""

--- a/test/test_structuretopython.py
+++ b/test/test_structuretopython.py
@@ -994,7 +994,9 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
     # "TypeError: Object of type date is not JSON serializable" on to_json().
     # ------------------------------------------------------------------
 
-    def _generate_issue_405_module(self, schema, package_name, avro_annotation=False):
+    def _generate_issue_405_module(
+            self, schema, package_name, avro_annotation=False,
+            dataclasses_json_annotation=True):
         """Generates a dataclasses-json annotated module and returns (src_dir, source_text)."""
         from avrotize.structuretopython import convert_structure_schema_to_python
 
@@ -1005,7 +1007,7 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
 
         convert_structure_schema_to_python(
             schema, output_dir, package_name=package_name,
-            dataclasses_json_annotation=True,
+            dataclasses_json_annotation=dataclasses_json_annotation,
             avro_annotation=avro_annotation)
 
         src_dir = os.path.join(output_dir, "src")
@@ -2068,6 +2070,12 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
         }
         malformed = (
             ("duration", "ninety seconds"),
+            ("duration", "1e10000000"),
+            ("duration", "1e-10000000"),
+            ("duration", "-1e-10000000"),
+            ("duration", "NaN"),
+            ("duration", "Infinity"),
+            ("duration", "1e-7"),
             ("uuid", "not-a-uuid"),
             ("uuid", "12345678123456781234567812345678"),
             ("uuid", "12345678-1234-5678-9ABC-DEF012345678"),
@@ -2161,6 +2169,7 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
             src_dir, "test_issue465_exact_duration.test.issue465.exactduration")
         fixtures = (
             (datetime.timedelta(seconds=90.5), "90.5"),
+            (datetime.timedelta(microseconds=1), "0.000001"),
             (datetime.timedelta(microseconds=-1), "-0.000001"),
             (datetime.timedelta(days=100000, microseconds=1),
              "8640000000.000001"),
@@ -2189,6 +2198,105 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
                         module.ExactDuration.from_serializer_dict(dict(raw))):
                     assert restored == record, \
                         f"{expected_wire} restored as {restored.value!r}"
+
+    def test_issue_465_invalid_outer_container_shapes_are_rejected(self):
+        """Invalid fixtures: custom scalar containers reject non-container values."""
+        schema = {
+            "type": "object",
+            "name": "StrictContainers",
+            "namespace": "test.issue465",
+            "properties": {
+                "durations": {
+                    "type": "array",
+                    "items": {"type": "duration"},
+                },
+                "ids": {
+                    "type": "set",
+                    "items": {"type": "uuid"},
+                },
+                "payloads": {
+                    "type": "map",
+                    "values": {"type": "binary"},
+                },
+                "maybe-payloads": {
+                    "type": ["null", {
+                        "type": "array",
+                        "items": {"type": "binary"},
+                    }],
+                },
+            },
+            "required": ["durations", "ids", "payloads", "maybe-payloads"],
+        }
+        src_dir, _source = self._generate_issue_465_module(
+            schema, "test_issue465_invalid_containers")
+        module = self._import_generated(
+            src_dir,
+            "test_issue465_invalid_containers.test.issue465.strictcontainers")
+        valid = {
+            "durations": ["1.0"],
+            "ids": ["12345678-1234-5678-1234-567812345678"],
+            "payloads": {"a": "YQ=="},
+            "maybe-payloads": ["Yg=="],
+        }
+        malformed = (
+            ("durations", True),
+            ("ids", 1),
+            ("payloads", []),
+            ("maybe-payloads", {}),
+        )
+
+        for field_name, bad_value in malformed:
+            raw = {**valid, field_name: bad_value}
+            text = json.dumps(raw)
+
+            def from_serializer_dict():
+                caller_data = dict(raw)
+                try:
+                    return module.StrictContainers.from_serializer_dict(
+                        caller_data)
+                finally:
+                    assert caller_data == raw
+
+            entry_points = {
+                "from_json": lambda: module.StrictContainers.from_json(text),
+                "schema().loads":
+                    lambda: module.StrictContainers.schema().loads(text),
+                "from_data(bytes)": lambda: module.StrictContainers.from_data(
+                    text.encode("utf-8"), "application/json"),
+                "from_data(dict)": lambda: module.StrictContainers.from_data(
+                    dict(raw), "application/json"),
+                "from_serializer_dict": from_serializer_dict,
+            }
+            for label, call in entry_points.items():
+                with self.subTest(field=field_name, entry_point=label):
+                    with self.assertRaises(Exception) as caught:
+                        call()
+                    assert field_name in str(caught.exception), \
+                        f"{label} error did not identify {field_name}: {caught.exception}"
+
+    def test_issue_465_non_annotated_binary_set_keeps_container_rebuild(self):
+        """Compatibility fixture: JSON codecs must not disable un-emitted decoders."""
+        schema = {
+            "type": "object",
+            "name": "PlainSet",
+            "namespace": "test.issue465",
+            "properties": {
+                "values": {"type": "set", "items": {"type": "binary"}},
+            },
+            "required": ["values"],
+        }
+        src_dir, source = self._generate_issue_405_module(
+            schema, "test_issue465_plain_set",
+            dataclasses_json_annotation=False)
+        module = self._import_generated(
+            src_dir, "test_issue465_plain_set.test.issue465.plainset")
+        caller_data = {"values": [b"a", b"b"]}
+
+        restored = module.PlainSet.from_serializer_dict(caller_data)
+        assert restored.values == {b"a", b"b"}, source
+        assert isinstance(restored.values, set), source
+        assert caller_data == {"values": [b"a", b"b"]}
+        assert "dataclasses_json" not in source
 
     def test_issue_465_typed_serializer_dict_is_not_mutated(self):
         """Already-typed fixture: guarded decoders preserve values and caller data."""

--- a/test/test_structuretopython.py
+++ b/test/test_structuretopython.py
@@ -2199,6 +2199,159 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
                     assert restored == record, \
                         f"{expected_wire} restored as {restored.value!r}"
 
+    def test_issue_465_duration_ignores_ambient_decimal_context(self):
+        """Boundary fixture: caller precision and traps cannot affect wire parsing."""
+        import decimal
+
+        schema = {
+            "type": "object",
+            "name": "ContextDuration",
+            "namespace": "test.issue465",
+            "properties": {"value": {"type": "duration"}},
+            "required": ["value"],
+        }
+        src_dir, _source = self._generate_issue_465_module(
+            schema, "test_issue465_decimal_context")
+        module = self._import_generated(
+            src_dir,
+            "test_issue465_decimal_context.test.issue465.contextduration")
+        text = '{"value": "1.0"}'
+        raw = {"value": "1.0"}
+        expected = module.ContextDuration(
+            value=datetime.timedelta(seconds=1))
+
+        original = decimal.getcontext()
+        with decimal.localcontext() as context:
+            context.prec = 10
+            context.traps[decimal.Inexact] = True
+            context.clear_flags()
+            for restored in (
+                    module.ContextDuration.from_json(text),
+                    module.ContextDuration.schema().loads(text),
+                    module.ContextDuration.from_data(
+                        text.encode("utf-8"), "application/json"),
+                    module.ContextDuration.from_data(
+                        dict(raw), "application/json"),
+                    module.ContextDuration.from_serializer_dict(dict(raw))):
+                assert restored == expected
+            assert context.prec == 10
+            assert context.traps[decimal.Inexact]
+            assert not context.flags[decimal.Inexact]
+        assert decimal.getcontext() is original
+
+    def test_issue_465_nullability_is_enforced_at_each_declared_shape(self):
+        """Null is accepted only where the field or element type is Optional."""
+        schema = {
+            "type": "object",
+            "name": "Nullability",
+            "namespace": "test.issue465",
+            "properties": {
+                "duration": {"type": "duration"},
+                "uuid": {"type": "uuid"},
+                "binary": {"type": "binary"},
+                "durations": {
+                    "type": "array",
+                    "items": {"type": "duration"},
+                },
+                "ids": {
+                    "type": "set",
+                    "items": {"type": "uuid"},
+                },
+                "payloads": {
+                    "type": "map",
+                    "values": {"type": "binary"},
+                },
+                "maybe-duration": {"type": ["null", "duration"]},
+                "maybe-payloads": {
+                    "type": ["null", {
+                        "type": "array",
+                        "items": {"type": "binary"},
+                    }],
+                },
+                "nullable-elements": {
+                    "type": "array",
+                    "items": {"type": ["null", "binary"]},
+                },
+            },
+            "required": [
+                "duration", "uuid", "binary", "durations", "ids",
+                "payloads", "maybe-duration", "maybe-payloads",
+                "nullable-elements",
+            ],
+        }
+        src_dir, _source = self._generate_issue_465_module(
+            schema, "test_issue465_nullability")
+        module = self._import_generated(
+            src_dir, "test_issue465_nullability.test.issue465.nullability")
+        valid = {
+            "duration": "1.0",
+            "uuid": "12345678-1234-5678-1234-567812345678",
+            "binary": "YQ==",
+            "durations": ["1.0"],
+            "ids": ["12345678-1234-5678-1234-567812345678"],
+            "payloads": {"a": "YQ=="},
+            "maybe-duration": None,
+            "maybe-payloads": None,
+            "nullable-elements": [None, "Yg=="],
+        }
+
+        expected_uuid = __import__("uuid").UUID(
+            "12345678-1234-5678-1234-567812345678")
+        expected = module.Nullability(
+            duration=datetime.timedelta(seconds=1),
+            uuid=expected_uuid,
+            binary=b"a",
+            durations=[datetime.timedelta(seconds=1)],
+            ids={expected_uuid},
+            payloads={"a": b"a"},
+            maybe_duration=None,
+            maybe_payloads=None,
+            nullable_elements=[None, b"b"],
+        )
+        text = json.dumps(valid)
+        for restored in (
+                module.Nullability.from_json(text),
+                module.Nullability.schema().loads(text),
+                module.Nullability.from_data(
+                    text.encode("utf-8"), "application/json"),
+                module.Nullability.from_data(dict(valid), "application/json"),
+                module.Nullability.from_serializer_dict(dict(valid))):
+            assert restored == expected
+
+        malformed = (
+            ("duration", None),
+            ("uuid", None),
+            ("binary", None),
+            ("durations", None),
+            ("ids", None),
+            ("payloads", None),
+            ("durations", [None]),
+            ("ids", [None]),
+            ("payloads", {"a": None}),
+        )
+        for field_name, bad_value in malformed:
+            raw = {**valid, field_name: bad_value}
+            bad_text = json.dumps(raw)
+            entry_points = {
+                "from_json": lambda: module.Nullability.from_json(bad_text),
+                "schema().loads":
+                    lambda: module.Nullability.schema().loads(bad_text),
+                "from_data(bytes)": lambda: module.Nullability.from_data(
+                    bad_text.encode("utf-8"), "application/json"),
+                "from_data(dict)": lambda: module.Nullability.from_data(
+                    dict(raw), "application/json"),
+                "from_serializer_dict":
+                    lambda: module.Nullability.from_serializer_dict(dict(raw)),
+            }
+            for label, call in entry_points.items():
+                with self.subTest(
+                        field=field_name, value=bad_value,
+                        entry_point=label):
+                    with self.assertRaises(Exception) as caught:
+                        call()
+                    assert field_name in str(caught.exception), \
+                        f"{label} error did not identify {field_name}: {caught.exception}"
+
     def test_issue_465_invalid_outer_container_shapes_are_rejected(self):
         """Invalid fixtures: custom scalar containers reject non-container values."""
         schema = {

--- a/test/test_structuretopython.py
+++ b/test/test_structuretopython.py
@@ -994,7 +994,7 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
     # "TypeError: Object of type date is not JSON serializable" on to_json().
     # ------------------------------------------------------------------
 
-    def _generate_issue_405_module(self, schema, package_name):
+    def _generate_issue_405_module(self, schema, package_name, avro_annotation=False):
         """Generates a dataclasses-json annotated module and returns (src_dir, source_text)."""
         from avrotize.structuretopython import convert_structure_schema_to_python
 
@@ -1005,7 +1005,8 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
 
         convert_structure_schema_to_python(
             schema, output_dir, package_name=package_name,
-            dataclasses_json_annotation=True)
+            dataclasses_json_annotation=True,
+            avro_annotation=avro_annotation)
 
         src_dir = os.path.join(output_dir, "src")
         class_file = None
@@ -1898,6 +1899,231 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
                 assert "maybe-day" in json.loads(dumped), \
                     f"schema().dumps lost the JSON field name:\n{source}"
                 assert module.Opt.schema().loads(dumped) == record
+
+    # ------------------------------------------------------------------
+    # Issue #465: duration, UUID and binary fields need the same
+    # dataclasses-json metadata coverage as the temporal scalars from #405.
+    # ------------------------------------------------------------------
+
+    _ISSUE_465_SCHEMA = {
+        "type": "object",
+        "name": "WireScalars",
+        "namespace": "test.issue465",
+        "properties": {
+            "elapsed-time": {"type": "duration"},
+            "class": {"type": "uuid"},
+            "binary-value": {
+                "type": "binary",
+                "altnames": {"json": "payload"},
+            },
+            "maybe-duration": {"type": ["null", "duration"]},
+            "maybe-id": {"type": ["null", "uuid"]},
+            "maybe-bytes": {"type": ["null", "binary"]},
+            "durations": {
+                "type": "array",
+                "items": {"type": "duration"},
+            },
+            "ids": {
+                "type": "map",
+                "values": {"type": "uuid"},
+            },
+            "blobs": {
+                "type": "set",
+                "items": {"type": "binary"},
+            },
+            "maybe-blobs": {
+                "type": ["null", {
+                    "type": "array",
+                    "items": {"type": "binary"},
+                }],
+            },
+        },
+        "required": [
+            "elapsed-time", "class", "binary-value", "maybe-duration",
+            "maybe-id", "maybe-bytes", "durations", "ids", "blobs",
+            "maybe-blobs",
+        ],
+    }
+
+    @staticmethod
+    def _issue_465_record(module, nullable=False):
+        value_uuid = __import__("uuid").UUID(
+            "12345678-1234-5678-1234-567812345678")
+        return module.WireScalars(
+            elapsed_time=datetime.timedelta(seconds=90.5),
+            class_=value_uuid,
+            binary_value=b"\x00\xffabc",
+            maybe_duration=None if nullable else datetime.timedelta(seconds=-0.25),
+            maybe_id=None if nullable else value_uuid,
+            maybe_bytes=None if nullable else b"\x01\x02",
+            durations=[datetime.timedelta(seconds=1.25)],
+            ids={"primary": value_uuid},
+            blobs={b"\xfb\xef"},
+            maybe_blobs=None if nullable else [b"\x00\x10"],
+        )
+
+    def _generate_issue_465_module(
+            self, schema=None, package_name="test_issue465",
+            avro_annotation=False):
+        return self._generate_issue_405_module(
+            schema or self._ISSUE_465_SCHEMA, package_name, avro_annotation)
+
+    def test_issue_465_fields_have_dataclasses_json_metadata(self):
+        """Positive fixture: each scalar and nullable scalar has a complete codec."""
+        _src_dir, source = self._generate_issue_465_module()
+
+        for field_class in ("_DurationField", "_UuidField", "_Base64Field"):
+            assert f"mm_field={field_class}(" in source, \
+                f"{field_class} metadata missing:\n{source}"
+        assert "datetime.timedelta(seconds=float(" in source, source
+        assert "uuid.UUID(" in source, source
+        assert "base64.b64decode(" in source and "validate=True" in source, source
+        assert "from marshmallow import fields, ValidationError" in source, source
+        assert "import base64" in source, source
+
+    def test_issue_465_wire_formats_and_all_json_entry_points(self):
+        """Positive fixture: every generated JSON producer and consumer agrees."""
+        src_dir, source = self._generate_issue_465_module(
+            package_name="test_issue465_entrypoints")
+        module = self._import_generated(
+            src_dir, "test_issue465_entrypoints.test.issue465.wirescalars")
+        record = self._issue_465_record(module)
+
+        json_text = record.to_json()
+        payload = json.loads(json_text)
+        assert payload["elapsed-time"] == "90.5", payload
+        assert payload["class"] == "12345678-1234-5678-1234-567812345678", payload
+        assert payload["payload"] == "AP9hYmM=", payload
+        assert payload["blobs"] == ["++8="], payload
+
+        schema_payload = json.loads(module.WireScalars.schema().dumps(record))
+        assert schema_payload == payload, \
+            f"schema().dumps and to_json disagree:\n{schema_payload}\n{payload}\n{source}"
+        assert json.loads(record.to_byte_array("application/json")) == payload
+
+        serialized = record.to_serializer_dict()
+        entry_points = {
+            "from_json": module.WireScalars.from_json(json_text),
+            "schema().loads": module.WireScalars.schema().loads(json_text),
+            "from_data(bytes)": module.WireScalars.from_data(
+                json_text.encode("utf-8"), "application/json"),
+            "from_data(dict)": module.WireScalars.from_data(
+                dict(payload), "application/json"),
+            "from_serializer_dict(JSON)": module.WireScalars.from_serializer_dict(
+                dict(payload)),
+            "from_serializer_dict(typed)": module.WireScalars.from_serializer_dict(
+                serialized),
+        }
+        for label, restored in entry_points.items():
+            with self.subTest(entry_point=label):
+                assert restored == record, f"{label} did not round-trip: {restored!r}"
+                assert isinstance(restored.elapsed_time, datetime.timedelta)
+                assert isinstance(restored.binary_value, bytes)
+                assert isinstance(restored.blobs, set)
+
+    def test_issue_465_nullable_values_round_trip_all_json_entry_points(self):
+        """Nullable fixture: null remains null through every JSON decoder."""
+        src_dir, _source = self._generate_issue_465_module(
+            package_name="test_issue465_nullable")
+        module = self._import_generated(
+            src_dir, "test_issue465_nullable.test.issue465.wirescalars")
+        record = self._issue_465_record(module, nullable=True)
+        text = record.to_json()
+        payload = json.loads(text)
+
+        for key in ("maybe-duration", "maybe-id", "maybe-bytes", "maybe-blobs"):
+            assert payload[key] is None, payload
+
+        for restored in (
+                module.WireScalars.from_json(text),
+                module.WireScalars.schema().loads(text),
+                module.WireScalars.from_data(
+                    text.encode("utf-8"), "application/json"),
+                module.WireScalars.from_data(dict(payload), "application/json"),
+                module.WireScalars.from_serializer_dict(dict(payload))):
+            assert restored == record, restored
+
+    def test_issue_465_malformed_strings_are_rejected_by_all_json_entry_points(self):
+        """Invalid fixtures: duration, UUID and base64 decoders fail at ingestion."""
+        schema = {
+            "type": "object",
+            "name": "StrictWire",
+            "namespace": "test.issue465",
+            "properties": {
+                "duration": {"type": "duration"},
+                "uuid": {"type": "uuid"},
+                "binary": {"type": "binary"},
+            },
+            "required": ["duration", "uuid", "binary"],
+        }
+        src_dir, _source = self._generate_issue_465_module(
+            schema, "test_issue465_invalid")
+        module = self._import_generated(
+            src_dir, "test_issue465_invalid.test.issue465.strictwire")
+        valid = {
+            "duration": "90.5",
+            "uuid": "12345678-1234-5678-1234-567812345678",
+            "binary": "AP9hYmM=",
+        }
+        malformed = (
+            ("duration", "ninety seconds"),
+            ("uuid", "not-a-uuid"),
+            ("binary", "not base64!"),
+            ("binary", "YQ"),
+            ("binary", "YQ==\n"),
+            ("binary", "-_8="),
+        )
+
+        for field_name, bad_value in malformed:
+            raw = {**valid, field_name: bad_value}
+            text = json.dumps(raw)
+            entry_points = {
+                "from_json": lambda: module.StrictWire.from_json(text),
+                "schema().loads": lambda: module.StrictWire.schema().loads(text),
+                "from_data(bytes)": lambda: module.StrictWire.from_data(
+                    text.encode("utf-8"), "application/json"),
+                "from_data(dict)": lambda: module.StrictWire.from_data(
+                    dict(raw), "application/json"),
+                "from_serializer_dict": lambda: module.StrictWire.from_serializer_dict(
+                    dict(raw)),
+            }
+            for label, call in entry_points.items():
+                with self.subTest(field=field_name, entry_point=label):
+                    with self.assertRaises(Exception) as caught:
+                        call()
+                    assert not isinstance(caught.exception, AttributeError), \
+                        f"{label} leaked AttributeError for {field_name}"
+
+    def test_issue_465_typed_serializer_dict_is_not_mutated(self):
+        """Already-typed fixture: guarded decoders preserve values and caller data."""
+        src_dir, _source = self._generate_issue_465_module(
+            package_name="test_issue465_typed")
+        module = self._import_generated(
+            src_dir, "test_issue465_typed.test.issue465.wirescalars")
+        record = self._issue_465_record(module)
+        serialized = record.to_serializer_dict()
+        original = dict(serialized)
+
+        restored = module.WireScalars.from_serializer_dict(serialized)
+        assert restored == record
+        assert serialized == original
+        assert isinstance(restored.elapsed_time, datetime.timedelta)
+        assert isinstance(restored.class_, __import__("uuid").UUID)
+        assert isinstance(restored.binary_value, bytes)
+
+    def test_issue_465_avro_dictionary_encoding_is_unchanged(self):
+        """Compatibility fixture: this JSON fix leaves established Avro values intact."""
+        src_dir, _source = self._generate_issue_465_module(
+            package_name="test_issue465_avro", avro_annotation=True)
+        module = self._import_generated(
+            src_dir, "test_issue465_avro.test.issue465.wirescalars")
+        record = self._issue_465_record(module)
+
+        avro_data = record.to_avro_dict()
+        assert avro_data["elapsed-time"] == "90.5"
+        assert avro_data["class"] == "12345678-1234-5678-1234-567812345678"
+        assert avro_data["payload"] == b"\x00\xffabc"
+        assert module.WireScalars.from_avro_dict(avro_data) == record
 
 
 if __name__ == '__main__':

--- a/test/test_structuretopython.py
+++ b/test/test_structuretopython.py
@@ -1975,7 +1975,8 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
         for field_class in ("_DurationField", "_UuidField", "_Base64Field"):
             assert f"mm_field={field_class}(" in source, \
                 f"{field_class} metadata missing:\n{source}"
-        assert "datetime.timedelta(seconds=float(" in source, source
+        assert "def _format_duration(" in source, source
+        assert "decimal.Decimal(" in source, source
         assert "uuid.UUID(" in source, source
         assert "base64.b64decode(" in source and "validate=True" in source, source
         assert "from marshmallow import fields, ValidationError" in source, source
@@ -2068,10 +2069,15 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
         malformed = (
             ("duration", "ninety seconds"),
             ("uuid", "not-a-uuid"),
+            ("uuid", "12345678123456781234567812345678"),
+            ("uuid", "12345678-1234-5678-9ABC-DEF012345678"),
+            ("uuid", "{12345678-1234-5678-1234-567812345678}"),
+            ("uuid", "urn:uuid:12345678-1234-5678-1234-567812345678"),
             ("binary", "not base64!"),
             ("binary", "YQ"),
             ("binary", "YQ==\n"),
             ("binary", "-_8="),
+            ("binary", "YR=="),
         )
 
         for field_name, bad_value in malformed:
@@ -2093,6 +2099,96 @@ for name, obj in inspect.getmembers(sys.modules['{module_name}']):
                         call()
                     assert not isinstance(caught.exception, AttributeError), \
                         f"{label} leaked AttributeError for {field_name}"
+
+    def test_issue_465_non_string_values_are_rejected_by_all_json_entry_points(self):
+        """Invalid fixtures: only null and the expected already-typed value pass through."""
+        schema = {
+            "type": "object",
+            "name": "StrictWireTypes",
+            "namespace": "test.issue465",
+            "properties": {
+                "duration": {"type": "duration"},
+                "uuid": {"type": "uuid"},
+                "binary": {"type": "binary"},
+            },
+            "required": ["duration", "uuid", "binary"],
+        }
+        src_dir, _source = self._generate_issue_465_module(
+            schema, "test_issue465_invalid_types")
+        module = self._import_generated(
+            src_dir, "test_issue465_invalid_types.test.issue465.strictwiretypes")
+        valid = {
+            "duration": "90.5",
+            "uuid": "12345678-1234-5678-1234-567812345678",
+            "binary": "AP9hYmM=",
+        }
+
+        for field_name in valid:
+            for bad_value in (True, 1, 1.5, [], {}):
+                raw = {**valid, field_name: bad_value}
+                text = json.dumps(raw)
+                entry_points = {
+                    "from_json": lambda: module.StrictWireTypes.from_json(text),
+                    "schema().loads": lambda: module.StrictWireTypes.schema().loads(text),
+                    "from_data(bytes)": lambda: module.StrictWireTypes.from_data(
+                        text.encode("utf-8"), "application/json"),
+                    "from_data(dict)": lambda: module.StrictWireTypes.from_data(
+                        dict(raw), "application/json"),
+                    "from_serializer_dict":
+                        lambda: module.StrictWireTypes.from_serializer_dict(dict(raw)),
+                }
+                for label, call in entry_points.items():
+                    with self.subTest(
+                            field=field_name, value=bad_value,
+                            entry_point=label):
+                        with self.assertRaises(Exception) as caught:
+                            call()
+                        assert field_name in str(caught.exception), \
+                            f"{label} error did not identify {field_name}: {caught.exception}"
+
+    def test_issue_465_duration_uses_exact_decimal_microseconds(self):
+        """Boundary fixtures: float conversion must not alter a timedelta by a microsecond."""
+        schema = {
+            "type": "object",
+            "name": "ExactDuration",
+            "namespace": "test.issue465",
+            "properties": {"value": {"type": "duration"}},
+            "required": ["value"],
+        }
+        src_dir, _source = self._generate_issue_465_module(
+            schema, "test_issue465_exact_duration")
+        module = self._import_generated(
+            src_dir, "test_issue465_exact_duration.test.issue465.exactduration")
+        fixtures = (
+            (datetime.timedelta(seconds=90.5), "90.5"),
+            (datetime.timedelta(microseconds=-1), "-0.000001"),
+            (datetime.timedelta(days=100000, microseconds=1),
+             "8640000000.000001"),
+            (datetime.timedelta(days=-100000, microseconds=1),
+             "-8639999999.999999"),
+        )
+
+        for value, expected_wire in fixtures:
+            with self.subTest(value=value):
+                record = module.ExactDuration(value=value)
+                text = record.to_json()
+                assert json.loads(text)["value"] == expected_wire, text
+                assert json.loads(module.ExactDuration.schema().dumps(record))[
+                    "value"] == expected_wire
+                assert json.loads(record.to_byte_array("application/json"))[
+                    "value"] == expected_wire
+
+                raw = {"value": expected_wire}
+                for restored in (
+                        module.ExactDuration.from_json(text),
+                        module.ExactDuration.schema().loads(text),
+                        module.ExactDuration.from_data(
+                            text.encode("utf-8"), "application/json"),
+                        module.ExactDuration.from_data(
+                            dict(raw), "application/json"),
+                        module.ExactDuration.from_serializer_dict(dict(raw))):
+                    assert restored == record, \
+                        f"{expected_wire} restored as {restored.value!r}"
 
     def test_issue_465_typed_serializer_dict_is_not_mutated(self):
         """Already-typed fixture: guarded decoders preserve values and caller data."""


### PR DESCRIPTION
Fixes #465.

## What changed and why?

`s2py` now emits dataclasses-json encoder/decoder metadata and matching marshmallow fields for JSON Structure `duration`, `uuid`, and `binary` values. The existing type-driven codec path covers scalar, nullable, list, set, string-keyed map, and optional-container shapes without extending ambiguous unions, tuples, or unsupported deep nesting.

Wire contracts follow the 2026-08-27 owner decision:

- `datetime.timedelta(seconds=90.5)` -> `"90.5"`
- `datetime.timedelta(microseconds=-1)` -> `"-0.000001"`
- `datetime.timedelta(days=100000, microseconds=1)` -> `"8640000000.000001"`
- `datetime.timedelta.max` -> `"86399999999999.999999"`
- `datetime.timedelta.min` -> `"-86399999913600.0"`
- `UUID("12345678-1234-5678-1234-567812345678")` -> `"12345678-1234-5678-1234-567812345678"`
- `b"\x00\xffabc"` -> `"AP9hYmM="` (canonical standard RFC 4648 base64)

Duration formatting uses timedelta's integer fields. Parsing derives integer microseconds directly from `Decimal.as_tuple()` and compares integer/tuple bounds without ambient-context arithmetic, so caller precision and traps cannot round, underflow, or reject valid input. A derived literal-size cap rejects oversized coefficients/exponents before `Decimal`, and a representable microsecond-digit bound runs before tuple slicing, zero extension, or integer accumulation. `1e-6` is accepted; `1e-7`, `1e-10000000`, non-finite values, out-of-range values, and overlong noncanonical spellings are rejected with field-naming errors. UUID input must exactly equal `str(parsed_uuid)`. Base64 decoding uses `validate=True` and requires exact canonical re-encoding, rejecting nonzero padding-bit alternatives such as `"YR=="`.

Generated `to_json`, `schema().dumps`, `to_byte_array`, `from_json`, `schema().loads`, `from_data` (bytes and dict), and `from_serializer_dict` agree. Required scalar/container fields reject `null`; optional fields preserve it. Required container elements reject `null`, while explicitly optional elements preserve it. Decoders pass through only the expected already-typed `timedelta`/`UUID`/`bytes` value (plus `None` only at optional type nodes); numbers, booleans, lists, and dictionaries are rejected with field-naming errors. Custom-scalar list/set/map decoders also reject invalid outer shapes rather than returning them unchanged. Typed serializer dictionaries remain typed and round-trip without mutation. JSON aliases and Python-keyword field names retain their wire keys.

When `dataclasses_json_annotation=False`, custom codecs no longer suppress the existing `Set` rebuild because no metadata decoder is emitted; `Set[bytes]` therefore retains master behavior.

## How did you check it?

Exact base: `5caa48e94a7b02b425f0494ad933ec92b465b4e8`.
Exact head: `ed63125edf515007cbcf09266b1866051716a407`.

- Initial fixtures on `5caa48e`: **12 failed, 2 passed, 48 deselected; 6 subtests passed**.
- Review-round-1 fixtures on predecessor `74a142afd0b8b0d1a16882f23858d183366f6895`: **92 failed, 7 passed, 48 deselected; 49 subtests passed**.
- Review-round-2 fixtures on predecessor `17337a38397a681a5ca54ab94d423a4eecd2a073`: **27 failed, 9 passed, 48 deselected; 165 subtests passed**. This reproduced extreme-exponent underflow, invalid outer-container pass-through, and the unannotated `Set[bytes]` rebuild regression.
- Review-round-3 fixtures on predecessor `6794d345226abc6bcba3869ac5fe27f8655b82ac`: **2 failed**. This reproduced required-field/element `null` pass-through and ambient Decimal-context failure.
- Review-round-4 guard fixtures on predecessor `617e142048f7955712c21f53c929dfb0c36aeaae`: **4 failures** (three oversized-literal subtest failures plus the negative-exponent digit-guard test). Mocked `Decimal` calls and a guard-specific chained cause prove guard ordering without wall-clock thresholds.
- Python 3.11.3 full s2py suite: `python -m pytest test\test_structuretopython.py -q` -> **62 passed, 260 subtests passed**.
- Python 3.10.10 #399/#464/#465 cohort: `python -m pytest test\test_structuretopython.py -k "issue_465 or issue_405" -q` -> **35 passed, 260 subtests passed**.
- Focused #465 coverage: **14 passed, 246 subtests passed**.

## Anything else? (optional)

Compatibility intent is patch restoration. Duration keeps the established decimal total-seconds representation while eliminating float, Decimal-context, and oversized-literal resource-exhaustion paths. Every canonical string emitted for the complete `timedelta` range remains accepted; only overlong noncanonical input spellings are newly capped. UUID output remains canonical; binary remains standard base64 with canonical validation. Nullability follows the declared field and element types consistently across schema and non-schema entry points. The Avro dictionary path remains unchanged and is explicitly regression-tested: duration and UUID keep their established strings and binary remains `bytes`. Non-dataclasses-json set rebuilding retains master behavior. No `a2py`, #463, or #481 code is touched, and the Python floor remains 3.10.