### PR TITLE
Fix TypeScript named tuple generation

### DIFF
--- a/avrotize/structuretots.py
+++ b/avrotize/structuretots.py
@@ -562,32 +562,92 @@ class StructureToTypeScript:
 
     def generate_tuple(self, structure_schema: Dict, parent_namespace: str, 
                       write_file: bool = True, explicit_name: str = '') -> str:
-        """ Generates a TypeScript tuple type from JSON Structure tuple type """
+        """Generates a named TypeScript class that serializes as a JSON array."""
         tuple_name = pascal(explicit_name if explicit_name else structure_schema.get('name', 'Tuple'))
         namespace = self.concat_namespace(self.base_package, structure_schema.get('namespace', parent_namespace)).lower()
         schema_namespace = structure_schema.get('namespace', parent_namespace)
-        typescript_qualified_name = self.typescript_fully_qualified_name_from_structure_type(parent_namespace, tuple_name)
+        typescript_qualified_name = self.typescript_fully_qualified_name_from_structure_type(schema_namespace, tuple_name)
         
         if typescript_qualified_name in self.generated_types:
             return typescript_qualified_name
 
         import_types: Set[str] = set()
-        tuple_items = structure_schema.get('items', [])
-        item_types = []
-        for idx, item in enumerate(tuple_items):
+        properties = structure_schema.get('properties', {})
+        tuple_order = structure_schema.get('tuple', [])
+        elements = []
+        for prop_name in tuple_order:
+            prop_schema = properties.get(prop_name, {'type': 'any'})
             item_type = self.convert_structure_type_to_typescript(
-                tuple_name, f'item{idx}', item, schema_namespace, import_types)
-            item_types.append(item_type)
+                tuple_name, prop_name, prop_schema, schema_namespace, import_types)
+            item_type_no_null = self.strip_nullable(item_type)
+            elements.append({
+                'name': self.safe_name(prop_name),
+                'type': item_type_no_null,
+                'test_value': self.generate_test_value({
+                    'type_no_null': item_type_no_null,
+                    'is_enum': any(
+                        import_type.endswith('.' + item_type_no_null)
+                        and self.generated_types.get(import_type) == 'enum'
+                        for import_type in import_types)
+                }),
+                'docstring': prop_schema.get('description', '') if isinstance(prop_schema, dict) else ''
+            })
 
-        # TypeScript tuples are just arrays with fixed length and types
-        tuple_type = f"[{', '.join(item_types)}]"
-        
-        # Generate type alias
-        tuple_definition = f"export type {tuple_name} = {tuple_type};\n"
+        imports = []
+        for import_type in import_types:
+            if import_type == typescript_qualified_name:
+                continue
+            import_type_parts = import_type.split('.')
+            import_type_name = pascal(import_type_parts[-1])
+            import_path = '/'.join(import_type_parts)
+            current_path = '/'.join(namespace.split('.'))
+            relative_import_path = os.path.relpath(import_path, current_path).replace(os.sep, '/')
+            if not relative_import_path.startswith('.'):
+                relative_import_path = f'./{relative_import_path}'
+            imports.append(f"import {{ {import_type_name} }} from '{relative_import_path}.js';")
+
+        tuple_type = f"[{', '.join(element['type'] for element in elements)}]"
+        constructor_parameters = ',\n        '.join(
+            f"public {element['name']}: {element['type']}" for element in elements)
+        array_values = ', '.join(f"this.{element['name']}" for element in elements)
+        parsed_values = ',\n            '.join(
+            f"value[{index}] as {element['type']}" for index, element in enumerate(elements))
+        test_values = ',\n            '.join(element['test_value'] for element in elements)
+        docstring = structure_schema.get('description', f'A {tuple_name} tuple.')
+        tuple_definition = '\n'.join(imports)
+        if imports:
+            tuple_definition += '\n'
+        tuple_definition += f"""/** {docstring} */
+export class {tuple_name} {{
+    constructor(
+        {constructor_parameters}
+    ) {{}}
+
+    public toJSON(): {tuple_type} {{
+        return [{array_values}];
+    }}
+
+    public static fromJSON(json: string): {tuple_name} {{
+        const value: unknown = JSON.parse(json);
+        if (!Array.isArray(value) || value.length !== {len(elements)}) {{
+            throw new Error('Expected a {tuple_name} JSON array with {len(elements)} elements');
+        }}
+        return new {tuple_name}(
+            {parsed_values}
+        );
+    }}
+
+    public static createInstance(): {tuple_name} {{
+        return new {tuple_name}(
+            {test_values}
+        );
+    }}
+}}
+"""
 
         if write_file:
             self.write_to_file(namespace, tuple_name, tuple_definition)
-        self.generated_types[typescript_qualified_name] = 'tuple'
+        self.generated_types[typescript_qualified_name] = 'class'
         return typescript_qualified_name
 
     def generate_test_value(self, field: Dict) -> str:

--- a/test/test_structuretots.py
+++ b/test/test_structuretots.py
@@ -188,6 +188,47 @@ class TestStructureToTypeScript(unittest.TestCase):
         except FileNotFoundError:
             print("Warning: npm not found, skipping TypeScript compilation for schema-test")
 
+    def test_named_tuple_uses_properties_and_serializes_in_tuple_order(self):
+        """A named tuple exposes properties but keeps its positional JSON form."""
+        schema = {
+            "type": "object",
+            "name": "Wgs84Position",
+            "properties": {
+                "position": {
+                    "type": "tuple",
+                    "name": "GeographicPoint",
+                    "properties": {
+                        "longitude": {"type": "double"},
+                        "latitude": {"type": "double"}
+                    },
+                    "tuple": ["longitude", "latitude"]
+                }
+            },
+            "required": ["position"]
+        }
+        ts_path = os.path.join(tempfile.gettempdir(), "avrotize", "named-tuple-ts")
+        if os.path.exists(ts_path):
+            shutil.rmtree(ts_path, ignore_errors=True)
+
+        convert_structure_schema_to_typescript(schema, ts_path)
+
+        tuple_path = os.path.join(ts_path, "src", "GeographicPoint.ts")
+        with open(tuple_path, 'r', encoding='utf-8') as tuple_file:
+            generated = tuple_file.read()
+
+        self.assertIn("public longitude: number", generated)
+        self.assertIn("public latitude: number", generated)
+        self.assertIn("return [this.longitude, this.latitude];", generated)
+        self.assertIn("value[0] as number", generated)
+        self.assertIn("value[1] as number", generated)
+        self.assertIn("static createInstance(): GeographicPoint", generated)
+
+        record_path = os.path.join(ts_path, "src", "Wgs84Position.ts")
+        with open(record_path, 'r', encoding='utf-8') as record_file:
+            record = record_file.read()
+        self.assertIn("public position: GeographicPoint", record)
+        self.assertIn("GeographicPoint.createInstance()", record)
+
     def test_convert_schema_list_to_typescript(self):
         """Test converting a list of schemas to TypeScript"""
         schemas = [


### PR DESCRIPTION
Fixes #499

## Summary

- read tuple fields from JSON Structure `properties` in declared `tuple` order
- generate a named TypeScript class with positional `toJSON()` and `fromJSON()` serialization
- generate `createInstance()` so containing generated classes compile
- add regression coverage for a named tuple nested in an object

## Validation

- `py -m pytest test/test_structuretots.py` (16 passed)
- generated package: `npm run build`
- runtime round trip: `{"position":[13.405,52.52]}` with restored `longitude` and `latitude` properties